### PR TITLE
feat: add provider/model discovery and activity endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - non-streaming `create_message` and streaming `stream_messages`
   - `OpenRouterClient::{create_message,stream_messages}` wrappers
   - new examples: `create_message.rs` and `stream_messages.rs`
+- Discovery and activity endpoint support:
+  - `api::discovery` module for `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`, `/activity`
+  - `OpenRouterClient` wrappers for each endpoint
+  - management-key requirement documented for `GET /activity` (`.provisioning_key(...)`)
 
 ## [0.5.1] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -241,10 +241,13 @@ match client.send_chat_completion(&request).await {
 | **Streaming Tool Calls** | ✅ | [`types::stream`](https://docs.rs/openrouter-rs/latest/openrouter_rs/types/stream/) |
 | Responses API | ✅ | [`api::responses`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/responses/) |
 | Anthropic Messages API | ✅ | [`api::messages`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/messages/) |
+| Provider/Activity Discovery | ✅ | [`api::discovery`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/discovery/) |
 | Model Information | ✅ | [`api::models`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/models/) |
 | API Key Management | ✅ | [`api::api_keys`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/api_keys/) |
 | Credit Management | ✅ | [`api::credits`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/credits/) |
 | Authentication | ✅ | [`api::auth`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/auth/) |
+
+`/activity` requires a management key; in this SDK set it with `.provisioning_key(...)`.
 
 ## 🎯 More Examples
 

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -1,0 +1,287 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use surf::http::headers::AUTHORIZATION;
+use urlencoding::encode;
+
+use crate::{error::OpenRouterError, types::ApiResponse, utils::handle_error};
+
+/// Number-like value used by OpenRouter pricing fields.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum BigNumber {
+    String(String),
+    Number(f64),
+}
+
+/// Public provider metadata returned by `GET /providers`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Provider {
+    pub name: String,
+    pub slug: String,
+    pub privacy_policy_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terms_of_service_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_page_url: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Model pricing payload returned by model discovery endpoints.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PublicPricing {
+    pub prompt: BigNumber,
+    pub completion: BigNumber,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_token: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_output: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_output: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_audio_cache: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_search: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal_reasoning: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_cache_read: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_cache_write: Option<BigNumber>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discount: Option<f64>,
+}
+
+/// Model architecture data in model discovery responses.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ModelArchitecture {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokenizer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instruct_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modality: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_modalities: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_modalities: Option<Vec<String>>,
+}
+
+/// Top provider metadata in model discovery responses.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TopProviderInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<f64>,
+    pub is_moderated: bool,
+}
+
+/// Per-request token limits for a model.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PerRequestLimits {
+    pub prompt_tokens: f64,
+    pub completion_tokens: f64,
+}
+
+/// Model payload returned by `GET /models/user`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UserModel {
+    pub id: String,
+    pub canonical_slug: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hugging_face_id: Option<String>,
+    pub name: String,
+    pub created: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub pricing: PublicPricing,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<f64>,
+    pub architecture: ModelArchitecture,
+    pub top_provider: TopProviderInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_request_limits: Option<PerRequestLimits>,
+    #[serde(default)]
+    pub supported_parameters: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_parameters: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_date: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Count payload returned by `GET /models/count`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ModelsCountData {
+    pub count: u64,
+}
+
+/// Percentile statistics payload used by endpoint throughput/latency.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PercentileStats {
+    pub p50: f64,
+    pub p75: f64,
+    pub p90: f64,
+    pub p99: f64,
+}
+
+/// Public endpoint payload returned by `GET /endpoints/zdr`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PublicEndpoint {
+    pub name: String,
+    pub model_id: String,
+    pub model_name: String,
+    pub context_length: f64,
+    pub pricing: PublicPricing,
+    pub provider_name: String,
+    pub tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantization: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_prompt_tokens: Option<f64>,
+    #[serde(default)]
+    pub supported_parameters: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uptime_last_30m: Option<f64>,
+    pub supports_implicit_caching: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_last_30m: Option<PercentileStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub throughput_last_30m: Option<PercentileStats>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Activity item payload returned by `GET /activity`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ActivityItem {
+    pub date: String,
+    pub model: String,
+    pub model_permaslug: String,
+    pub endpoint_id: String,
+    pub provider_name: String,
+    pub usage: f64,
+    pub byok_usage_inference: f64,
+    pub requests: f64,
+    pub prompt_tokens: f64,
+    pub completion_tokens: f64,
+    pub reasoning_tokens: f64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// List all providers (`GET /providers`).
+pub async fn list_providers(
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<Provider>, OpenRouterError> {
+    let url = format!("{base_url}/providers");
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let parsed: ApiResponse<Vec<Provider>> = response.body_json().await?;
+        Ok(parsed.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// List models filtered by user settings (`GET /models/user`).
+pub async fn list_models_for_user(
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<UserModel>, OpenRouterError> {
+    let url = format!("{base_url}/models/user");
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let parsed: ApiResponse<Vec<UserModel>> = response.body_json().await?;
+        Ok(parsed.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Count available models (`GET /models/count`).
+pub async fn count_models(
+    base_url: &str,
+    api_key: &str,
+) -> Result<ModelsCountData, OpenRouterError> {
+    let url = format!("{base_url}/models/count");
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let parsed: ApiResponse<ModelsCountData> = response.body_json().await?;
+        Ok(parsed.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// List ZDR-compatible endpoints (`GET /endpoints/zdr`).
+pub async fn list_zdr_endpoints(
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<PublicEndpoint>, OpenRouterError> {
+    let url = format!("{base_url}/endpoints/zdr");
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let parsed: ApiResponse<Vec<PublicEndpoint>> = response.body_json().await?;
+        Ok(parsed.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Get endpoint-grouped activity (`GET /activity`).
+///
+/// `date` is optional and should be in `YYYY-MM-DD` format.
+pub async fn get_activity(
+    base_url: &str,
+    management_key: &str,
+    date: Option<&str>,
+) -> Result<Vec<ActivityItem>, OpenRouterError> {
+    let url = if let Some(date) = date {
+        format!("{base_url}/activity?date={}", encode(date))
+    } else {
+        format!("{base_url}/activity")
+    };
+
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let parsed: ApiResponse<Vec<ActivityItem>> = response.body_json().await?;
+        Ok(parsed.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -138,6 +138,7 @@ pub mod auth;
 pub mod chat;
 pub mod completion;
 pub mod credits;
+pub mod discovery;
 pub mod embeddings;
 pub mod errors;
 pub mod generation;

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -1,0 +1,282 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::{
+    api::discovery::{
+        self, ActivityItem, BigNumber, ModelsCountData, Provider, PublicEndpoint, UserModel,
+    },
+    types::ApiResponse,
+};
+
+#[test]
+fn test_providers_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "name": "OpenAI",
+            "slug": "openai",
+            "privacy_policy_url": "https://openai.com/privacy",
+            "terms_of_service_url": "https://openai.com/terms",
+            "status_page_url": "https://status.openai.com"
+        }]
+    }"#;
+
+    let parsed: ApiResponse<Vec<Provider>> =
+        serde_json::from_str(raw).expect("providers response should deserialize");
+    assert_eq!(parsed.data.len(), 1);
+    assert_eq!(parsed.data[0].slug, "openai");
+    assert_eq!(
+        parsed.data[0].status_page_url.as_deref(),
+        Some("https://status.openai.com")
+    );
+}
+
+#[test]
+fn test_models_for_user_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "id": "openai/gpt-4.1",
+            "canonical_slug": "openai/gpt-4.1",
+            "hugging_face_id": null,
+            "name": "GPT-4.1",
+            "created": 1710000000,
+            "description": "Test model",
+            "pricing": {
+                "prompt": "0.000002",
+                "completion": 0.000008
+            },
+            "context_length": 128000,
+            "architecture": {
+                "tokenizer": "GPT",
+                "instruct_type": "chatml",
+                "modality": "text->text",
+                "input_modalities": ["text"],
+                "output_modalities": ["text"]
+            },
+            "top_provider": {
+                "context_length": 128000,
+                "max_completion_tokens": 16384,
+                "is_moderated": true
+            },
+            "per_request_limits": null,
+            "supported_parameters": ["temperature", "top_p"],
+            "default_parameters": null,
+            "expiration_date": null
+        }]
+    }"#;
+
+    let parsed: ApiResponse<Vec<UserModel>> =
+        serde_json::from_str(raw).expect("models/user response should deserialize");
+    assert_eq!(parsed.data.len(), 1);
+    assert_eq!(parsed.data[0].canonical_slug, "openai/gpt-4.1");
+    assert_eq!(parsed.data[0].supported_parameters.len(), 2);
+    assert!(matches!(
+        parsed.data[0].pricing.prompt,
+        BigNumber::String(_)
+    ));
+    assert!(matches!(
+        parsed.data[0].pricing.completion,
+        BigNumber::Number(_)
+    ));
+}
+
+#[test]
+fn test_models_count_response_deserialization() {
+    let raw = r#"{"data":{"count":150}}"#;
+    let parsed: ApiResponse<ModelsCountData> =
+        serde_json::from_str(raw).expect("models/count response should deserialize");
+    assert_eq!(parsed.data.count, 150);
+}
+
+#[test]
+fn test_zdr_endpoints_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "name": "OpenAI: GPT-4.1",
+            "model_id": "openai/gpt-4.1-2025-04-14",
+            "model_name": "GPT-4.1",
+            "context_length": 128000,
+            "pricing": {
+                "prompt": "0.000002",
+                "completion": "0.000008"
+            },
+            "provider_name": "OpenAI",
+            "tag": "openai",
+            "quantization": null,
+            "max_completion_tokens": 16384,
+            "max_prompt_tokens": 128000,
+            "supported_parameters": ["temperature", "top_p"],
+            "status": 0,
+            "uptime_last_30m": 99.9,
+            "supports_implicit_caching": true,
+            "latency_last_30m": {
+                "p50": 0.1,
+                "p75": 0.2,
+                "p90": 0.3,
+                "p99": 0.5
+            },
+            "throughput_last_30m": null
+        }]
+    }"#;
+
+    let parsed: ApiResponse<Vec<PublicEndpoint>> =
+        serde_json::from_str(raw).expect("endpoints/zdr response should deserialize");
+    assert_eq!(parsed.data.len(), 1);
+    assert_eq!(parsed.data[0].model_name, "GPT-4.1");
+    assert_eq!(parsed.data[0].status, Some(0));
+    assert!(parsed.data[0].throughput_last_30m.is_none());
+}
+
+#[test]
+fn test_activity_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "date": "2025-08-24",
+            "model": "openai/gpt-4.1",
+            "model_permaslug": "openai/gpt-4.1-2025-04-14",
+            "endpoint_id": "550e8400-e29b-41d4-a716-446655440000",
+            "provider_name": "OpenAI",
+            "usage": 0.015,
+            "byok_usage_inference": 0.012,
+            "requests": 5,
+            "prompt_tokens": 50,
+            "completion_tokens": 125,
+            "reasoning_tokens": 25
+        }]
+    }"#;
+
+    let parsed: ApiResponse<Vec<ActivityItem>> =
+        serde_json::from_str(raw).expect("activity response should deserialize");
+    assert_eq!(parsed.data.len(), 1);
+    assert_eq!(parsed.data[0].date, "2025-08-24");
+    assert_eq!(parsed.data[0].requests, 5.0);
+}
+
+#[tokio::test]
+async fn test_list_models_for_user_request_path() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_line = String::from_utf8_lossy(&request_bytes)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        tx.send(request_line)
+            .expect("server should send request line");
+
+        let body = r#"{"data":[]}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let models = discovery::list_models_for_user(&base_url, "test-key")
+        .await
+        .expect("models/user request should succeed");
+    assert!(models.is_empty());
+
+    let request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request line");
+    assert_eq!(request_line, "GET /api/v1/models/user HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_activity_with_date_query_and_auth_header() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_text = String::from_utf8_lossy(&request_bytes).to_string();
+        tx.send(request_text).expect("server should send request");
+
+        let body = r#"{"data":[]}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let items = discovery::get_activity(&base_url, "mgmt-key", Some("2025-08-24"))
+        .await
+        .expect("activity request should succeed");
+    assert!(items.is_empty());
+
+    let request_text = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    let mut lines = request_text.lines();
+    let request_line = lines.next().unwrap_or_default();
+    assert_eq!(
+        request_line,
+        "GET /api/v1/activity?date=2025-08-24 HTTP/1.1"
+    );
+
+    let request_lower = request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer mgmt-key")
+            || request_lower.contains("authorization:bearer mgmt-key"),
+        "authorization header should include management key, request:\n{request_text}"
+    );
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -7,6 +7,7 @@ pub mod api_keys;
 pub mod chat_request;
 pub mod completion;
 pub mod config;
