### PR TITLE
chore: add in-repo release skill

### DIFF
--- a/.agents/skills/openrouter-rs-release/SKILL.md
+++ b/.agents/skills/openrouter-rs-release/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: openrouter-rs-release
+description: Prepare and publish a new openrouter-rs version with consistent version updates and release notes. Use when asked to cut a release, bump crate versions, publish to crates.io, update changelog entries, refresh README installation version, and update the README bottom Release History latest section.
+---
+
+# OpenRouter-rs Release
+
+## Overview
+
+Use this skill to run the full `openrouter-rs` release workflow without missing version sync points.
+Always update `Cargo.toml`, `CHANGELOG.md`, and README release sections together before tagging.
+
+## Release Inputs
+
+Collect these values first:
+
+- Target version (for example `0.5.1`)
+- Release date in `YYYY-MM-DD`
+- Summary bullets grouped by `Added`, `Changed`, `Fixed` (reuse from `CHANGELOG.md` when possible)
+
+## Update Versioned Files
+
+Apply updates in this order to avoid drift.
+
+1. Update package version in `Cargo.toml`.
+2. Update README installation snippet version (`openrouter-rs = "..."`).
+3. Update any outdated docs snippet that pins a crate version (notably `src/lib.rs` doctext if present).
+4. Update `CHANGELOG.md`:
+- Move finalized items from `## [Unreleased]` into a new version section.
+- Create `## [<version>] - <date>` with `### Added`/`### Changed`/`### Fixed` headings as needed.
+- Keep `## [Unreleased]` at the top for next cycle.
+5. Update README bottom `## 📈 Release History`:
+- Insert a new `### Version <version> *(Latest)*` section at the top of the history list.
+- Remove `*(Latest)*` marker from the previous latest version.
+- Copy concise release bullets aligned with the changelog section.
+
+Use [references/release-targets.md](references/release-targets.md) to verify exact files and grep checks.
+
+## Validate Before Commit
+
+Run local checks in this order:
+
+1. `cargo fmt --all`
+2. `cargo clippy --all-targets --all-features -- -D warnings`
+3. `cargo test --test unit`
+4. `bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh <version>`
+
+If `verify_release_sync.sh` reports mismatch, fix files before commit/tag.
+
+## Commit, Tag, and Publish
+
+When all checks pass:
+
+1. Commit release prep changes.
+2. Push to `main` via PR according to repo policy.
+3. Create and push the release tag: `v<version>`.
+4. Confirm GitHub Actions `Release` workflow passes:
+- verify job
+- crates.io publish (requires `CARGO_REGISTRY_TOKEN`)
+- GitHub release creation
+
+## Release Note Composition
+
+Use `CHANGELOG.md` as the source of truth.
+
+- Keep GitHub release notes and README bottom latest bullets semantically aligned.
+- Prefer concise bullets that explain user-visible impact.
+- Mention breaking changes explicitly.
+
+## Quick Execution Checklist
+
+- [ ] `Cargo.toml` version bumped
+- [ ] README installation version updated
+- [ ] `src/lib.rs` pinned crate snippet updated (if present)
+- [ ] `CHANGELOG.md` new version section created
+- [ ] README bottom Release History latest section updated
+- [ ] local checks passed (`fmt`, `clippy`, `unit`)
+- [ ] version sync script passed
+- [ ] tag `v<version>` pushed
+- [ ] release workflow green

--- a/.agents/skills/openrouter-rs-release/agents/openai.yaml
+++ b/.agents/skills/openrouter-rs-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OpenRouter-rs Release"
+  short_description: "Prepare and publish openrouter-rs releases safely"
+  default_prompt: "Use $openrouter-rs-release to prepare, verify, and publish the next openrouter-rs release."

--- a/.agents/skills/openrouter-rs-release/references/release-targets.md
+++ b/.agents/skills/openrouter-rs-release/references/release-targets.md
@@ -1,0 +1,43 @@
+# Release Targets for openrouter-rs
+
+Use this checklist to avoid missing version updates.
+
+## Required files
+
+1. `Cargo.toml`
+- Update `[package].version`.
+
+2. `CHANGELOG.md`
+- Keep `## [Unreleased]` at top.
+- Add `## [x.y.z] - YYYY-MM-DD` for the release.
+- Move relevant entries from Unreleased into the new section.
+
+3. `README.md`
+- Installation block: `openrouter-rs = "x.y.z"`.
+- Bottom section: `## 📈 Release History`.
+- Add `### Version x.y.z *(Latest)*` and remove `*(Latest)*` from prior latest.
+
+## Recommended file
+
+1. `src/lib.rs`
+- Check doc example dependency line `openrouter-rs = "..."` and keep it aligned.
+
+## Grep checks
+
+Run these commands from repo root:
+
+```bash
+rg -n '^version\s*=\s*"' Cargo.toml
+rg -n 'openrouter-rs\s*=\s*"' README.md src/lib.rs
+rg -n '^## \[Unreleased\]|^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md
+rg -n '^## 📈 Release History|^### Version ' README.md
+```
+
+## Consistency rule
+
+The release version should be consistent across:
+
+- `Cargo.toml` package version
+- README installation snippet
+- README bottom latest version header
+- latest version section in `CHANGELOG.md`

