### PR TITLE
feat: add oauth auth-code creation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `api::discovery` module for `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`, `/activity`
   - `OpenRouterClient` wrappers for each endpoint
   - management-key requirement documented for `GET /activity` (`.provisioning_key(...)`)
+- OAuth auth-code creation support:
+  - add `POST /auth/keys/code` request/response types and client wrapper (`create_auth_code`)
+  - add PKCE end-to-end doc snippet (`create_auth_code` -> `exchange_code_for_api_key`)
 
 ## [0.5.1] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,32 @@ match client.send_chat_completion(&request).await {
 }
 ```
 
+### 🔐 OAuth PKCE Flow
+
+```rust
+use openrouter_rs::{OpenRouterClient, api::auth};
+
+let client = OpenRouterClient::builder()
+    .api_key("your_api_key")
+    .build()?;
+
+let create = auth::CreateAuthCodeRequest::builder()
+    .callback_url("https://myapp.com/auth/callback")
+    .code_challenge("your_pkce_code_challenge")
+    .code_challenge_method(auth::CodeChallengeMethod::S256)
+    .build()?;
+
+let auth_code = client.create_auth_code(&create).await?;
+
+let key = client
+    .exchange_code_for_api_key(
+        &auth_code.id,
+        Some("your_pkce_code_verifier"),
+        Some(auth::CodeChallengeMethod::S256),
+    )
+    .await?;
+```
+
 ## 📊 API Coverage
 
 | Feature | Status | Module |

--- a/src/client.rs
+++ b/src/client.rs
@@ -276,6 +276,54 @@ impl OpenRouterClient {
         }
     }
 
+    /// Create an authorization code for PKCE flow (`POST /auth/keys/code`).
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The auth-code creation request built with `CreateAuthCodeRequest::builder()`.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<auth::AuthCodeData, OpenRouterError>` - The created authorization code payload.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use openrouter_rs::{OpenRouterClient, api::auth};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
+    ///
+    /// let create = auth::CreateAuthCodeRequest::builder()
+    ///     .callback_url("https://myapp.com/auth/callback")
+    ///     .code_challenge("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    ///     .code_challenge_method(auth::CodeChallengeMethod::S256)
+    ///     .build()?;
+    ///
+    /// let auth_code = client.create_auth_code(&create).await?;
+    ///
+    /// let exchanged = client
+    ///     .exchange_code_for_api_key(
+    ///         &auth_code.id,
+    ///         Some("your_pkce_code_verifier"),
+    ///         Some(auth::CodeChallengeMethod::S256),
+    ///     )
+    ///     .await?;
+    ///
+    /// println!("New key: {}", exchanged.key);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_auth_code(
+        &self,
+        request: &auth::CreateAuthCodeRequest,
+    ) -> Result<auth::AuthCodeData, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            auth::create_auth_code(&self.base_url, api_key, request).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Exchange an authorization code from the PKCE flow for a user-controlled API key.
     ///
     /// # Arguments

