### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-02-28
+
 ### Added
 - Support `cache_control` on multipart text content via `ContentPart::text_with_cache_control`, `ContentPart::cacheable_text`, and `ContentPart::cacheable_text_with_ttl`.
 
 ### Changed
 - Extended reasoning effort support to include `xhigh`, `minimal`, and `none`.
+
+### Fixed
+- Updated examples to read `OPENROUTER_API_KEY` and `OPENROUTER_PROVISIONING_KEY` at runtime (instead of compile-time `.env` macro expansion), preventing CI/build failures.
+- Bumped `bytes` from `1.10.1` to `1.11.1` to address `GHSA-434x-w66g-qw3r` (`CVE-2026-25541`).
 
 ## [0.5.0] - 2026-02-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openrouter-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-openrouter-rs = "0.5.0"
+openrouter-rs = "0.5.1"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -395,7 +395,14 @@ This is a **third-party SDK** not officially affiliated with OpenRouter. Use at 
 
 ## 📈 Release History
 
-### Version 0.5.0 *(Latest)*
+### Version 0.5.1 *(Latest)*
+
+- 🧩 **New**: Multipart text `cache_control` helpers (`text_with_cache_control`, `cacheable_text`, `cacheable_text_with_ttl`)
+- 🧠 **Improved**: Reasoning effort now supports `xhigh`, `minimal`, and `none`
+- 🛡️ **Security**: Upgraded `bytes` to `1.11.1` (`GHSA-434x-w66g-qw3r`)
+- 🔧 **Fixed**: Examples now load API keys at runtime to avoid compile-time `.env` failures in CI
+
+### Version 0.5.0
 
 - 🌊 **New**: Streaming tool calls support with `ToolAwareStream` - automatically accumulates partial tool call fragments
 - 🔧 **New**: `PartialToolCall` and `PartialFunctionCall` types for incremental streaming data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.4.7"
+//! openrouter-rs = "0.5.1"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- bump crate version to `0.5.1`
- update `CHANGELOG.md` with `0.5.1` release notes
- update README install snippet and bottom release history latest section
- align `src/lib.rs` dependency doc snippet to `0.5.1`

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test unit
- release sync verification script for `0.5.1`