+pub mod discovery;
 pub mod embeddings;
 pub mod messages;
 pub mod provider;


### PR DESCRIPTION
## Summary
- add new `api::discovery` module covering:
  - `GET /providers`
  - `GET /models/user`
  - `GET /models/count`
  - `GET /endpoints/zdr`
  - `GET /activity`
- add typed response models for provider discovery, user model catalog, model count, ZDR endpoints, and activity items
- add client wrappers:
  - `list_providers`
  - `list_models_for_user`
  - `count_models`
  - `list_zdr_endpoints`
  - `get_activity`
- document management-key requirement for `GET /activity` (`.provisioning_key(...)`) in client docs and README
- add unit tests for all new typed responses and request path/query behavior

## OpenAPI Alignment
Checked against `https://openrouter.ai/openapi.json`:
- endpoint coverage for issue scope paths: complete
- field-level checks:
  - `Provider` vs `/providers` item: missing `[]`, extra `[]`
  - `UserModel` vs `Model`: missing `[]`, extra `[]`
  - `ModelsCountData` vs `/models/count data`: missing `[]`, extra `[]`
  - `PublicEndpoint` vs `PublicEndpoint`: missing `[]`, extra `[]`
  - `ActivityItem` vs `ActivityItem`: missing `[]`, extra `[]`

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo check --examples`

Closes #30