--- a/.agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh
+++ b/.agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+version="$1"
+
+if [[ ! -f Cargo.toml || ! -f README.md || ! -f CHANGELOG.md ]]; then
+  echo "Run this script from the repository root (Cargo.toml/README.md/CHANGELOG.md not found)."
+  exit 1
+fi
+
+fail=0
+
+echo "Checking Cargo.toml version..."
+if ! rg -n "^version\\s*=\\s*\"${version}\"$" Cargo.toml >/dev/null; then
+  echo "[FAIL] Cargo.toml package version is not ${version}"
+  fail=1
+else
+  echo "[OK] Cargo.toml version matches ${version}"
+fi
+
+echo "Checking README installation snippet..."
+if ! rg -n "openrouter-rs\\s*=\\s*\"${version}\"" README.md >/dev/null; then
+  echo "[FAIL] README installation snippet does not reference ${version}"
+  fail=1
+else
+  echo "[OK] README installation snippet matches ${version}"
+fi
+
+echo "Checking CHANGELOG top released section..."
+first_release_line="$(rg -n '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -n1 || true)"
+if [[ -z "${first_release_line}" ]]; then
+  echo "[FAIL] No released version section found in CHANGELOG.md"
+  fail=1
+elif [[ "${first_release_line}" != *"[${version}]"* ]]; then
+  echo "[FAIL] Latest released changelog section is not [${version}]"
+  echo "       Found: ${first_release_line}"
+  fail=1
+else
+  echo "[OK] CHANGELOG latest section is [${version}]"
+fi
+
+echo "Checking README Release History latest marker..."
+latest_line="$(rg -n '^### Version .*\*\(Latest\)\*' README.md | head -n1 || true)"
+if [[ -z "${latest_line}" ]]; then
+  echo "[FAIL] README Release History missing '(Latest)' marker"
+  fail=1
+elif [[ "${latest_line}" != *"Version ${version} "* ]]; then
+  echo "[FAIL] README latest release marker is not Version ${version}"
+  echo "       Found: ${latest_line}"
+  fail=1
+else
+  echo "[OK] README latest release marker matches ${version}"
+fi
+
+if [[ ${fail} -ne 0 ]]; then
+  echo "Release sync checks failed."
+  exit 1
+fi
+
+echo "All release sync checks passed for version ${version}."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/` contains library code.
+- `src/client.rs` is the main SDK client and builder entrypoint.
+- `src/api/` holds endpoint modules (`chat`, `completion`, `models`, `api_keys`, `credits`, `auth`, `generation`).
+- `src/types/` contains shared request/response types, including streaming and tool-call types.
+- `src/config/` contains configuration models and `default_config.toml` presets.
+- `tests/unit/` contains fast, local deserialization/config tests.
+- `tests/integration/` contains live API tests and shared helpers in `test_utils.rs`.
+- `examples/` contains runnable end-to-end usage samples.
+
+## Build, Test, and Development Commands
+- `cargo build` builds the crate.
+- `cargo check` validates compileability quickly.
+- `cargo fmt --all` formats code using `rustfmt`.
+- `cargo clippy --all-targets --all-features` runs lints (keep warnings at zero).
+- `cargo test --test unit` runs unit tests.
+- `OPENROUTER_API_KEY=... cargo test --test integration -- --nocapture` runs live integration tests.
+- `cargo run --example send_chat_completion` runs a reference example (see `examples/` for more).
+
+## Coding Style & Naming Conventions
+- Follow standard Rust formatting (4-space indentation, `rustfmt` output).
+- Use `snake_case` for modules/functions/tests, `PascalCase` for structs/enums/traits, and `SCREAMING_SNAKE_CASE` for constants.
+- Preserve existing patterns: builder-style APIs, typed request/response models, and explicit error handling via `Result<_, OpenRouterError>`.
+- Keep module boundaries clear (`api` for endpoint logic, `types` for data contracts).
+
+## Testing Guidelines
+- Add unit tests for parsing/typing behavior changes in `tests/unit/*.rs`.
+- Add integration tests for endpoint behavior changes in `tests/integration/*.rs`.
+- Name tests with `test_*` and keep assertions specific.
+- Integration tests require `OPENROUTER_API_KEY`; some examples/features also use `OPENROUTER_PROVISIONING_KEY`.
+
+## Commit & Pull Request Guidelines
+- Follow existing commit style: `feat:`, `fix:`, `docs:`, `chore:` + concise summary.
+- Keep PRs focused; include rationale, behavior changes, and linked issues/PRs.
+- For API changes, update examples and docs (`README.md`, `CHANGELOG.md`) in the same PR.
+- Before opening a PR, run: `cargo fmt --all`, `cargo clippy --all-targets --all-features`, and relevant tests.
+
+## Security & Configuration Tips
+- Use environment variables for secrets; never hardcode API keys.
+- Start from `.env.example` for local setup and keep `.env` out of commits.
+
+## Skills
+- `openrouter-rs-release`: prepare and publish a new version with synchronized updates to `Cargo.toml`, `CHANGELOG.md`, README release history, and release validation checks. (file: `.agents/skills/openrouter-rs-release/SKILL.md`)
+
+### Skill Trigger Rule
+- Use `openrouter-rs-release` when the user asks to publish/release/cut a new version.


### PR DESCRIPTION
## Summary
- add in-repo openrouter-rs-release skill under .agents/skills/openrouter-rs-release
- make release verification script/path portable for repository-local usage
- update AGENTS.md with skill entry and trigger rule

## Validation
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.5.1
