### PR TITLE
feat: add official response format variants

### DIFF
--- a/src/types/response_format.rs
+++ b/src/types/response_format.rs
@@ -7,8 +7,14 @@ use serde_json::Value;
 pub enum ResponseFormatType {
     /// Standard text response (default)
     Text,
+    /// JSON object response
+    JsonObject,
     /// JSON response following a specific schema
     JsonSchema,
+    /// Grammar-constrained response
+    Grammar,
+    /// Python-constrained response
+    Python,
 }
 
 /// JSON Schema configuration for structured outputs
@@ -27,17 +33,42 @@ pub struct JsonSchemaConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum ResponseFormat {
-    /// Simple format type specification
+    /// Legacy shorthand format type specification (e.g. "text")
     TypeOnly(ResponseFormatType),
+    /// Canonical type envelope (e.g. {"type":"text"})
+    Typed {
+        #[serde(rename = "type")]
+        type_: ResponseFormatType,
+    },
     /// Full configuration for JSON Schema responses
     JsonSchema {
         #[serde(rename = "type")]
         type_: ResponseFormatType,
         json_schema: JsonSchemaConfig,
     },
+    /// Grammar-constrained text response format
+    Grammar {
+        #[serde(rename = "type")]
+        type_: ResponseFormatType,
+        grammar: String,
+    },
 }
 
 impl ResponseFormat {
+    /// Create a standard text response format.
+    pub fn text() -> Self {
+        ResponseFormat::Typed {
+            type_: ResponseFormatType::Text,
+        }
+    }
+
+    /// Create a JSON object response format.
+    pub fn json_object() -> Self {
+        ResponseFormat::Typed {
+            type_: ResponseFormatType::JsonObject,
+        }
+    }
+
     /// Create a new JSON Schema response format
     pub fn json_schema(name: impl Into<String>, strict: bool, schema: Value) -> Self {
         ResponseFormat::JsonSchema {
@@ -49,10 +80,25 @@ impl ResponseFormat {
             },
         }
     }
+
+    /// Create a grammar-constrained response format.
+    pub fn grammar(grammar: impl Into<String>) -> Self {
+        ResponseFormat::Grammar {
+            type_: ResponseFormatType::Grammar,
+            grammar: grammar.into(),
+        }
+    }
+
+    /// Create a python-constrained response format.
+    pub fn python() -> Self {
+        ResponseFormat::Typed {
+            type_: ResponseFormatType::Python,
+        }
+    }
 }
 
 impl Default for ResponseFormat {
     fn default() -> Self {
-        ResponseFormat::TypeOnly(ResponseFormatType::Text)
+        ResponseFormat::text()
     }
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -8,4 +8,5 @@ pub mod chat_request;
 pub mod completion;
 pub mod config;
 pub mod provider;
+pub mod response_format;
 pub mod stream;

--- a/tests/unit/response_format.rs
+++ b/tests/unit/response_format.rs
@@ -1,0 +1,62 @@
+use openrouter_rs::types::{ResponseFormat, ResponseFormatType};
+use serde_json::json;
+
+#[test]
+fn test_response_format_text_serialize() {
+    let format = ResponseFormat::text();
+    let value = serde_json::to_value(&format).expect("text format should serialize");
+    assert_eq!(value["type"], "text");
+}
+
+#[test]
+fn test_response_format_json_object_serialize() {
+    let format = ResponseFormat::json_object();
+    let value = serde_json::to_value(&format).expect("json_object format should serialize");
+    assert_eq!(value["type"], "json_object");
+}
+
+#[test]
+fn test_response_format_json_schema_serialize() {
+    let format = ResponseFormat::json_schema(
+        "math_response",
+        true,
+        json!({
+            "type": "object",
+            "properties": {
+                "answer": { "type": "number" }
+            },
+            "required": ["answer"]
+        }),
+    );
+
+    let value = serde_json::to_value(&format).expect("json_schema format should serialize");
+    assert_eq!(value["type"], "json_schema");
+    assert_eq!(value["json_schema"]["name"], "math_response");
+    assert_eq!(value["json_schema"]["strict"], true);
+}
+
+#[test]
+fn test_response_format_grammar_serialize() {
+    let format = ResponseFormat::grammar("root ::= \"yes\" | \"no\"");
+    let value = serde_json::to_value(&format).expect("grammar format should serialize");
+    assert_eq!(value["type"], "grammar");
+    assert_eq!(value["grammar"], "root ::= \"yes\" | \"no\"");
+}
+
+#[test]
+fn test_response_format_python_serialize() {
+    let format = ResponseFormat::python();
+    let value = serde_json::to_value(&format).expect("python format should serialize");
+    assert_eq!(value["type"], "python");
+}
+
+#[test]
+fn test_response_format_legacy_type_only_deserialize() {
+    let format: ResponseFormat = serde_json::from_str("\"json_object\"")
+        .expect("legacy type-only format should deserialize");
+
+    match format {
+        ResponseFormat::TypeOnly(ResponseFormatType::JsonObject) => {}
+        _ => panic!("expected legacy TypeOnly(JsonObject)"),
+    }
+}


### PR DESCRIPTION
## Summary
- Extends response format support with official variants:
  - `json_object`
  - `grammar`
  - `python`
- Adds convenience constructors:
  - `ResponseFormat::text()`
  - `ResponseFormat::json_object()`
  - `ResponseFormat::grammar(...)`
  - `ResponseFormat::python()`
- Preserves backward compatibility via legacy `TypeOnly(...)` deserialization.
- Adds unit tests for all variants.

## Official API Alignment Check
Official response-format types expected:
- `text`
- `json_object`
- `json_schema`
- `grammar`
- `python`

Missing in SDK after this PR: none.

## Tests
- `cargo test --test unit`
- `cargo clippy --all-targets --all-features`

Closes #25
