### PR TITLE
Add multi-modal content support for vision models

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,6 @@ pub mod error;
 pub mod types;
 pub mod utils;
 
-pub use api::chat::Message;
+pub use api::chat::{Content, ContentPart, ImageUrl, Message};
 pub use api::models::Model;
 pub use client::OpenRouterClient;

--- a/tests/unit/completion.rs
+++ b/tests/unit/completion.rs
@@ -121,9 +121,14 @@ fn test_response_with_reasoning_details() {
     assert_eq!(choice.content(), Some("The answer is 42."));
     assert_eq!(choice.reasoning(), Some("Let me think step by step..."));
 
-    let reasoning_details = choice.reasoning_details().expect("Should have reasoning_details");
+    let reasoning_details = choice
+        .reasoning_details()
+        .expect("Should have reasoning_details");
     assert_eq!(reasoning_details.len(), 2);
-    assert_eq!(reasoning_details[0].content(), "First, I need to consider...");
+    assert_eq!(
+        reasoning_details[0].content(),
+        "First, I need to consider..."
+    );
     assert_eq!(reasoning_details[0].reasoning_type(), "reasoning.text");
 }
 


### PR DESCRIPTION
- Add ImageUrl struct with optional detail level
- Add ContentPart enum (Text, ImageUrl) with tagged serialization
- Add Content enum (Text string or Parts array) with untagged serialization
- Update Message to use Content instead of String
- Add Message::with_parts() for multi-modal messages
- Export new types from lib.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I'm still testing the changes, so marking as draft.