### PR TITLE
feat: add Anthropic Messages API support (/messages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Anthropic-compatible `/messages` API support:
+  - `api::messages` module with typed request/response models
+  - non-streaming `create_message` and streaming `stream_messages`
+  - `OpenRouterClient::{create_message,stream_messages}` wrappers
+  - new examples: `create_message.rs` and `stream_messages.rs`
+
 ## [0.5.1] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ match client.send_chat_completion(&request).await {
 | **Reasoning Tokens** | ✅ | [`api::chat`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/chat/) |
 | Streaming Responses | ✅ | [`api::chat`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/chat/) |
 | **Streaming Tool Calls** | ✅ | [`types::stream`](https://docs.rs/openrouter-rs/latest/openrouter_rs/types/stream/) |
+| Responses API | ✅ | [`api::responses`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/responses/) |
+| Anthropic Messages API | ✅ | [`api::messages`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/messages/) |
 | Model Information | ✅ | [`api::models`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/models/) |
 | API Key Management | ✅ | [`api::api_keys`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/api_keys/) |
 | Credit Management | ✅ | [`api::credits`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/credits/) |

--- a/examples/create_message.rs
+++ b/examples/create_message.rs
@@ -1,0 +1,23 @@
+use openrouter_rs::{
+    OpenRouterClient,
+    api::messages::{AnthropicMessage, AnthropicMessagesRequest},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(256)
+        .messages(vec![AnthropicMessage::user("Say hello in one sentence.")])
+        .build()?;
+
+    let response = client.create_message(&request).await?;
+    println!("message id: {:?}", response.id);
+    println!("stop reason: {:?}", response.stop_reason);
+    println!("content blocks: {}", response.content.len());
+
+    Ok(())
+}

--- a/examples/stream_messages.rs
+++ b/examples/stream_messages.rs
@@ -1,0 +1,41 @@
+use futures_util::StreamExt;
+use openrouter_rs::{
+    OpenRouterClient,
+    api::messages::{AnthropicMessage, AnthropicMessagesRequest, AnthropicMessagesStreamEvent},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(256)
+        .messages(vec![AnthropicMessage::user(
+            "Write a short haiku about Rust.",
+        )])
+        .build()?;
+
+    let mut stream = client.stream_messages(&request).await?;
+
+    while let Some(item) = stream.next().await {
+        let event = item?;
+        match event.data {
+            AnthropicMessagesStreamEvent::ContentBlockDelta { delta, .. } => {
+                if delta["type"] == "text_delta" {
+                    if let Some(text) = delta["text"].as_str() {
+                        print!("{text}");
+                    }
+                }
+            }
+            AnthropicMessagesStreamEvent::MessageStop => {
+                println!();
+                println!("done");
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -1,0 +1,774 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use futures_util::{AsyncBufReadExt, StreamExt, stream, stream::BoxStream};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use surf::http::headers::AUTHORIZATION;
+
+use crate::{
+    api::chat::{CacheControl, Plugin, TraceOptions},
+    error::OpenRouterError,
+    strip_option_vec_setter,
+    types::ProviderPreferences,
+    utils::handle_error,
+};
+
+/// Role for Anthropic-compatible messages.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AnthropicRole {
+    User,
+    Assistant,
+}
+
+/// Text block for `system` prompts.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnthropicSystemTextBlock {
+    #[serde(rename = "type")]
+    pub block_type: AnthropicSystemTextBlockType,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub citations: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl AnthropicSystemTextBlock {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            block_type: AnthropicSystemTextBlockType::Text,
+            text: text.into(),
+            citations: None,
+            cache_control: None,
+            extra: HashMap::new(),
+        }
+    }
+}
+
+/// Block type for Anthropic system text blocks.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicSystemTextBlockType {
+    Text,
+}
+
+/// System prompt format for Anthropic messages.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum AnthropicSystemPrompt {
+    Text(String),
+    Blocks(Vec<AnthropicSystemTextBlock>),
+}
+
+/// Message content for Anthropic messages.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum AnthropicMessageContent {
+    Text(String),
+    Parts(Vec<AnthropicContentPart>),
+}
+
+impl From<String> for AnthropicMessageContent {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for AnthropicMessageContent {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
+impl From<Vec<AnthropicContentPart>> for AnthropicMessageContent {
+    fn from(value: Vec<AnthropicContentPart>) -> Self {
+        Self::Parts(value)
+    }
+}
+
+/// Multi-modal content part for Anthropic-compatible messages.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicContentPart {
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        citations: Option<Vec<Value>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    Image {
+        source: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    Document {
+        source: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        citations: Option<Vec<Value>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    ToolResult {
+        tool_use_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<AnthropicMessageContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
+    RedactedThinking {
+        data: String,
+    },
+    ServerToolUse {
+        id: String,
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    SearchResult {
+        source: String,
+        title: String,
+        content: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        citations: Option<Vec<Value>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+}
+
+impl AnthropicContentPart {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text {
+            text: text.into(),
+            citations: None,
+            cache_control: None,
+        }
+    }
+
+    pub fn image_url(url: impl Into<String>) -> Self {
+        Self::Image {
+            source: json!({
+                "type": "url",
+                "url": url.into()
+            }),
+            cache_control: None,
+        }
+    }
+
+    pub fn image_base64(media_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Image {
+            source: json!({
+                "type": "base64",
+                "media_type": media_type.into(),
+                "data": data.into()
+            }),
+            cache_control: None,
+        }
+    }
+
+    pub fn document_url(url: impl Into<String>) -> Self {
+        Self::Document {
+            source: json!({
+                "type": "url",
+                "url": url.into()
+            }),
+            title: None,
+            context: None,
+            citations: None,
+            cache_control: None,
+        }
+    }
+
+    pub fn tool_use(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        input: impl Into<Value>,
+    ) -> Self {
+        Self::ToolUse {
+            id: id.into(),
+            name: name.into(),
+            input: Some(input.into()),
+            cache_control: None,
+        }
+    }
+
+    pub fn tool_result(
+        tool_use_id: impl Into<String>,
+        content: impl Into<AnthropicMessageContent>,
+    ) -> Self {
+        Self::ToolResult {
+            tool_use_id: tool_use_id.into(),
+            content: Some(content.into()),
+            is_error: None,
+            cache_control: None,
+        }
+    }
+}
+
+/// A user/assistant message in Anthropic format.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnthropicMessage {
+    pub role: AnthropicRole,
+    pub content: AnthropicMessageContent,
+}
+
+impl AnthropicMessage {
+    pub fn new(role: AnthropicRole, content: impl Into<AnthropicMessageContent>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+        }
+    }
+
+    pub fn user(content: impl Into<AnthropicMessageContent>) -> Self {
+        Self::new(AnthropicRole::User, content)
+    }
+
+    pub fn assistant(content: impl Into<AnthropicMessageContent>) -> Self {
+        Self::new(AnthropicRole::Assistant, content)
+    }
+
+    pub fn with_parts(role: AnthropicRole, parts: Vec<AnthropicContentPart>) -> Self {
+        Self {
+            role,
+            content: AnthropicMessageContent::Parts(parts),
+        }
+    }
+}
+
+/// Anthropic metadata payload.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct AnthropicMessagesMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl AnthropicMessagesMetadata {
+    pub fn with_user_id(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: Some(user_id.into()),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+/// Tool definition for Anthropic-compatible messages.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnthropicTool {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<Value>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub tool_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl AnthropicTool {
+    pub fn custom(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        input_schema: impl Into<Value>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: Some(description.into()),
+            input_schema: Some(input_schema.into()),
+            tool_type: Some("custom".to_string()),
+            cache_control: None,
+            extra: HashMap::new(),
+        }
+    }
+
+    pub fn hosted(tool_type: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            input_schema: None,
+            tool_type: Some(tool_type.into()),
+            cache_control: None,
+            extra: HashMap::new(),
+        }
+    }
+
+    pub fn option(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.extra.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// Tool choice policy for Anthropic-compatible messages.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicToolChoice {
+    Auto {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+    Any {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+    None,
+    Tool {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+}
+
+impl AnthropicToolChoice {
+    pub fn auto() -> Self {
+        Self::Auto {
+            disable_parallel_tool_use: None,
+        }
+    }
+
+    pub fn any() -> Self {
+        Self::Any {
+            disable_parallel_tool_use: None,
+        }
+    }
+
+    pub fn none() -> Self {
+        Self::None
+    }
+
+    pub fn tool(name: impl Into<String>) -> Self {
+        Self::Tool {
+            name: name.into(),
+            disable_parallel_tool_use: None,
+        }
+    }
+}
+
+/// Thinking control for Anthropic-compatible messages.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicThinking {
+    Enabled { budget_tokens: u32 },
+    Disabled,
+    Adaptive,
+}
+
+impl AnthropicThinking {
+    pub fn enabled(budget_tokens: u32) -> Self {
+        Self::Enabled { budget_tokens }
+    }
+
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    pub fn adaptive() -> Self {
+        Self::Adaptive
+    }
+}
+
+/// Output effort level for Anthropic output configuration.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AnthropicOutputEffort {
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+/// Output config for Anthropic messages.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct AnthropicOutputConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<AnthropicOutputEffort>,
+}
+
+impl AnthropicOutputConfig {
+    pub fn with_effort(effort: AnthropicOutputEffort) -> Self {
+        Self {
+            effort: Some(effort),
+        }
+    }
+}
+
+/// Request body for `POST /messages`.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct AnthropicMessagesRequest {
+    #[builder(setter(into))]
+    model: String,
+
+    max_tokens: u32,
+
+    messages: Vec<AnthropicMessage>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<AnthropicSystemPrompt>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<AnthropicMessagesMetadata>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_sequences: Option<Vec<String>>,
+
+    #[builder(setter(skip), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f64>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<u32>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<AnthropicTool>>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<AnthropicToolChoice>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<AnthropicThinking>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<ProviderPreferences>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plugins: Option<Vec<Plugin>>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route: Option<String>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace: Option<TraceOptions>,
+
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    models: Option<Vec<String>>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_config: Option<AnthropicOutputConfig>,
+}
+
+impl AnthropicMessagesRequestBuilder {
+    strip_option_vec_setter!(stop_sequences, String);
+    strip_option_vec_setter!(tools, AnthropicTool);
+    strip_option_vec_setter!(plugins, Plugin);
+    strip_option_vec_setter!(models, String);
+
+    pub fn tool(&mut self, tool: AnthropicTool) -> &mut Self {
+        if let Some(Some(ref mut existing_tools)) = self.tools {
+            existing_tools.push(tool);
+        } else {
+            self.tools = Some(Some(vec![tool]));
+        }
+        self
+    }
+
+    pub fn add_message(&mut self, message: AnthropicMessage) -> &mut Self {
+        if let Some(ref mut messages) = self.messages {
+            messages.push(message);
+        } else {
+            self.messages = Some(vec![message]);
+        }
+        self
+    }
+
+    pub fn thinking_enabled(&mut self, budget_tokens: u32) -> &mut Self {
+        self.thinking = Some(Some(AnthropicThinking::enabled(budget_tokens)));
+        self
+    }
+}
+
+impl AnthropicMessagesRequest {
+    pub fn builder() -> AnthropicMessagesRequestBuilder {
+        AnthropicMessagesRequestBuilder::default()
+    }
+
+    pub fn new(model: impl Into<String>, max_tokens: u32, messages: Vec<AnthropicMessage>) -> Self {
+        Self::builder()
+            .model(model.into())
+            .max_tokens(max_tokens)
+            .messages(messages)
+            .build()
+            .expect("Failed to build AnthropicMessagesRequest")
+    }
+
+    pub fn messages(&self) -> &Vec<AnthropicMessage> {
+        &self.messages
+    }
+
+    pub fn tools(&self) -> Option<&Vec<AnthropicTool>> {
+        self.tools.as_ref()
+    }
+
+    fn stream(&self, stream: bool) -> Self {
+        let mut req = self.clone();
+        req.stream = Some(stream);
+        req
+    }
+}
+
+/// Usage object in Anthropic messages response.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct AnthropicMessagesUsage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Non-streaming response payload returned by `POST /messages`.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct AnthropicMessagesResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub object_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<AnthropicContentPart>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<AnthropicMessagesUsage>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Streaming data event payload for `POST /messages` when `stream=true`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicMessagesStreamEvent {
+    MessageStart {
+        message: Box<AnthropicMessagesResponse>,
+    },
+    MessageDelta {
+        delta: Value,
+        usage: Value,
+    },
+    MessageStop,
+    ContentBlockStart {
+        index: u32,
+        content_block: Box<AnthropicContentPart>,
+    },
+    ContentBlockDelta {
+        index: u32,
+        delta: Value,
+    },
+    ContentBlockStop {
+        index: u32,
+    },
+    Ping,
+    Error {
+        error: Value,
+    },
+}
+
+impl AnthropicMessagesStreamEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::MessageStart { .. } => "message_start",
+            Self::MessageDelta { .. } => "message_delta",
+            Self::MessageStop => "message_stop",
+            Self::ContentBlockStart { .. } => "content_block_start",
+            Self::ContentBlockDelta { .. } => "content_block_delta",
+            Self::ContentBlockStop { .. } => "content_block_stop",
+            Self::Ping => "ping",
+            Self::Error { .. } => "error",
+        }
+    }
+}
+
+/// Streaming SSE envelope returned by `POST /messages`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnthropicMessagesSseEvent {
+    pub event: String,
+    pub data: AnthropicMessagesStreamEvent,
+}
+
+/// Send a non-streaming request to the Anthropic-compatible Messages API.
+pub async fn create_message(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &AnthropicMessagesRequest,
+) -> Result<AnthropicMessagesResponse, OpenRouterError> {
+    let url = format!("{base_url}/messages");
+    let request = request.stream(false);
+
+    let mut surf_req = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .body_json(&request)?;
+
+    if let Some(x_title) = x_title {
+        surf_req = surf_req.header("X-Title", x_title);
+    }
+    if let Some(http_referer) = http_referer {
+        surf_req = surf_req.header("HTTP-Referer", http_referer);
+    }
+
+    let mut response = surf_req.await?;
+
+    if response.status().is_success() {
+        let response_data: AnthropicMessagesResponse = response.body_json().await?;
+        Ok(response_data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Send a streaming request to the Anthropic-compatible Messages API.
+pub async fn stream_messages(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &AnthropicMessagesRequest,
+) -> Result<BoxStream<'static, Result<AnthropicMessagesSseEvent, OpenRouterError>>, OpenRouterError>
+{
+    let url = format!("{base_url}/messages");
+    let request = request.stream(true);
+
+    let mut surf_req = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .body_json(&request)?;
+
+    if let Some(x_title) = x_title {
+        surf_req = surf_req.header("X-Title", x_title);
+    }
+    if let Some(http_referer) = http_referer {
+        surf_req = surf_req.header("HTTP-Referer", http_referer);
+    }
+
+    let response = surf_req.await?;
+
+    if response.status().is_success() {
+        let lines = response.lines();
+        let stream = stream::unfold(
+            (lines, None::<String>),
+            |(mut lines, mut current_event)| async move {
+                loop {
+                    match lines.next().await {
+                        Some(Ok(line)) => {
+                            if line.is_empty() || line.starts_with(':') {
+                                continue;
+                            }
+                            if let Some(event_name) = line.strip_prefix("event: ") {
+                                current_event = Some(event_name.to_string());
+                                continue;
+                            }
+                            if let Some(data) = line.strip_prefix("data: ") {
+                                if data == "[DONE]" {
+                                    return None;
+                                }
+                                let parsed =
+                                    serde_json::from_str::<AnthropicMessagesStreamEvent>(data)
+                                        .map_err(OpenRouterError::Serialization)
+                                        .map(|payload| {
+                                            let event =
+                                                current_event.clone().unwrap_or_else(|| {
+                                                    payload.event_type().to_string()
+                                                });
+                                            AnthropicMessagesSseEvent {
+                                                event,
+                                                data: payload,
+                                            }
+                                        });
+                                return Some((parsed, (lines, None)));
+                            }
+                        }
+                        Some(Err(error)) => {
+                            return Some((Err(OpenRouterError::Io(error)), (lines, current_event)));
+                        }
+                        None => return None,
+                    }
+                }
+            },
+        )
+        .boxed();
+
+        Ok(stream)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -140,5 +140,6 @@ pub mod completion;
 pub mod credits;
 pub mod errors;
 pub mod generation;
+pub mod messages;
 pub mod models;
 pub mod responses;

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -1,0 +1,287 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use futures_util::StreamExt;
+use openrouter_rs::api::{
+    chat::{Plugin, TraceOptions},
+    messages::{
+        AnthropicContentPart, AnthropicMessage, AnthropicMessagesMetadata,
+        AnthropicMessagesRequest, AnthropicMessagesResponse, AnthropicMessagesStreamEvent,
+        AnthropicOutputConfig, AnthropicOutputEffort, AnthropicRole, AnthropicSystemPrompt,
+        AnthropicSystemTextBlock, AnthropicThinking, AnthropicTool, AnthropicToolChoice,
+        stream_messages,
+    },
+};
+use serde_json::json;
+
+#[test]
+fn test_anthropic_messages_request_serialization() {
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(512)
+        .messages(vec![
+            AnthropicMessage::user("hello"),
+            AnthropicMessage::with_parts(
+                AnthropicRole::User,
+                vec![AnthropicContentPart::image_url(
+                    "https://example.com/image.png",
+                )],
+            ),
+        ])
+        .system(AnthropicSystemPrompt::Blocks(vec![
+            AnthropicSystemTextBlock::text("You are concise."),
+        ]))
+        .metadata(AnthropicMessagesMetadata::with_user_id("user-123"))
+        .stop_sequences(vec!["<END>".to_string()])
+        .temperature(0.2)
+        .top_p(0.9)
+        .top_k(40)
+        .tools(vec![
+            AnthropicTool::custom(
+                "get_weather",
+                "Get weather by city",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    },
+                    "required": ["city"]
+                }),
+            ),
+            AnthropicTool::hosted("web_search_20250305", "web_search").option("max_uses", 2),
+        ])
+        .tool_choice(AnthropicToolChoice::auto())
+        .thinking(AnthropicThinking::enabled(1024))
+        .service_tier("auto")
+        .plugins(vec![Plugin::new("web").option("max_results", 3)])
+        .route("fallback")
+        .user("user-123")
+        .session_id("session-abc")
+        .trace(TraceOptions {
+            trace_id: Some("trace-1".to_string()),
+            trace_name: None,
+            span_name: Some("messages.unit".to_string()),
+            generation_name: None,
+            parent_span_id: None,
+            extra: Default::default(),
+        })
+        .models(vec!["anthropic/claude-sonnet-4".to_string()])
+        .output_config(AnthropicOutputConfig::with_effort(
+            AnthropicOutputEffort::Medium,
+        ))
+        .build()
+        .expect("messages request should build");
+
+    let value = serde_json::to_value(&request).expect("messages request should serialize");
+
+    assert_eq!(value["model"], "anthropic/claude-sonnet-4");
+    assert_eq!(value["max_tokens"], 512);
+    assert_eq!(value["messages"][0]["role"], "user");
+    assert_eq!(value["messages"][0]["content"], "hello");
+    assert_eq!(value["system"][0]["type"], "text");
+    assert_eq!(value["metadata"]["user_id"], "user-123");
+    assert_eq!(value["tools"][0]["name"], "get_weather");
+    assert_eq!(value["tools"][1]["type"], "web_search_20250305");
+    assert_eq!(value["tool_choice"]["type"], "auto");
+    assert_eq!(value["thinking"]["type"], "enabled");
+    assert_eq!(value["thinking"]["budget_tokens"], 1024);
+    assert_eq!(value["output_config"]["effort"], "medium");
+    assert_eq!(value["plugins"][0]["id"], "web");
+}
+
+#[test]
+fn test_anthropic_messages_response_deserialization() {
+    let raw = r#"{
+        "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "text",
+                "text": "Hello there.",
+                "citations": null
+            }
+        ],
+        "model": "claude-sonnet-4-5-20250929",
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 15,
+            "service_tier": "standard"
+        }
+    }"#;
+
+    let response: AnthropicMessagesResponse =
+        serde_json::from_str(raw).expect("messages response should deserialize");
+    assert_eq!(response.id.as_deref(), Some("msg_01XFDUDYJgAACzvnptvVoYEL"));
+    assert_eq!(response.object_type.as_deref(), Some("message"));
+    assert_eq!(response.role.as_deref(), Some("assistant"));
+    assert_eq!(response.stop_reason.as_deref(), Some("end_turn"));
+    assert_eq!(
+        response
+            .usage
+            .as_ref()
+            .and_then(|usage| usage.output_tokens)
+            .unwrap_or_default(),
+        15
+    );
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        AnthropicContentPart::Text { text, .. } => assert_eq!(text, "Hello there."),
+        _ => panic!("expected text content block"),
+    }
+}
+
+#[test]
+fn test_anthropic_messages_stream_event_deserialization() {
+    let raw = r#"{
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+            "type": "text_delta",
+            "text": "Hello"
+        }
+    }"#;
+
+    let event: AnthropicMessagesStreamEvent =
+        serde_json::from_str(raw).expect("stream event should deserialize");
+    assert_eq!(event.event_type(), "content_block_delta");
+    match event {
+        AnthropicMessagesStreamEvent::ContentBlockDelta { index, delta } => {
+            assert_eq!(index, 0);
+            assert_eq!(delta["type"], "text_delta");
+            assert_eq!(delta["text"], "Hello");
+        }
+        _ => panic!("expected content_block_delta"),
+    }
+}
+
+#[tokio::test]
+async fn test_stream_messages_parses_event_and_data_lines() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+
+    let (tx, rx) = mpsc::channel::<(String, String)>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let header_end = request_bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|idx| idx + 4)
+            .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body = request_bytes[header_end..].to_vec();
+        while body.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body.extend_from_slice(&chunk[..read]);
+        }
+        let body_text = String::from_utf8_lossy(&body[..content_length]).to_string();
+        tx.send((request_line, body_text))
+            .expect("server should send request info");
+
+        let response_body = concat!(
+            "event: message_start\r\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"anthropic/claude-sonnet-4\",\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\r\n",
+            "\r\n",
+            "event: content_block_delta\r\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\r\n",
+            "\r\n",
+            "data: [DONE]\r\n",
+            "\r\n"
+        );
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(128)
+        .messages(vec![AnthropicMessage::user("hello")])
+        .build()
+        .expect("messages request should build");
+
+    let base_url = format!("http://{addr}/api/v1");
+    let mut stream = stream_messages(&base_url, "test-key", &None, &None, &request)
+        .await
+        .expect("stream_messages should succeed");
+
+    let mut events = Vec::new();
+    while let Some(item) = stream.next().await {
+        events.push(item.expect("stream item should parse"));
+    }
+
+    let (request_line, request_body) = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request details");
+
+    assert_eq!(request_line, "POST /api/v1/messages HTTP/1.1");
+    let request_json: serde_json::Value =
+        serde_json::from_str(&request_body).expect("request body should be valid JSON");
+    assert_eq!(request_json["stream"], true);
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event, "message_start");
+    assert_eq!(events[1].event, "content_block_delta");
+    match &events[1].data {
+        AnthropicMessagesStreamEvent::ContentBlockDelta { index, delta } => {
+            assert_eq!(*index, 0);
+            assert_eq!(delta["text"], "Hi");
+        }
+        _ => panic!("expected content_block_delta"),
+    }
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -7,6 +7,7 @@ pub mod api_keys;
 pub mod chat_request;
 pub mod completion;
 pub mod config;
+pub mod messages;
 pub mod provider;
 pub mod response_format;
 pub mod responses;


### PR DESCRIPTION
## Summary
- add new `api::messages` module for Anthropic-compatible `/messages`
- implement non-streaming `create_message` and streaming `stream_messages` with SSE `event` + `data` parsing
- add typed request/response/stream event models including core tools/thinking/system/message content blocks
- add `OpenRouterClient::{create_message, stream_messages}` wrappers
- add unit tests for request serialization, response/event deserialization, and end-to-end SSE line parsing via local server
- add examples: `create_message.rs` and `stream_messages.rs`
- update README API coverage table and CHANGELOG

## OpenAPI alignment
- request fields checked against `AnthropicMessagesRequest` in `https://openrouter.ai/openapi.json`
- field-level diff result: no missing fields, no extra fields
- stream event variants aligned to official types:
  - `message_start`, `message_delta`, `message_stop`
  - `content_block_start`, `content_block_delta`, `content_block_stop`
  - `ping`, `error`

## Validation
- `cargo fmt --all`
- `cargo test --test unit`
- `cargo clippy --all-targets --all-features`
- `cargo check --examples`

Closes #29
