### PR TITLE
Add support for tool calls when streaming responses

### DIFF
--- a/examples/stream_chat_with_tools.rs
+++ b/examples/stream_chat_with_tools.rs
@@ -1,0 +1,161 @@
+//! # Streaming with Tool Calls Example
+//!
+//! This example demonstrates how to use `ToolAwareStream` to handle streaming
+//! responses that include tool calls. Content is printed in real time as it
+//! arrives, while tool call fragments are automatically accumulated and
+//! delivered as complete objects once the stream finishes.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! OPENROUTER_API_KEY=your_key cargo run --example stream_chat_with_tools
+//! ```
+
+use std::env;
+
+use futures_util::StreamExt;
+use openrouter_rs::{
+    OpenRouterClient,
+    api::chat::{ChatCompletionRequest, Message},
+    types::stream::StreamEvent,
+    types::{Role, Tool, completion::FinishReason},
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY environment variable not set");
+
+    let client = OpenRouterClient::builder()
+        .api_key(api_key)
+        .http_referer("https://github.com/realmorrisliu/openrouter-rs")
+        .x_title("openrouter-rs streaming tool calls example")
+        .build()?;
+
+    // Define a weather tool
+    let weather_tool = Tool::builder()
+        .name("get_weather")
+        .description("Get current weather information for a location")
+        .parameters(json!({
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "City name, e.g. 'San Francisco, CA'"
+                }
+            },
+            "required": ["location"]
+        }))
+        .build()?;
+
+    let request = ChatCompletionRequest::builder()
+        .model("openai/gpt-4o-mini")
+        .messages(vec![
+            Message::new(
+                Role::System,
+                "You are a helpful assistant. Use the get_weather tool when asked about weather.",
+            ),
+            Message::new(Role::User, "What's the weather in San Francisco and Tokyo?"),
+        ])
+        .tool(weather_tool)
+        .tool_choice_auto()
+        .max_tokens(500)
+        .build()?;
+
+    println!("--- Streaming with tool-aware processing ---\n");
+
+    // Use the tool-aware stream wrapper
+    let mut stream = client.stream_chat_completion_tool_aware(&request).await?;
+
+    while let Some(event) = stream.next().await {
+        match event {
+            StreamEvent::ContentDelta(text) => {
+                // Content is printed immediately as it streams in
+                print!("{}", text);
+            }
+            StreamEvent::ReasoningDelta(text) => {
+                print!("[reasoning] {}", text);
+            }
+            StreamEvent::ReasoningDetailsDelta(details) => {
+                for detail in &details {
+                    if let Some(content) = detail.content() {
+                        print!("[detail] {}", content);
+                    }
+                }
+            }
+            StreamEvent::Done {
+                tool_calls,
+                finish_reason,
+                usage,
+                id,
+                model,
+            } => {
+                println!();
+                println!("\n--- Stream complete ---");
+                println!("  ID: {}", id);
+                println!("  Model: {}", model);
+
+                if let Some(reason) = &finish_reason {
+                    println!("  Finish reason: {:?}", reason);
+                }
+
+                if let Some(usage) = &usage {
+                    println!(
+                        "  Tokens: {} prompt + {} completion = {} total",
+                        usage.prompt_tokens, usage.completion_tokens, usage.total_tokens
+                    );
+                }
+
+                if !tool_calls.is_empty() {
+                    println!("\n  Tool calls ({}):", tool_calls.len());
+                    for (i, tc) in tool_calls.iter().enumerate() {
+                        println!("    {}. {} (id: {})", i + 1, tc.name(), tc.id());
+                        println!("       Arguments: {}", tc.arguments_json());
+                    }
+
+                    // If tools were called, simulate execution and send results back
+                    if matches!(finish_reason, Some(FinishReason::ToolCalls)) {
+                        println!("\n--- Simulating tool execution ---\n");
+
+                        let mut messages = request.messages().clone();
+                        // Add the assistant's response with tool calls
+                        messages.push(Message::assistant_with_tool_calls("", tool_calls.clone()));
+
+                        for tc in &tool_calls {
+                            let result = format!("Weather in {}: Sunny, 22C", tc.arguments_json());
+                            println!("  {} -> {}", tc.name(), result);
+                            messages.push(Message::tool_response(tc.id(), result));
+                        }
+
+                        // Second round: stream the final response
+                        println!("\n--- Streaming final response ---\n");
+
+                        let follow_up = ChatCompletionRequest::builder()
+                            .model("openai/gpt-4o-mini")
+                            .messages(messages)
+                            .max_tokens(500)
+                            .build()?;
+
+                        let mut stream2 =
+                            client.stream_chat_completion_tool_aware(&follow_up).await?;
+
+                        while let Some(event2) = stream2.next().await {
+                            match event2 {
+                                StreamEvent::ContentDelta(text) => print!("{}", text),
+                                StreamEvent::Done { .. } => println!("\n\n--- Done ---"),
+                                StreamEvent::Error(e) => eprintln!("\nError: {}", e),
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            StreamEvent::Error(e) => {
+                eprintln!("\nStream error: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -144,6 +144,7 @@
 pub mod completion;
 pub mod provider;
 pub mod response_format;
+pub mod stream;
 pub mod tool;
 pub mod typed_tool;
 
@@ -151,7 +152,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-pub use {completion::*, provider::*, response_format::*, tool::*, typed_tool::*};
+pub use {completion::*, provider::*, response_format::*, stream::*, tool::*, typed_tool::*};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiResponse<T> {

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -1,0 +1,329 @@
+//! # Tool-Aware Streaming
+//!
+//! This module provides [`ToolAwareStream`], a wrapper around the raw SSE
+//! stream that automatically accumulates partial tool call fragments into
+//! complete [`ToolCall`] objects while still yielding text and reasoning
+//! content deltas in real time.
+//!
+//! ## Problem
+//!
+//! When the OpenRouter API streams a response that includes tool calls,
+//! the tool call data arrives incrementally across many SSE chunks:
+//!
+//! - Chunk 1: `{index: 0, id: "call_abc", type: "function", function: {name: "get_weather", arguments: ""}}`
+//! - Chunk 2: `{index: 0, function: {arguments: "{\"loc"}}`
+//! - Chunk 3: `{index: 0, function: {arguments: "ation\":"}}`
+//! - Chunk N: `{index: 0, function: {arguments: " \"NYC\"}"}}`
+//!
+//! The raw stream yields these as [`PartialToolCall`] fragments that cannot
+//! be used directly. `ToolAwareStream` handles merging them by `index`.
+//!
+//! ## Solution
+//!
+//! Wrap the raw stream in a `ToolAwareStream` to get a stream of
+//! [`StreamEvent`] values:
+//!
+//! ```rust,no_run
+//! use futures_util::StreamExt;
+//! use openrouter_rs::types::stream::{ToolAwareStream, StreamEvent};
+//!
+//! # async fn example(client: openrouter_rs::OpenRouterClient, request: openrouter_rs::api::chat::ChatCompletionRequest) -> Result<(), Box<dyn std::error::Error>> {
+//! let raw_stream = client.stream_chat_completion(&request).await?;
+//! let mut stream = ToolAwareStream::new(raw_stream);
+//!
+//! while let Some(event) = stream.next().await {
+//!     match event {
+//!         StreamEvent::ContentDelta(text) => print!("{}", text),
+//!         StreamEvent::ReasoningDelta(text) => { /* reasoning content */ },
+//!         StreamEvent::Done { tool_calls, .. } => {
+//!             for tc in &tool_calls {
+//!                 println!("Tool: {} args: {}", tc.name(), tc.arguments_json());
+//!             }
+//!         },
+//!         StreamEvent::Error(e) => eprintln!("Error: {}", e),
+//!         _ => {}
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use std::collections::BTreeMap;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::stream::BoxStream;
+use futures_util::{Stream, StreamExt};
+
+use crate::error::OpenRouterError;
+use crate::types::completion::{
+    CompletionsResponse, FinishReason, FunctionCall, PartialToolCall, ReasoningDetail,
+    ResponseUsage, ToolCall,
+};
+
+/// Events emitted by [`ToolAwareStream`].
+///
+/// Content and reasoning deltas are yielded immediately as they arrive.
+/// Tool calls are accumulated internally and emitted as complete objects
+/// only once in the final [`StreamEvent::Done`] event.
+#[derive(Debug)]
+pub enum StreamEvent {
+    /// A fragment of text content from the assistant's response.
+    ContentDelta(String),
+
+    /// A fragment of reasoning/chain-of-thought content.
+    ReasoningDelta(String),
+
+    /// Structured reasoning detail blocks (e.g., encrypted reasoning).
+    ReasoningDetailsDelta(Vec<ReasoningDetail>),
+
+    /// The stream has finished. Contains all accumulated data.
+    ///
+    /// `tool_calls` will be empty if the model did not invoke any tools.
+    /// `usage` is typically only present in the final SSE chunk.
+    Done {
+        /// Fully assembled tool calls (empty if none were requested).
+        tool_calls: Vec<ToolCall>,
+        /// The reason the model stopped generating.
+        finish_reason: Option<FinishReason>,
+        /// Token usage statistics (if provided by the API).
+        usage: Option<ResponseUsage>,
+        /// The response ID from the API.
+        id: String,
+        /// The model that generated the response.
+        model: String,
+    },
+
+    /// An error occurred while processing the stream.
+    Error(OpenRouterError),
+}
+
+/// Internal accumulator for a single tool call being assembled from
+/// streaming fragments.
+#[derive(Debug, Clone, Default)]
+struct ToolCallAccumulator {
+    id: Option<String>,
+    type_: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+impl ToolCallAccumulator {
+    /// Merge a partial tool call fragment into this accumulator.
+    fn merge(&mut self, partial: &PartialToolCall) {
+        if let Some(id) = &partial.id {
+            self.id = Some(id.clone());
+        }
+        if let Some(type_) = &partial.type_ {
+            self.type_ = Some(type_.clone());
+        }
+        if let Some(func) = &partial.function {
+            if let Some(name) = &func.name {
+                self.name = Some(name.clone());
+            }
+            if let Some(args) = &func.arguments {
+                self.arguments.push_str(args);
+            }
+        }
+    }
+
+    /// Try to convert this accumulator into a complete [`ToolCall`].
+    ///
+    /// Returns `None` if required fields (`id`, `name`) are still missing,
+    /// which would indicate an incomplete stream.
+    fn into_tool_call(self) -> Option<ToolCall> {
+        Some(ToolCall {
+            id: self.id?,
+            type_: self.type_.unwrap_or_else(|| "function".to_string()),
+            function: FunctionCall {
+                name: self.name?,
+                arguments: self.arguments,
+            },
+            index: None,
+        })
+    }
+}
+
+/// A stream wrapper that accumulates partial tool call fragments and
+/// yields [`StreamEvent`] values.
+///
+/// Text content and reasoning deltas are forwarded immediately. Tool call
+/// chunks are buffered internally and assembled into complete [`ToolCall`]
+/// objects, which are emitted in the final [`StreamEvent::Done`] event.
+///
+/// # Construction
+///
+/// Wrap any raw streaming response from
+/// [`stream_chat_completion`](crate::api::chat::stream_chat_completion):
+///
+/// ```rust,no_run
+/// # async fn example(client: openrouter_rs::OpenRouterClient, request: openrouter_rs::api::chat::ChatCompletionRequest) -> Result<(), Box<dyn std::error::Error>> {
+/// use openrouter_rs::types::stream::ToolAwareStream;
+///
+/// let raw = client.stream_chat_completion(&request).await?;
+/// let stream = ToolAwareStream::new(raw);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Or use the convenience method on the client:
+///
+/// ```rust,no_run
+/// # async fn example(client: openrouter_rs::OpenRouterClient, request: openrouter_rs::api::chat::ChatCompletionRequest) -> Result<(), Box<dyn std::error::Error>> {
+/// let stream = client.stream_chat_completion_tool_aware(&request).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct ToolAwareStream {
+    inner: BoxStream<'static, Result<CompletionsResponse, OpenRouterError>>,
+    /// Tool call fragments accumulated by tool call index.
+    tool_accumulators: BTreeMap<u32, ToolCallAccumulator>,
+    /// Buffered events ready to be yielded.
+    pending_events: Vec<StreamEvent>,
+    /// Last seen response ID.
+    last_id: String,
+    /// Last seen model name.
+    last_model: String,
+    /// Last seen usage stats.
+    last_usage: Option<ResponseUsage>,
+    /// Last seen finish reason.
+    last_finish_reason: Option<FinishReason>,
+    /// Whether the stream has completed.
+    finished: bool,
+}
+
+impl ToolAwareStream {
+    /// Create a new `ToolAwareStream` wrapping a raw SSE stream.
+    pub fn new(inner: BoxStream<'static, Result<CompletionsResponse, OpenRouterError>>) -> Self {
+        Self {
+            inner,
+            tool_accumulators: BTreeMap::new(),
+            pending_events: Vec::new(),
+            last_id: String::new(),
+            last_model: String::new(),
+            last_usage: None,
+            last_finish_reason: None,
+            finished: false,
+        }
+    }
+
+    /// Process a single `CompletionsResponse` chunk, extracting events
+    /// and accumulating tool call fragments.
+    fn process_chunk(&mut self, response: CompletionsResponse) {
+        // Track metadata from every chunk
+        self.last_id.clone_from(&response.id);
+        self.last_model.clone_from(&response.model);
+        if response.usage.is_some() {
+            self.last_usage = response.usage;
+        }
+
+        for choice in &response.choices {
+            // Track finish reason
+            if let Some(reason) = choice.finish_reason() {
+                self.last_finish_reason = Some(reason.clone());
+            }
+
+            // Extract content delta
+            if let Some(content) = choice.content() {
+                if !content.is_empty() {
+                    self.pending_events
+                        .push(StreamEvent::ContentDelta(content.to_string()));
+                }
+            }
+
+            // Extract reasoning delta
+            if let Some(reasoning) = choice.reasoning() {
+                if !reasoning.is_empty() {
+                    self.pending_events
+                        .push(StreamEvent::ReasoningDelta(reasoning.to_string()));
+                }
+            }
+
+            // Extract reasoning details
+            if let Some(details) = choice.reasoning_details() {
+                if !details.is_empty() {
+                    self.pending_events
+                        .push(StreamEvent::ReasoningDetailsDelta(details.to_vec()));
+                }
+            }
+
+            // Accumulate partial tool calls
+            if let Some(partial_tool_calls) = choice.partial_tool_calls() {
+                for partial in partial_tool_calls {
+                    // Use the index field to identify which tool call this
+                    // fragment belongs to. Default to 0 if not specified.
+                    let idx = partial.index.unwrap_or(0);
+                    let acc = self.tool_accumulators.entry(idx).or_default();
+                    acc.merge(partial);
+                }
+            }
+        }
+    }
+
+    /// Finalize the stream: assemble complete tool calls and emit `Done`.
+    fn finalize(&mut self) {
+        let tool_calls: Vec<ToolCall> = self
+            .tool_accumulators
+            .values()
+            .cloned()
+            .filter_map(|acc| acc.into_tool_call())
+            .collect();
+
+        self.pending_events.push(StreamEvent::Done {
+            tool_calls,
+            finish_reason: self.last_finish_reason.take(),
+            usage: self.last_usage.take(),
+            id: std::mem::take(&mut self.last_id),
+            model: std::mem::take(&mut self.last_model),
+        });
+
+        self.finished = true;
+    }
+}
+
+impl Stream for ToolAwareStream {
+    type Item = StreamEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Drain any buffered events first
+        if !self.pending_events.is_empty() {
+            return Poll::Ready(Some(self.pending_events.remove(0)));
+        }
+
+        if self.finished {
+            return Poll::Ready(None);
+        }
+
+        // Poll the inner stream for the next chunk
+        match self.inner.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(response))) => {
+                self.process_chunk(response);
+
+                // Return the first pending event if any
+                if !self.pending_events.is_empty() {
+                    Poll::Ready(Some(self.pending_events.remove(0)))
+                } else {
+                    // No events from this chunk (e.g., empty delta), poll again
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(StreamEvent::Error(e))),
+            Poll::Ready(None) => {
+                // Inner stream ended -- emit Done with accumulated tool calls
+                if !self.finished {
+                    self.finalize();
+                    // Return the Done event
+                    if !self.pending_events.is_empty() {
+                        Poll::Ready(Some(self.pending_events.remove(0)))
+                    } else {
+                        Poll::Ready(None)
+                    }
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -166,16 +166,18 @@ impl ToolBuilder {
     }
 
     /// Set parameters from a serializable struct
-    pub fn parameters_from<T: Serialize>(&mut self, params: &T) -> Result<&mut Self, OpenRouterError> {
-        let value = serde_json::to_value(params)
-            .map_err(|e| OpenRouterError::Serialization(e))?;
+    pub fn parameters_from<T: Serialize>(
+        &mut self,
+        params: &T,
+    ) -> Result<&mut Self, OpenRouterError> {
+        let value = serde_json::to_value(params).map_err(|e| OpenRouterError::Serialization(e))?;
         Ok(self.parameters(value))
     }
 
     /// Set parameters from a JSON string
     pub fn parameters_json(&mut self, json: &str) -> Result<&mut Self, OpenRouterError> {
-        let value: Value = serde_json::from_str(json)
-            .map_err(|e| OpenRouterError::Serialization(e))?;
+        let value: Value =
+            serde_json::from_str(json).map_err(|e| OpenRouterError::Serialization(e))?;
         Ok(self.parameters(value))
     }
 }
@@ -188,17 +190,19 @@ impl FunctionDefinitionBuilder {
     }
 
     /// Set parameters from a serializable struct
-    pub fn parameters_from<T: Serialize>(&mut self, params: &T) -> Result<&mut Self, OpenRouterError> {
-        let value = serde_json::to_value(params)
-            .map_err(|e| OpenRouterError::Serialization(e))?;
+    pub fn parameters_from<T: Serialize>(
+        &mut self,
+        params: &T,
+    ) -> Result<&mut Self, OpenRouterError> {
+        let value = serde_json::to_value(params).map_err(|e| OpenRouterError::Serialization(e))?;
         self.parameters = Some(value);
         Ok(self)
     }
 
     /// Set parameters from a JSON string
     pub fn parameters_json(&mut self, json: &str) -> Result<&mut Self, OpenRouterError> {
-        let value: Value = serde_json::from_str(json)
-            .map_err(|e| OpenRouterError::Serialization(e))?;
+        let value: Value =
+            serde_json::from_str(json).map_err(|e| OpenRouterError::Serialization(e))?;
         self.parameters = Some(value);
         Ok(self)
     }
@@ -297,12 +301,7 @@ pub struct SpecificToolFunction {
 ///     &["operation", "a", "b"]
 /// );
 /// ```
-pub fn create_tool(
-    name: &str,
-    description: &str,
-    properties: Value,
-    required: &[&str],
-) -> Tool {
+pub fn create_tool(name: &str, description: &str, properties: Value, required: &[&str]) -> Tool {
     let parameters = serde_json::json!({
         "type": "object",
         "properties": properties,
@@ -342,7 +341,7 @@ mod tests {
         assert_eq!(serde_json::to_string(&auto).unwrap(), r#""auto""#);
         assert_eq!(serde_json::to_string(&none).unwrap(), r#""none""#);
         assert_eq!(serde_json::to_string(&required).unwrap(), r#""required""#);
-        
+
         if let ToolChoice::Specific(spec) = specific {
             assert_eq!(spec.function.name, "my_function");
         } else {
@@ -356,12 +355,12 @@ mod tests {
             "weather",
             "Get weather",
             json!({"location": {"type": "string"}}),
-            &["location"]
+            &["location"],
         );
 
         assert_eq!(tool.function.name, "weather");
         assert_eq!(tool.function.description, "Get weather");
-        
+
         let params = &tool.function.parameters;
         assert_eq!(params["type"], "object");
         assert_eq!(params["required"], json!(["location"]));

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -5,3 +5,4 @@ fn dummy_test() {
 
 pub mod completion;
 pub mod config;
+pub mod stream;

--- a/tests/unit/stream.rs
+++ b/tests/unit/stream.rs
@@ -1,0 +1,672 @@
+use futures_util::{StreamExt, stream};
+use openrouter_rs::error::OpenRouterError;
+use openrouter_rs::types::completion::{
+    Choice, CompletionsResponse, Delta, ObjectType, PartialFunctionCall, PartialToolCall,
+    ResponseUsage, StreamingChoice,
+};
+use openrouter_rs::types::stream::{StreamEvent, ToolAwareStream};
+
+// =============================================
+// PartialToolCall deserialization tests
+// =============================================
+
+#[test]
+fn test_partial_tool_call_full_first_chunk() {
+    // First chunk typically has id, type, and function name
+    let json = r#"{
+        "index": 0,
+        "id": "call_abc123",
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "arguments": ""
+        }
+    }"#;
+
+    let partial: PartialToolCall = serde_json::from_str(json).unwrap();
+    assert_eq!(partial.index, Some(0));
+    assert_eq!(partial.id.as_deref(), Some("call_abc123"));
+    assert_eq!(partial.type_.as_deref(), Some("function"));
+
+    let func = partial.function.unwrap();
+    assert_eq!(func.name.as_deref(), Some("get_weather"));
+    assert_eq!(func.arguments.as_deref(), Some(""));
+}
+
+#[test]
+fn test_partial_tool_call_arguments_only_chunk() {
+    // Subsequent chunks only have index + arguments fragment
+    let json = r#"{
+        "index": 0,
+        "function": {
+            "arguments": "{\"location"
+        }
+    }"#;
+
+    let partial: PartialToolCall = serde_json::from_str(json).unwrap();
+    assert_eq!(partial.index, Some(0));
+    assert!(partial.id.is_none());
+    assert!(partial.type_.is_none());
+
+    let func = partial.function.unwrap();
+    assert!(func.name.is_none());
+    assert_eq!(func.arguments.as_deref(), Some("{\"location"));
+}
+
+#[test]
+fn test_partial_tool_call_minimal_chunk() {
+    // Minimal chunk with only index
+    let json = r#"{"index": 1}"#;
+
+    let partial: PartialToolCall = serde_json::from_str(json).unwrap();
+    assert_eq!(partial.index, Some(1));
+    assert!(partial.id.is_none());
+    assert!(partial.type_.is_none());
+    assert!(partial.function.is_none());
+}
+
+#[test]
+fn test_partial_tool_call_empty_object() {
+    let json = r#"{}"#;
+
+    let partial: PartialToolCall = serde_json::from_str(json).unwrap();
+    assert!(partial.index.is_none());
+    assert!(partial.id.is_none());
+    assert!(partial.type_.is_none());
+    assert!(partial.function.is_none());
+}
+
+#[test]
+fn test_partial_function_call_default() {
+    let partial = PartialFunctionCall::default();
+    assert!(partial.name.is_none());
+    assert!(partial.arguments.is_none());
+}
+
+#[test]
+fn test_streaming_chunk_with_partial_tool_calls() {
+    // Full streaming SSE chunk with tool_calls in delta
+    let json = r#"{
+        "id": "gen-123",
+        "choices": [{
+            "finish_reason": null,
+            "index": 0,
+            "delta": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": ""
+                    }
+                }]
+            }
+        }],
+        "created": 1700000000,
+        "model": "test-model",
+        "object": "chat.completion.chunk"
+    }"#;
+
+    let response: CompletionsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(response.choices.len(), 1);
+
+    let choice = &response.choices[0];
+    // tool_calls() should return None for streaming
+    assert!(choice.tool_calls().is_none());
+
+    // partial_tool_calls() should return the fragments
+    let partials = choice.partial_tool_calls().unwrap();
+    assert_eq!(partials.len(), 1);
+    assert_eq!(partials[0].id.as_deref(), Some("call_abc"));
+    assert_eq!(
+        partials[0].function.as_ref().unwrap().name.as_deref(),
+        Some("get_weather")
+    );
+}
+
+#[test]
+fn test_streaming_chunk_arguments_fragment() {
+    let json = r#"{
+        "id": "gen-123",
+        "choices": [{
+            "finish_reason": null,
+            "index": 0,
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": {
+                        "arguments": "{\"loc"
+                    }
+                }]
+            }
+        }],
+        "created": 1700000000,
+        "model": "test-model",
+        "object": "chat.completion.chunk"
+    }"#;
+
+    let response: CompletionsResponse = serde_json::from_str(json).unwrap();
+    let partials = response.choices[0].partial_tool_calls().unwrap();
+    assert_eq!(partials.len(), 1);
+    assert_eq!(
+        partials[0]
+            .function
+            .as_ref()
+            .unwrap()
+            .arguments
+            .as_deref(),
+        Some("{\"loc")
+    );
+}
+
+// =============================================
+// ToolAwareStream accumulation tests
+// =============================================
+
+/// Helper: create a CompletionsResponse with a streaming content delta.
+fn content_chunk(id: &str, model: &str, content: &str) -> CompletionsResponse {
+    CompletionsResponse {
+        id: id.to_string(),
+        choices: vec![Choice::Streaming(StreamingChoice {
+            finish_reason: None,
+            native_finish_reason: None,
+            delta: Delta {
+                content: Some(content.to_string()),
+                role: None,
+                tool_calls: None,
+                reasoning: None,
+                reasoning_details: None,
+                refusal: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        })],
+        created: 1700000000,
+        model: model.to_string(),
+        object_type: ObjectType::ChatCompletionChunk,
+        provider: None,
+        system_fingerprint: None,
+        usage: None,
+    }
+}
+
+/// Helper: create a CompletionsResponse with a partial tool call delta.
+fn tool_call_chunk(
+    id: &str,
+    model: &str,
+    tool_call_index: u32,
+    tool_id: Option<&str>,
+    tool_type: Option<&str>,
+    func_name: Option<&str>,
+    func_args: Option<&str>,
+) -> CompletionsResponse {
+    let function = if func_name.is_some() || func_args.is_some() {
+        Some(PartialFunctionCall {
+            name: func_name.map(|s| s.to_string()),
+            arguments: func_args.map(|s| s.to_string()),
+        })
+    } else {
+        None
+    };
+
+    CompletionsResponse {
+        id: id.to_string(),
+        choices: vec![Choice::Streaming(StreamingChoice {
+            finish_reason: None,
+            native_finish_reason: None,
+            delta: Delta {
+                content: None,
+                role: None,
+                tool_calls: Some(vec![PartialToolCall {
+                    id: tool_id.map(|s| s.to_string()),
+                    type_: tool_type.map(|s| s.to_string()),
+                    function,
+                    index: Some(tool_call_index),
+                }]),
+                reasoning: None,
+                reasoning_details: None,
+                refusal: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        })],
+        created: 1700000000,
+        model: model.to_string(),
+        object_type: ObjectType::ChatCompletionChunk,
+        provider: None,
+        system_fingerprint: None,
+        usage: None,
+    }
+}
+
+/// Helper: create a final chunk with finish_reason and usage.
+fn done_chunk(
+    id: &str,
+    model: &str,
+    finish_reason: &str,
+    usage: Option<ResponseUsage>,
+) -> CompletionsResponse {
+    use openrouter_rs::types::completion::FinishReason;
+
+    let reason = match finish_reason {
+        "tool_calls" => Some(FinishReason::ToolCalls),
+        "stop" => Some(FinishReason::Stop),
+        _ => None,
+    };
+
+    CompletionsResponse {
+        id: id.to_string(),
+        choices: vec![Choice::Streaming(StreamingChoice {
+            finish_reason: reason,
+            native_finish_reason: Some(finish_reason.to_string()),
+            delta: Delta {
+                content: None,
+                role: None,
+                tool_calls: None,
+                reasoning: None,
+                reasoning_details: None,
+                refusal: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        })],
+        created: 1700000000,
+        model: model.to_string(),
+        object_type: ObjectType::ChatCompletionChunk,
+        provider: None,
+        system_fingerprint: None,
+        usage,
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_content_only() {
+    // Stream with only text content, no tool calls
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
+        Ok(content_chunk("gen-1", "test-model", "Hello")),
+        Ok(content_chunk("gen-1", "test-model", " world")),
+        Ok(done_chunk("gen-1", "test-model", "stop", None)),
+    ];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // Should have: ContentDelta("Hello"), ContentDelta(" world"), Done
+    assert_eq!(events.len(), 3);
+
+    match &events[0] {
+        StreamEvent::ContentDelta(text) => assert_eq!(text, "Hello"),
+        other => panic!("Expected ContentDelta, got {:?}", other),
+    }
+
+    match &events[1] {
+        StreamEvent::ContentDelta(text) => assert_eq!(text, " world"),
+        other => panic!("Expected ContentDelta, got {:?}", other),
+    }
+
+    match &events[2] {
+        StreamEvent::Done {
+            tool_calls,
+            finish_reason,
+            model,
+            ..
+        } => {
+            assert!(tool_calls.is_empty());
+            assert!(matches!(
+                finish_reason,
+                Some(openrouter_rs::types::completion::FinishReason::Stop)
+            ));
+            assert_eq!(model, "test-model");
+        }
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_single_tool_call() {
+    // Simulate streaming a single tool call
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
+        // First chunk: tool call header
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            0,
+            Some("call_abc"),
+            Some("function"),
+            Some("get_weather"),
+            Some(""),
+        )),
+        // Arguments fragments
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            0,
+            None,
+            None,
+            None,
+            Some("{\"location"),
+        )),
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            0,
+            None,
+            None,
+            None,
+            Some("\": \"NYC\"}"),
+        )),
+        // Final chunk
+        Ok(done_chunk(
+            "gen-1",
+            "gpt-4",
+            "tool_calls",
+            Some(ResponseUsage {
+                prompt_tokens: 100,
+                completion_tokens: 20,
+                total_tokens: 120,
+            }),
+        )),
+    ];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // Should have exactly 1 event: Done (no content deltas)
+    assert_eq!(events.len(), 1);
+
+    match &events[0] {
+        StreamEvent::Done {
+            tool_calls,
+            finish_reason,
+            usage,
+            id,
+            model,
+        } => {
+            assert_eq!(tool_calls.len(), 1);
+            assert_eq!(tool_calls[0].id, "call_abc");
+            assert_eq!(tool_calls[0].type_, "function");
+            assert_eq!(tool_calls[0].function.name, "get_weather");
+            assert_eq!(
+                tool_calls[0].function.arguments,
+                "{\"location\": \"NYC\"}"
+            );
+            assert!(matches!(
+                finish_reason,
+                Some(openrouter_rs::types::completion::FinishReason::ToolCalls)
+            ));
+            assert!(usage.is_some());
+            assert_eq!(usage.as_ref().unwrap().total_tokens, 120);
+            assert_eq!(id, "gen-1");
+            assert_eq!(model, "gpt-4");
+        }
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_parallel_tool_calls() {
+    // Simulate two tool calls arriving in parallel (interleaved by index)
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
+        // Tool call 0 header
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            0,
+            Some("call_1"),
+            Some("function"),
+            Some("get_weather"),
+            Some(""),
+        )),
+        // Tool call 1 header
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            1,
+            Some("call_2"),
+            Some("function"),
+            Some("get_time"),
+            Some(""),
+        )),
+        // Tool call 0 arguments
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            0,
+            None,
+            None,
+            None,
+            Some("{\"city\": \"NYC\"}"),
+        )),
+        // Tool call 1 arguments
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            1,
+            None,
+            None,
+            None,
+            Some("{\"timezone\": \"EST\"}"),
+        )),
+        // Done
+        Ok(done_chunk("gen-1", "gpt-4", "tool_calls", None)),
+    ];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 1);
+
+    match &events[0] {
+        StreamEvent::Done { tool_calls, .. } => {
+            assert_eq!(tool_calls.len(), 2);
+
+            // BTreeMap preserves order by key (index), so index 0 comes first
+            assert_eq!(tool_calls[0].id, "call_1");
+            assert_eq!(tool_calls[0].function.name, "get_weather");
+            assert_eq!(tool_calls[0].function.arguments, "{\"city\": \"NYC\"}");
+
+            assert_eq!(tool_calls[1].id, "call_2");
+            assert_eq!(tool_calls[1].function.name, "get_time");
+            assert_eq!(
+                tool_calls[1].function.arguments,
+                "{\"timezone\": \"EST\"}"
+            );
+        }
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_content_then_tool_calls() {
+    // Model generates some content text AND then makes tool calls
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
+        Ok(content_chunk("gen-1", "gpt-4", "Let me check ")),
+        Ok(content_chunk("gen-1", "gpt-4", "the weather.")),
+        Ok(tool_call_chunk(
+            "gen-1",
+            "gpt-4",
+            0,
+            Some("call_abc"),
+            Some("function"),
+            Some("get_weather"),
+            Some("{\"city\": \"NYC\"}"),
+        )),
+        Ok(done_chunk("gen-1", "gpt-4", "tool_calls", None)),
+    ];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // 2 content deltas + 1 Done
+    assert_eq!(events.len(), 3);
+
+    match &events[0] {
+        StreamEvent::ContentDelta(text) => assert_eq!(text, "Let me check "),
+        other => panic!("Expected ContentDelta, got {:?}", other),
+    }
+
+    match &events[1] {
+        StreamEvent::ContentDelta(text) => assert_eq!(text, "the weather."),
+        other => panic!("Expected ContentDelta, got {:?}", other),
+    }
+
+    match &events[2] {
+        StreamEvent::Done { tool_calls, .. } => {
+            assert_eq!(tool_calls.len(), 1);
+            assert_eq!(tool_calls[0].function.name, "get_weather");
+            assert_eq!(tool_calls[0].function.arguments, "{\"city\": \"NYC\"}");
+        }
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_error_handling() {
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
+        Ok(content_chunk("gen-1", "test", "Hello")),
+        Err(OpenRouterError::Unknown("stream failed".to_string())),
+    ];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // ContentDelta, Error, Done (finalize on stream end)
+    assert_eq!(events.len(), 3);
+
+    match &events[0] {
+        StreamEvent::ContentDelta(text) => assert_eq!(text, "Hello"),
+        other => panic!("Expected ContentDelta, got {:?}", other),
+    }
+
+    match &events[1] {
+        StreamEvent::Error(_) => {} // Expected
+        other => panic!("Expected Error, got {:?}", other),
+    }
+
+    match &events[2] {
+        StreamEvent::Done { tool_calls, .. } => {
+            assert!(tool_calls.is_empty());
+        }
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_empty_stream() {
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // Even an empty stream should emit Done
+    assert_eq!(events.len(), 1);
+
+    match &events[0] {
+        StreamEvent::Done {
+            tool_calls,
+            finish_reason,
+            usage,
+            ..
+        } => {
+            assert!(tool_calls.is_empty());
+            assert!(finish_reason.is_none());
+            assert!(usage.is_none());
+        }
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_reasoning_deltas() {
+    let reasoning_chunk = CompletionsResponse {
+        id: "gen-1".to_string(),
+        choices: vec![Choice::Streaming(StreamingChoice {
+            finish_reason: None,
+            native_finish_reason: None,
+            delta: Delta {
+                content: None,
+                role: None,
+                tool_calls: None,
+                reasoning: Some("Let me think...".to_string()),
+                reasoning_details: None,
+                refusal: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        })],
+        created: 1700000000,
+        model: "test-model".to_string(),
+        object_type: ObjectType::ChatCompletionChunk,
+        provider: None,
+        system_fingerprint: None,
+        usage: None,
+    };
+
+    let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
+        Ok(reasoning_chunk),
+        Ok(content_chunk("gen-1", "test-model", "The answer is 42.")),
+        Ok(done_chunk("gen-1", "test-model", "stop", None)),
+    ];
+
+    let raw_stream = stream::iter(chunks).boxed();
+    let mut stream = ToolAwareStream::new(raw_stream);
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 3);
+
+    match &events[0] {
+        StreamEvent::ReasoningDelta(text) => assert_eq!(text, "Let me think..."),
+        other => panic!("Expected ReasoningDelta, got {:?}", other),
+    }
+
+    match &events[1] {
+        StreamEvent::ContentDelta(text) => assert_eq!(text, "The answer is 42."),
+        other => panic!("Expected ContentDelta, got {:?}", other),
+    }
+
+    match &events[2] {
+        StreamEvent::Done { .. } => {}
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}


### PR DESCRIPTION
As discussed in #14, this PR contains a WIP implementation of tool calling support for streamed responses. The goal is to support streaming content updates while waiting for tool calls to complete.

## Problem

When the OpenRouter API streams a response that includes tool calls, the tool call data arrives incrementally across many SSE chunks. A typical sequence looks like:

```text
data: {..., "delta": {"tool_calls": [{"index":0, "id":"call_abc", "type":"function", "function":{"name":"get_weather","arguments":""}}]}}
data: {..., "delta": {"tool_calls": [{"index":0, "function":{"arguments":"{\"loc"}}]}}
data: {..., "delta": {"tool_calls": [{"index":0, "function":{"arguments":"ation\":"}}]}}
data: {..., "delta": {"tool_calls": [{"index":0, "function":{"arguments":" \"NYC\"}"}}]}}
data: {..., "choices":[{"finish_reason":"tool_calls", "delta":{}}], "usage": {...}}
data: [DONE]
```

Previously, the `Delta` struct used `Vec<ToolCall>` for its `tool_calls` field, where `ToolCall` required all fields (`id`, `type`, `function.name`, `function.arguments`) to be present. This caused deserialization failures on streaming chunks after the first one, since subsequent chunks only contain partial data (e.g., just an `arguments` fragment).


## Key design decisions
1. Separate PartialToolCall type rather than making ToolCall fields optional -- preserves backward compatibility for non-streaming code
2. Choice::tool_calls() returns None for streaming -- the partial fragments were never usable anyway; partial_tool_calls() provides raw access for advanced users
3. BTreeMap for accumulators -- keyed by tool call index, preserves insertion order for deterministic output
4. StreamEvent::Done carries everything -- tool calls, finish reason, usage, id, model all in one event at the end


## Solution

### New Types

Two new structs handle partial streaming data:

**`PartialFunctionCall`** (`src/types/completion.rs`) -- all fields optional:

```rust
pub struct PartialFunctionCall {
    pub name: Option<String>,
    pub arguments: Option<String>,
}
```

**`PartialToolCall`** (`src/types/completion.rs`) -- all fields optional:

```rust
pub struct PartialToolCall {
    pub id: Option<String>,
    pub type_: Option<String>,        // JSON key: "type"
    pub function: Option<PartialFunctionCall>,
    pub index: Option<u32>,
}
```

### Delta Type Change

The `Delta` struct now uses `PartialToolCall`:

```rust
pub struct Delta {
    pub content: Option<String>,
    pub role: Option<String>,
    pub tool_calls: Option<Vec<PartialToolCall>>,  // Changed from Vec<ToolCall>
    pub reasoning: Option<String>,
    pub reasoning_details: Option<Vec<ReasoningDetail>>,
    pub refusal: Option<String>,
}
```

### Choice::tool_calls() Behavior Change

`Choice::tool_calls()` now returns `None` for the `Streaming` variant, since streaming choices only contain partial fragments that aren't usable as complete tool calls:

```rust
impl Choice {
    /// Returns complete tool calls for non-streaming responses.
    /// Returns None for streaming responses.
    pub fn tool_calls(&self) -> Option<&[ToolCall]> { ... }

    /// Returns partial tool call fragments from a streaming delta.
    /// Returns None for non-streaming responses.
    pub fn partial_tool_calls(&self) -> Option<&[PartialToolCall]> { ... }
}
```

### ToolAwareStream Wrapper

The new `ToolAwareStream` (`src/types/stream.rs`) wraps the raw SSE stream and:

1. **Yields content/reasoning deltas immediately** as `StreamEvent::ContentDelta` and `StreamEvent::ReasoningDelta`
2. **Accumulates tool call fragments internally** by merging them by `index`
3. **Emits complete tool calls** in the final `StreamEvent::Done` event

```rust
pub enum StreamEvent {
    /// Text content fragment -- yielded immediately.
    ContentDelta(String),
    /// Reasoning content fragment -- yielded immediately.
    ReasoningDelta(String),
    /// Structured reasoning detail blocks.
    ReasoningDetailsDelta(Vec<ReasoningDetail>),
    /// Stream finished -- contains all accumulated data.
    Done {
        tool_calls: Vec<ToolCall>,           // Complete, assembled tool calls
        finish_reason: Option<FinishReason>,
        usage: Option<ResponseUsage>,
        id: String,
        model: String,
    },
    /// An error occurred during streaming.
    Error(OpenRouterError),
}
```

## API Summary

### New Types

| Type | Location | Description |
|------|----------|-------------|
| `PartialFunctionCall` | `types::completion` | Function call fragment with optional fields |
| `PartialToolCall` | `types::completion` | Tool call fragment with optional fields |
| `StreamEvent` | `types::stream` | Event enum yielded by `ToolAwareStream` |
| `ToolAwareStream` | `types::stream` | Stream wrapper that accumulates tool calls |

### New Methods

| Method | On | Description |
|--------|-----|-------------|
| `Choice::partial_tool_calls()` | `Choice` | Returns `Option<&[PartialToolCall]>` for streaming choices |
| `stream_chat_completion_tool_aware()` | `OpenRouterClient` | Convenience method returning `ToolAwareStream` |
| `ToolAwareStream::new()` | `ToolAwareStream` | Wraps a raw `BoxStream` |

### Breaking Changes

| Change | Impact | Migration |
|--------|--------|-----------|
| `Delta.tool_calls` type changed from `Option<Vec<ToolCall>>` to `Option<Vec<PartialToolCall>>` | Code directly accessing `delta.tool_calls` will see different types | Use `ToolAwareStream` for assembled tool calls, or access `PartialToolCall` fields with `.as_deref()` / `.unwrap_or_default()` |
| `Choice::tool_calls()` returns `None` for `Streaming` variant | Code calling `.tool_calls()` on streaming choices previously got partial/broken data; now gets `None` | Use `Choice::partial_tool_calls()` for raw access, or use `ToolAwareStream` |

