### PR TITLE
feat: add responses API with streaming support

### DIFF
--- a/examples/create_response.rs
+++ b/examples/create_response.rs
@@ -1,0 +1,22 @@
+use openrouter_rs::{OpenRouterClient, api::responses::ResponsesRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = ResponsesRequest::builder()
+        .model("openai/gpt-5")
+        .input(json!([{
+            "role": "user",
+            "content": "Say hello in one sentence."
+        }]))
+        .build()?;
+
+    let response = client.create_response(&request).await?;
+    println!("response id: {:?}", response.id);
+    println!("status: {:?}", response.status);
+
+    Ok(())
+}

--- a/examples/stream_response.rs
+++ b/examples/stream_response.rs
@@ -1,0 +1,28 @@
+use futures_util::StreamExt;
+use openrouter_rs::{OpenRouterClient, api::responses::ResponsesRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = ResponsesRequest::builder()
+        .model("openai/gpt-5")
+        .input(json!([{
+            "role": "user",
+            "content": "Write a short haiku about Rust."
+        }]))
+        .build()?;
+
+    let stream = client.stream_response(&request).await?;
+
+    stream
+        .filter_map(|event| async { event.ok() })
+        .for_each(|event| async move {
+            println!("event: {}", event.event_type);
+        })
+        .await;
+
+    Ok(())
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -141,3 +141,4 @@ pub mod credits;
 pub mod errors;
 pub mod generation;
 pub mod models;
+pub mod responses;

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use futures_util::{AsyncBufReadExt, StreamExt, stream::BoxStream};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use surf::http::headers::AUTHORIZATION;
+
+use crate::{
+    api::chat::{Plugin, TraceOptions},
+    error::OpenRouterError,
+    strip_option_map_setter, strip_option_vec_setter,
+    types::ProviderPreferences,
+    utils::handle_error,
+};
+
+/// Request body for the OpenRouter Responses API (`POST /responses`).
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct ResponsesRequest {
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input: Option<Value>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions: Option<String>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<HashMap<String, String>>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<Value>>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<Value>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    models: Option<Vec<String>>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<Value>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<Value>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u32>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f64>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_logprobs: Option<u32>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tool_calls: Option<u32>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    presence_penalty: Option<f64>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frequency_penalty: Option<f64>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<f64>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image_config: Option<HashMap<String, Value>>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modalities: Option<Vec<String>>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_response_id: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<Value>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include: Option<Vec<String>>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background: Option<bool>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    safety_identifier: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    store: Option<bool>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<String>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncation: Option<String>,
+
+    #[builder(setter(skip), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<ProviderPreferences>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plugins: Option<Vec<Plugin>>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route: Option<String>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace: Option<TraceOptions>,
+}
+
+impl ResponsesRequestBuilder {
+    strip_option_map_setter!(metadata, String, String);
+    strip_option_vec_setter!(tools, Value);
+    strip_option_vec_setter!(models, String);
+    strip_option_map_setter!(image_config, String, Value);
+    strip_option_vec_setter!(modalities, String);
+    strip_option_vec_setter!(include, String);
+    strip_option_vec_setter!(plugins, Plugin);
+}
+
+impl ResponsesRequest {
+    pub fn builder() -> ResponsesRequestBuilder {
+        ResponsesRequestBuilder::default()
+    }
+
+    pub fn new(model: impl Into<String>, input: Value) -> Self {
+        Self::builder()
+            .model(model.into())
+            .input(input)
+            .build()
+            .expect("Failed to build ResponsesRequest")
+    }
+
+    fn stream(&self, stream: bool) -> Self {
+        let mut req = self.clone();
+        req.stream = Some(stream);
+        req
+    }
+}
+
+/// Non-streaming response payload returned by `POST /responses`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ResponsesResponse {
+    pub id: Option<String>,
+    #[serde(rename = "object")]
+    pub object_type: Option<String>,
+    pub created_at: Option<u64>,
+    pub model: Option<String>,
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Value>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Streaming event payload returned by `POST /responses` when `stream=true`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ResponsesStreamEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequence_number: Option<u64>,
+    #[serde(flatten)]
+    pub data: HashMap<String, Value>,
+}
+
+/// Send a non-streaming request to the Responses API.
+pub async fn create_response(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &ResponsesRequest,
+) -> Result<ResponsesResponse, OpenRouterError> {
+    let url = format!("{base_url}/responses");
+    let request = request.stream(false);
+
+    let mut surf_req = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .body_json(&request)?;
+
+    if let Some(x_title) = x_title {
+        surf_req = surf_req.header("X-Title", x_title);
+    }
+    if let Some(http_referer) = http_referer {
+        surf_req = surf_req.header("HTTP-Referer", http_referer);
+    }
+
+    let mut response = surf_req.await?;
+
+    if response.status().is_success() {
+        let response_data: ResponsesResponse = response.body_json().await?;
+        Ok(response_data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Send a streaming request to the Responses API.
+pub async fn stream_response(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &ResponsesRequest,
+) -> Result<BoxStream<'static, Result<ResponsesStreamEvent, OpenRouterError>>, OpenRouterError> {
+    let url = format!("{base_url}/responses");
+    let request = request.stream(true);
+
+    let mut surf_req = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .body_json(&request)?;
+
+    if let Some(x_title) = x_title {
+        surf_req = surf_req.header("X-Title", x_title);
+    }
+    if let Some(http_referer) = http_referer {
+        surf_req = surf_req.header("HTTP-Referer", http_referer);
+    }
+
+    let response = surf_req.await?;
+
+    if response.status().is_success() {
+        let lines = response
+            .lines()
+            .filter_map(async |line| match line {
+                Ok(line) => line
+                    .strip_prefix("data: ")
+                    .filter(|line| *line != "[DONE]")
+                    .map(serde_json::from_str::<ResponsesStreamEvent>)
+                    .map(|event| event.map_err(OpenRouterError::Serialization)),
+                Err(error) => Some(Err(OpenRouterError::Io(error))),
+            })
+            .boxed();
+
+        Ok(lines)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -9,4 +9,5 @@ pub mod completion;
 pub mod config;
 pub mod provider;
 pub mod response_format;
+pub mod responses;
 pub mod stream;

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -1,0 +1,149 @@
+use openrouter_rs::api::{
+    chat::{Plugin, TraceOptions},
+    responses::{ResponsesRequest, ResponsesResponse, ResponsesStreamEvent},
+};
+use serde_json::json;
+
+#[test]
+fn test_responses_request_serialization() {
+    let request = ResponsesRequest::builder()
+        .model("openai/gpt-5")
+        .input(json!([{
+            "role": "user",
+            "content": "Hello from responses API"
+        }]))
+        .instructions("Be concise")
+        .metadata([("env", "test"), ("feature", "responses")])
+        .tools(vec![json!({
+            "type": "function",
+            "name": "get_weather",
+            "parameters": { "type": "object" }
+        })])
+        .tool_choice(json!("auto"))
+        .parallel_tool_calls(true)
+        .models(vec![
+            "openai/gpt-5".to_string(),
+            "openai/gpt-4o".to_string(),
+        ])
+        .max_output_tokens(256)
+        .temperature(0.2)
+        .top_p(0.9)
+        .top_logprobs(5)
+        .max_tool_calls(2)
+        .presence_penalty(0.0)
+        .frequency_penalty(0.0)
+        .top_k(40.0)
+        .image_config([("aspect_ratio", json!("16:9"))])
+        .modalities(vec!["text".to_string(), "image".to_string()])
+        .prompt_cache_key("cache-key-1")
+        .previous_response_id("resp-prev")
+        .include(vec!["reasoning.encrypted_content".to_string()])
+        .background(false)
+        .safety_identifier("user-123")
+        .store(false)
+        .service_tier("auto")
+        .truncation("auto")
+        .user("user-123")
+        .session_id("session-abc")
+        .trace(TraceOptions {
+            trace_id: Some("trace-1".to_string()),
+            trace_name: None,
+            span_name: Some("responses.unit".to_string()),
+            generation_name: None,
+            parent_span_id: None,
+            extra: Default::default(),
+        })
+        .plugins(vec![Plugin::new("web").option("max_results", 3)])
+        .build()
+        .expect("responses request should build");
+
+    let value = serde_json::to_value(&request).expect("responses request should serialize");
+    assert_eq!(value["model"], "openai/gpt-5");
+    assert_eq!(value["instructions"], "Be concise");
+    assert_eq!(value["metadata"]["env"], "test");
+    assert_eq!(value["tool_choice"], "auto");
+    assert_eq!(value["parallel_tool_calls"], true);
+    assert_eq!(value["max_output_tokens"], 256);
+    assert_eq!(value["modalities"][1], "image");
+    assert_eq!(value["plugins"][0]["id"], "web");
+    assert_eq!(value["trace"]["trace_id"], "trace-1");
+    assert_eq!(value["trace"]["span_name"], "responses.unit");
+}
+
+#[test]
+fn test_responses_response_deserialization() {
+    let raw = r#"{
+        "id": "resp-abc123",
+        "object": "response",
+        "created_at": 1704067200,
+        "model": "gpt-4",
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "id": "msg-abc123",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": "Hello!",
+                "annotations": []
+            }]
+        }],
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 25,
+            "total_tokens": 35
+        }
+    }"#;
+
+    let response: ResponsesResponse =
+        serde_json::from_str(raw).expect("responses payload should deserialize");
+    assert_eq!(response.id.as_deref(), Some("resp-abc123"));
+    assert_eq!(response.object_type.as_deref(), Some("response"));
+    assert_eq!(response.status.as_deref(), Some("completed"));
+    assert!(response.output.is_some());
+    assert!(response.usage.is_some());
+}
+
+#[test]
+fn test_responses_stream_event_deserialization() {
+    let raw = r#"{
+        "type": "response.output_text.delta",
+        "sequence_number": 4,
+        "delta": "Hello"
+    }"#;
+
+    let event: ResponsesStreamEvent =
+        serde_json::from_str(raw).expect("stream event should deserialize");
+    assert_eq!(event.event_type, "response.output_text.delta");
+    assert_eq!(event.sequence_number, Some(4));
+    assert_eq!(
+        event.data.get("delta").and_then(|value| value.as_str()),
+        Some("Hello")
+    );
+}
+
+#[test]
+fn test_responses_stream_event_with_response_payload() {
+    let raw = r#"{
+        "type": "response.completed",
+        "sequence_number": 10,
+        "response": {
+            "id": "resp-abc123",
+            "status": "completed"
+        }
+    }"#;
+
+    let event: ResponsesStreamEvent =
+        serde_json::from_str(raw).expect("stream event with response should deserialize");
+    assert_eq!(event.event_type, "response.completed");
+    assert_eq!(event.sequence_number, Some(10));
+    assert_eq!(
+        event
+            .data
+            .get("response")
+            .and_then(|value| value.get("id"))
+            .and_then(|value| value.as_str()),
+        Some("resp-abc123")
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `api::responses` with `/responses` support:
  - `ResponsesRequest` (builder + stream toggle)
  - `ResponsesResponse` (non-streaming payload)
  - `ResponsesStreamEvent` (SSE event payload)
  - `create_response(...)` and `stream_response(...)` endpoint functions
- Adds `OpenRouterClient` wrappers:
  - `create_response(...)`
  - `stream_response(...)`
- Adds tests and examples:
  - `tests/unit/responses.rs`
  - `examples/create_response.rs`
  - `examples/stream_response.rs`

## Official API Alignment Check
Compared `ResponsesRequest` against `OpenResponsesRequest.properties` in `https://openrouter.ai/openapi.json`.

Result:
- Missing in SDK: none
- SDK-only request fields: none

## Validation
- `cargo test --test unit`
- `cargo clippy --all-targets --all-features`
- `cargo check --examples`

Closes #26