--- a/tests/unit/auth.rs
+++ b/tests/unit/auth.rs
@@ -1,0 +1,156 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::api::auth::{self, CodeChallengeMethod, CreateAuthCodeRequest, UsageLimitType};
+use serde_json::json;
+
+#[test]
+fn test_create_auth_code_request_serialization() {
+    let request = CreateAuthCodeRequest::builder()
+        .callback_url("https://myapp.com/auth/callback")
+        .code_challenge("abc123")
+        .code_challenge_method(CodeChallengeMethod::S256)
+        .limit(100.0)
+        .expires_at("2026-12-31T23:59:59Z")
+        .key_label("My Custom Key")
+        .usage_limit_type(UsageLimitType::Monthly)
+        .spawn_agent("sdk")
+        .spawn_cloud("aws")
+        .build()
+        .expect("request should build");
+
+    let value = serde_json::to_value(request).expect("request should serialize");
+    assert_eq!(value["callback_url"], "https://myapp.com/auth/callback");
+    assert_eq!(value["code_challenge"], "abc123");
+    assert_eq!(value["code_challenge_method"], "S256");
+    assert_eq!(value["limit"], 100.0);
+    assert_eq!(value["usage_limit_type"], "monthly");
+    assert_eq!(value["spawn_agent"], "sdk");
+    assert_eq!(value["spawn_cloud"], "aws");
+}
+
+#[test]
+fn test_code_challenge_method_plain_serialization() {
+    let value = serde_json::to_value(CodeChallengeMethod::Plain)
+        .expect("CodeChallengeMethod::Plain should serialize");
+    assert_eq!(value, json!("plain"));
+}
+
+#[test]
+fn test_create_auth_code_response_deserialization() {
+    let raw = r#"{
+        "data": {
+            "id": "auth_code_xyz789",
+            "app_id": 12345,
+            "created_at": "2025-08-24T10:30:00Z"
+        }
+    }"#;
+
+    let response: openrouter_rs::types::ApiResponse<auth::AuthCodeData> =
+        serde_json::from_str(raw).expect("response should deserialize");
+    assert_eq!(response.data.id, "auth_code_xyz789");
+    assert_eq!(response.data.app_id, 12345.0);
+    assert_eq!(response.data.created_at, "2025-08-24T10:30:00Z");
+}
+
+#[tokio::test]
+async fn test_create_auth_code_uses_auth_keys_code_path() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<(String, String)>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let header_end = request_bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|idx| idx + 4)
+            .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body = request_bytes[header_end..].to_vec();
+        while body.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body.extend_from_slice(&chunk[..read]);
+        }
+        let body_text = String::from_utf8_lossy(&body[..content_length]).to_string();
+        tx.send((request_line, body_text))
+            .expect("server should send request details");
+
+        let response_body = r#"{"data":{"id":"auth_code_xyz789","app_id":12345,"created_at":"2025-08-24T10:30:00Z"}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    let request = CreateAuthCodeRequest::builder()
+        .callback_url("https://myapp.com/auth/callback")
+        .code_challenge("abc123")
+        .code_challenge_method(CodeChallengeMethod::S256)
+        .build()
+        .expect("request should build");
+
+    let base_url = format!("http://{addr}/api/v1");
+    let response = auth::create_auth_code(&base_url, "test-key", &request)
+        .await
+        .expect("create_auth_code should succeed");
+    assert_eq!(response.id, "auth_code_xyz789");
+
+    let (request_line, request_body) = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request details");
+    assert_eq!(request_line, "POST /api/v1/auth/keys/code HTTP/1.1");
+    let body_json: serde_json::Value =
+        serde_json::from_str(&request_body).expect("request body should be json");
+    assert_eq!(body_json["callback_url"], "https://myapp.com/auth/callback");
+    assert_eq!(body_json["code_challenge_method"], "S256");
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -4,6 +4,7 @@ fn dummy_test() {
 }
 
 pub mod api_keys;
+pub mod auth;
 pub mod chat_request;
 pub mod completion;
 pub mod config;


### PR DESCRIPTION
## Summary
- add OAuth auth-code creation support for `POST /auth/keys/code`
- add new request/response types:
  - `CreateAuthCodeRequest`
  - `AuthCodeData`
  - `UsageLimitType`
- add API function `auth::create_auth_code(...)`
- add client wrapper `OpenRouterClient::create_auth_code(...)`
- include end-to-end PKCE doc snippets:
  - client rustdoc on `create_auth_code`
  - README `OAuth PKCE Flow` section
- ensure `CodeChallengeMethod` serializes to OpenAPI-compatible values (`S256` / `plain`)

## OpenAPI Alignment
Checked against `https://openrouter.ai/openapi.json`:
- `CreateAuthCodeRequest` vs `/auth/keys/code` request schema fields: missing `[]`, extra `[]`
- `AuthCodeData` vs `/auth/keys/code` response `data` schema fields: missing `[]`, extra `[]`

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo check --examples`

Closes #31
