### PR TITLE
feat: implement full guardrails API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OAuth auth-code creation support:
   - add `POST /auth/keys/code` request/response types and client wrapper (`create_auth_code`)
   - add PKCE end-to-end doc snippet (`create_auth_code` -> `exchange_code_for_api_key`)
+- Guardrails endpoint support:
+  - `api::guardrails` module for `/guardrails` and all guardrail assignment endpoints
+  - `OpenRouterClient` wrappers for create/read/update/delete and key/member assignment flows
+  - management-key requirement documented for guardrail endpoints (`.provisioning_key(...)`)
 
 ## [0.5.1] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -268,12 +268,14 @@ let key = client
 | Responses API | ✅ | [`api::responses`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/responses/) |
 | Anthropic Messages API | ✅ | [`api::messages`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/messages/) |
 | Provider/Activity Discovery | ✅ | [`api::discovery`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/discovery/) |
+| Guardrails | ✅ | [`api::guardrails`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/guardrails/) |
 | Model Information | ✅ | [`api::models`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/models/) |
 | API Key Management | ✅ | [`api::api_keys`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/api_keys/) |
 | Credit Management | ✅ | [`api::credits`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/credits/) |
 | Authentication | ✅ | [`api::auth`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/auth/) |
 
 `/activity` requires a management key; in this SDK set it with `.provisioning_key(...)`.
+`/guardrails*` endpoints also require a management key; in this SDK set it with `.provisioning_key(...)`.
 
 ## 🎯 More Examples
 

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -1,0 +1,486 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use surf::http::headers::AUTHORIZATION;
+use urlencoding::encode;
+
+use crate::{
+    error::OpenRouterError, strip_option_vec_setter, types::ApiResponse, utils::handle_error,
+};
+
+/// Guardrail model.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Guardrail {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reset_interval: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_providers: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_models: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforce_zdr: Option<bool>,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+/// Paginated guardrails list response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuardrailListResponse {
+    pub data: Vec<Guardrail>,
+    pub total_count: f64,
+}
+
+/// Request payload for creating a guardrail (`POST /guardrails`).
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct CreateGuardrailRequest {
+    #[builder(setter(into))]
+    name: String,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit_usd: Option<f64>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reset_interval: Option<String>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_providers: Option<Vec<String>>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_models: Option<Vec<String>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_zdr: Option<bool>,
+}
+
+impl CreateGuardrailRequestBuilder {
+    strip_option_vec_setter!(allowed_providers, String);
+    strip_option_vec_setter!(allowed_models, String);
+}
+
+impl CreateGuardrailRequest {
+    pub fn builder() -> CreateGuardrailRequestBuilder {
+        CreateGuardrailRequestBuilder::default()
+    }
+}
+
+/// Request payload for updating a guardrail (`PATCH /guardrails/{id}`).
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct UpdateGuardrailRequest {
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit_usd: Option<f64>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reset_interval: Option<String>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_providers: Option<Vec<String>>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_models: Option<Vec<String>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_zdr: Option<bool>,
+}
+
+impl UpdateGuardrailRequestBuilder {
+    strip_option_vec_setter!(allowed_providers, String);
+    strip_option_vec_setter!(allowed_models, String);
+}
+
+impl UpdateGuardrailRequest {
+    pub fn builder() -> UpdateGuardrailRequestBuilder {
+        UpdateGuardrailRequestBuilder::default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct DeleteGuardrailResponse {
+    deleted: bool,
+}
+
+/// Key assignment model.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuardrailKeyAssignment {
+    pub id: String,
+    pub key_hash: String,
+    pub guardrail_id: String,
+    pub key_name: String,
+    pub key_label: String,
+    pub assigned_by: String,
+    pub created_at: String,
+}
+
+/// Member assignment model.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuardrailMemberAssignment {
+    pub id: String,
+    pub user_id: String,
+    pub organization_id: String,
+    pub guardrail_id: String,
+    pub assigned_by: String,
+    pub created_at: String,
+}
+
+/// Paginated key assignment list response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuardrailKeyAssignmentsResponse {
+    pub data: Vec<GuardrailKeyAssignment>,
+    pub total_count: f64,
+}
+
+/// Paginated member assignment list response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuardrailMemberAssignmentsResponse {
+    pub data: Vec<GuardrailMemberAssignment>,
+    pub total_count: f64,
+}
+
+/// Request payload for key bulk assignment endpoints.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct BulkKeyAssignmentRequest {
+    key_hashes: Vec<String>,
+}
+
+impl BulkKeyAssignmentRequest {
+    pub fn builder() -> BulkKeyAssignmentRequestBuilder {
+        BulkKeyAssignmentRequestBuilder::default()
+    }
+}
+
+/// Request payload for member bulk assignment endpoints.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct BulkMemberAssignmentRequest {
+    member_user_ids: Vec<String>,
+}
+
+impl BulkMemberAssignmentRequest {
+    pub fn builder() -> BulkMemberAssignmentRequestBuilder {
+        BulkMemberAssignmentRequestBuilder::default()
+    }
+}
+
+/// Response payload for assignment endpoints.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AssignedCountResponse {
+    pub assigned_count: f64,
+}
+
+/// Response payload for unassignment endpoints.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UnassignedCountResponse {
+    pub unassigned_count: f64,
+}
+
+fn with_pagination(url: String, offset: Option<u32>, limit: Option<u32>) -> String {
+    let mut params = Vec::new();
+    if let Some(offset) = offset {
+        params.push(format!("offset={offset}"));
+    }
+    if let Some(limit) = limit {
+        params.push(format!("limit={limit}"));
+    }
+
+    if params.is_empty() {
+        url
+    } else {
+        format!("{url}?{}", params.join("&"))
+    }
+}
+
+pub async fn list_guardrails(
+    base_url: &str,
+    management_key: &str,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<GuardrailListResponse, OpenRouterError> {
+    let url = with_pagination(format!("{base_url}/guardrails"), offset, limit);
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn create_guardrail(
+    base_url: &str,
+    management_key: &str,
+    request: &CreateGuardrailRequest,
+) -> Result<Guardrail, OpenRouterError> {
+    let url = format!("{base_url}/guardrails");
+    let mut response = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .body_json(request)?
+        .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<Guardrail> = response.body_json().await?;
+        Ok(payload.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn get_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<Guardrail, OpenRouterError> {
+    let url = format!("{base_url}/guardrails/{}", encode(id));
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<Guardrail> = response.body_json().await?;
+        Ok(payload.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn update_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateGuardrailRequest,
+) -> Result<Guardrail, OpenRouterError> {
+    let url = format!("{base_url}/guardrails/{}", encode(id));
+    let mut response = surf::patch(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .body_json(request)?
+        .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<Guardrail> = response.body_json().await?;
+        Ok(payload.data)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn delete_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<bool, OpenRouterError> {
+    let url = format!("{base_url}/guardrails/{}", encode(id));
+    let mut response = surf::delete(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        let payload: DeleteGuardrailResponse = response.body_json().await?;
+        Ok(payload.deleted)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn list_guardrail_key_assignments(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<GuardrailKeyAssignmentsResponse, OpenRouterError> {
+    let url = with_pagination(
+        format!("{base_url}/guardrails/{}/assignments/keys", encode(id)),
+        offset,
+        limit,
+    );
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn bulk_assign_keys_to_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkKeyAssignmentRequest,
+) -> Result<AssignedCountResponse, OpenRouterError> {
+    let url = format!("{base_url}/guardrails/{}/assignments/keys", encode(id));
+    let mut response = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .body_json(request)?
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn bulk_unassign_keys_from_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkKeyAssignmentRequest,
+) -> Result<UnassignedCountResponse, OpenRouterError> {
+    let url = format!(
+        "{base_url}/guardrails/{}/assignments/keys/remove",
+        encode(id)
+    );
+    let mut response = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .body_json(request)?
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn list_guardrail_member_assignments(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<GuardrailMemberAssignmentsResponse, OpenRouterError> {
+    let url = with_pagination(
+        format!("{base_url}/guardrails/{}/assignments/members", encode(id)),
+        offset,
+        limit,
+    );
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn bulk_assign_members_to_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkMemberAssignmentRequest,
+) -> Result<AssignedCountResponse, OpenRouterError> {
+    let url = format!("{base_url}/guardrails/{}/assignments/members", encode(id));
+    let mut response = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .body_json(request)?
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn bulk_unassign_members_from_guardrail(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkMemberAssignmentRequest,
+) -> Result<UnassignedCountResponse, OpenRouterError> {
+    let url = format!(
+        "{base_url}/guardrails/{}/assignments/members/remove",
+        encode(id)
+    );
+    let mut response = surf::post(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .body_json(request)?
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn list_key_assignments(
+    base_url: &str,
+    management_key: &str,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<GuardrailKeyAssignmentsResponse, OpenRouterError> {
+    let url = with_pagination(
+        format!("{base_url}/guardrails/assignments/keys"),
+        offset,
+        limit,
+    );
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn list_member_assignments(
+    base_url: &str,
+    management_key: &str,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<GuardrailMemberAssignmentsResponse, OpenRouterError> {
+    let url = with_pagination(
+        format!("{base_url}/guardrails/assignments/members"),
+        offset,
+        limit,
+    );
+    let mut response = surf::get(url)
+        .header(AUTHORIZATION, format!("Bearer {management_key}"))
+        .await?;
+
+    if response.status().is_success() {
+        Ok(response.body_json().await?)
+    } else {
+        handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -142,6 +142,7 @@ pub mod discovery;
 pub mod embeddings;
 pub mod errors;
 pub mod generation;
+pub mod guardrails;
 pub mod messages;
 pub mod models;
 pub mod responses;

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,8 @@ use futures_util::stream::BoxStream;
 
 use crate::{
     api::{
-        api_keys, auth, chat, completion, credits, discovery, embeddings, generation, messages,
-        models, responses,
+        api_keys, auth, chat, completion, credits, discovery, embeddings, generation, guardrails,
+        messages, models, responses,
     },
     config::OpenRouterConfig,
     error::OpenRouterError,
@@ -319,6 +319,202 @@ impl OpenRouterClient {
     ) -> Result<auth::AuthCodeData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
             auth::create_auth_code(&self.base_url, api_key, request).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List guardrails (`GET /guardrails`). Requires a management key.
+    pub async fn list_guardrails(
+        &self,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<guardrails::GuardrailListResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::list_guardrails(&self.base_url, provisioning_key, offset, limit).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Create a guardrail (`POST /guardrails`). Requires a management key.
+    pub async fn create_guardrail(
+        &self,
+        request: &guardrails::CreateGuardrailRequest,
+    ) -> Result<guardrails::Guardrail, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::create_guardrail(&self.base_url, provisioning_key, request).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Get a guardrail by ID (`GET /guardrails/{id}`). Requires a management key.
+    pub async fn get_guardrail(&self, id: &str) -> Result<guardrails::Guardrail, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::get_guardrail(&self.base_url, provisioning_key, id).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Update a guardrail (`PATCH /guardrails/{id}`). Requires a management key.
+    pub async fn update_guardrail(
+        &self,
+        id: &str,
+        request: &guardrails::UpdateGuardrailRequest,
+    ) -> Result<guardrails::Guardrail, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::update_guardrail(&self.base_url, provisioning_key, id, request).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Delete a guardrail (`DELETE /guardrails/{id}`). Requires a management key.
+    pub async fn delete_guardrail(&self, id: &str) -> Result<bool, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::delete_guardrail(&self.base_url, provisioning_key, id).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List key assignments for a guardrail (`GET /guardrails/{id}/assignments/keys`).
+    pub async fn list_guardrail_key_assignments(
+        &self,
+        id: &str,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<guardrails::GuardrailKeyAssignmentsResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::list_guardrail_key_assignments(
+                &self.base_url,
+                provisioning_key,
+                id,
+                offset,
+                limit,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Bulk assign key hashes to a guardrail (`POST /guardrails/{id}/assignments/keys`).
+    pub async fn bulk_assign_keys_to_guardrail(
+        &self,
+        id: &str,
+        request: &guardrails::BulkKeyAssignmentRequest,
+    ) -> Result<guardrails::AssignedCountResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::bulk_assign_keys_to_guardrail(&self.base_url, provisioning_key, id, request)
+                .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Bulk unassign key hashes from a guardrail (`POST /guardrails/{id}/assignments/keys/remove`).
+    pub async fn bulk_unassign_keys_from_guardrail(
+        &self,
+        id: &str,
+        request: &guardrails::BulkKeyAssignmentRequest,
+    ) -> Result<guardrails::UnassignedCountResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::bulk_unassign_keys_from_guardrail(
+                &self.base_url,
+                provisioning_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List member assignments for a guardrail (`GET /guardrails/{id}/assignments/members`).
+    pub async fn list_guardrail_member_assignments(
+        &self,
+        id: &str,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<guardrails::GuardrailMemberAssignmentsResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::list_guardrail_member_assignments(
+                &self.base_url,
+                provisioning_key,
+                id,
+                offset,
+                limit,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Bulk assign members to a guardrail (`POST /guardrails/{id}/assignments/members`).
+    pub async fn bulk_assign_members_to_guardrail(
+        &self,
+        id: &str,
+        request: &guardrails::BulkMemberAssignmentRequest,
+    ) -> Result<guardrails::AssignedCountResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::bulk_assign_members_to_guardrail(
+                &self.base_url,
+                provisioning_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Bulk unassign members from a guardrail (`POST /guardrails/{id}/assignments/members/remove`).
+    pub async fn bulk_unassign_members_from_guardrail(
+        &self,
+        id: &str,
+        request: &guardrails::BulkMemberAssignmentRequest,
+    ) -> Result<guardrails::UnassignedCountResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::bulk_unassign_members_from_guardrail(
+                &self.base_url,
+                provisioning_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List all key assignments (`GET /guardrails/assignments/keys`). Requires a management key.
+    pub async fn list_key_assignments(
+        &self,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<guardrails::GuardrailKeyAssignmentsResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::list_key_assignments(&self.base_url, provisioning_key, offset, limit).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List all member assignments (`GET /guardrails/assignments/members`). Requires a management key.
+    pub async fn list_member_assignments(
+        &self,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Result<guardrails::GuardrailMemberAssignmentsResponse, OpenRouterError> {
+        if let Some(provisioning_key) = &self.provisioning_key {
+            guardrails::list_member_assignments(&self.base_url, provisioning_key, offset, limit)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@
 //! | Credit Management | ✅ | [`api::credits`] |
 //! | Generation Data | ✅ | [`api::generation`] |
 //! | Authentication | ✅ | [`api::auth`] |
+//! | Guardrails | ✅ | [`api::guardrails`] |
 //!
 //! ## 📖 Examples
 //!

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -1,0 +1,340 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::{
+    api::guardrails::{
+        self, AssignedCountResponse, BulkKeyAssignmentRequest, CreateGuardrailRequest, Guardrail,
+        GuardrailKeyAssignmentsResponse, GuardrailListResponse, GuardrailMemberAssignmentsResponse,
+        UnassignedCountResponse, UpdateGuardrailRequest,
+    },
+    types::ApiResponse,
+};
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send captured request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+#[test]
+fn test_create_guardrail_request_serialization() {
+    let request = CreateGuardrailRequest::builder()
+        .name("Production")
+        .description("Production guardrail")
+        .limit_usd(100.0)
+        .reset_interval("monthly")
+        .allowed_providers(vec!["openai".to_string(), "anthropic".to_string()])
+        .allowed_models(vec![
+            "openai/gpt-4.1".to_string(),
+            "anthropic/claude-sonnet-4".to_string(),
+        ])
+        .enforce_zdr(true)
+        .build()
+        .expect("create guardrail request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["name"], "Production");
+    assert_eq!(value["description"], "Production guardrail");
+    assert_eq!(value["limit_usd"], 100.0);
+    assert_eq!(value["reset_interval"], "monthly");
+    assert_eq!(value["allowed_providers"][0], "openai");
+    assert_eq!(value["allowed_models"][1], "anthropic/claude-sonnet-4");
+    assert_eq!(value["enforce_zdr"], true);
+}
+
+#[test]
+fn test_update_guardrail_request_serialization() {
+    let request = UpdateGuardrailRequest::builder()
+        .name("Updated")
+        .enforce_zdr(false)
+        .build()
+        .expect("update guardrail request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["name"], "Updated");
+    assert_eq!(value["enforce_zdr"], false);
+    assert!(value.get("description").is_none());
+    assert!(value.get("allowed_models").is_none());
+}
+
+#[test]
+fn test_guardrail_response_deserialization() {
+    let raw = r#"{
+        "data": {
+            "id": "gr_123",
+            "name": "Production Guardrail",
+            "description": "Guardrail for production traffic",
+            "limit_usd": 100,
+            "reset_interval": "monthly",
+            "allowed_providers": ["openai"],
+            "allowed_models": ["openai/gpt-4.1"],
+            "enforce_zdr": true,
+            "created_at": "2025-01-01T00:00:00.000Z",
+            "updated_at": "2025-01-02T00:00:00.000Z"
+        }
+    }"#;
+
+    let parsed: ApiResponse<Guardrail> =
+        serde_json::from_str(raw).expect("guardrail response should deserialize");
+    assert_eq!(parsed.data.id, "gr_123");
+    assert_eq!(parsed.data.name, "Production Guardrail");
+    assert_eq!(parsed.data.allowed_providers.unwrap_or_default().len(), 1);
+    assert_eq!(parsed.data.enforce_zdr, Some(true));
+}
+
+#[test]
+fn test_guardrail_list_and_assignment_deserialization() {
+    let list_raw = r#"{
+        "data": [{
+            "id": "gr_123",
+            "name": "Production Guardrail",
+            "description": "Guardrail for production traffic",
+            "limit_usd": 100,
+            "reset_interval": "monthly",
+            "allowed_providers": ["openai"],
+            "allowed_models": ["openai/gpt-4.1"],
+            "enforce_zdr": true,
+            "created_at": "2025-01-01T00:00:00.000Z",
+            "updated_at": "2025-01-02T00:00:00.000Z"
+        }],
+        "total_count": 1
+    }"#;
+
+    let key_assignments_raw = r#"{
+        "data": [{
+            "id": "gka_1",
+            "key_hash": "sk-or-v1-abc",
+            "guardrail_id": "gr_123",
+            "key_name": "Production Key",
+            "key_label": "prod",
+            "assigned_by": "user_1",
+            "created_at": "2025-01-01T00:00:00.000Z"
+        }],
+        "total_count": 1
+    }"#;
+
+    let member_assignments_raw = r#"{
+        "data": [{
+            "id": "gma_1",
+            "user_id": "user_2",
+            "organization_id": "org_1",
+            "guardrail_id": "gr_123",
+            "assigned_by": "user_1",
+            "created_at": "2025-01-01T00:00:00.000Z"
+        }],
+        "total_count": 1
+    }"#;
+
+    let list: GuardrailListResponse =
+        serde_json::from_str(list_raw).expect("guardrail list should deserialize");
+    let key_assignments: GuardrailKeyAssignmentsResponse =
+        serde_json::from_str(key_assignments_raw).expect("key assignments should deserialize");
+    let member_assignments: GuardrailMemberAssignmentsResponse =
+        serde_json::from_str(member_assignments_raw)
+            .expect("member assignments should deserialize");
+
+    assert_eq!(list.total_count, 1.0);
+    assert_eq!(key_assignments.total_count, 1.0);
+    assert_eq!(member_assignments.total_count, 1.0);
+    assert_eq!(key_assignments.data[0].assigned_by, "user_1");
+    assert_eq!(member_assignments.data[0].assigned_by, "user_1");
+}
+
+#[test]
+fn test_assignment_counter_response_deserialization() {
+    let assigned_raw = r#"{"assigned_count":2}"#;
+    let unassigned_raw = r#"{"unassigned_count":1}"#;
+
+    let assigned: AssignedCountResponse =
+        serde_json::from_str(assigned_raw).expect("assigned_count should deserialize");
+    let unassigned: UnassignedCountResponse =
+        serde_json::from_str(unassigned_raw).expect("unassigned_count should deserialize");
+
+    assert_eq!(assigned.assigned_count, 2.0);
+    assert_eq!(unassigned.unassigned_count, 1.0);
+}
+
+#[tokio::test]
+async fn test_list_guardrails_with_pagination_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+
+    let result = guardrails::list_guardrails(&base_url, "mgmt-key", Some(10), Some(25))
+        .await
+        .expect("list guardrails should succeed");
+    assert_eq!(result.total_count, 0.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/guardrails?offset=10&limit=25 HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer mgmt-key")
+            || request_lower.contains("authorization:bearer mgmt-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_bulk_assign_keys_encodes_id_and_sends_body() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"assigned_count":2}"#);
+    let request = BulkKeyAssignmentRequest::builder()
+        .key_hashes(vec!["hash_1".to_string(), "hash_2".to_string()])
+        .build()
+        .expect("bulk assignment request should build");
+
+    let response =
+        guardrails::bulk_assign_keys_to_guardrail(&base_url, "mgmt-key", "team/prod 1", &request)
+            .await
+            .expect("bulk assign should succeed");
+    assert_eq!(response.assigned_count, 2.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/guardrails/team%2Fprod%201/assignments/keys HTTP/1.1"
+    );
+    let request_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
+    assert_eq!(request_json["key_hashes"][0], "hash_1");
+    assert_eq!(request_json["key_hashes"][1], "hash_2");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_member_assignments_global_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+
+    let result = guardrails::list_member_assignments(&base_url, "mgmt-key", Some(1), Some(2))
+        .await
+        .expect("list member assignments should succeed");
+    assert_eq!(result.total_count, 0.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/guardrails/assignments/members?offset=1&limit=2 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_delete_guardrail_uses_id_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"deleted":true}"#);
+
+    let deleted = guardrails::delete_guardrail(&base_url, "mgmt-key", "gr/test 1")
+        .await
+        .expect("delete guardrail should succeed");
+    assert!(deleted);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "DELETE /api/v1/guardrails/gr%2Ftest%201 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -10,6 +10,7 @@ pub mod completion;
 pub mod config;
 pub mod discovery;
 pub mod embeddings;
+pub mod guardrails;
 pub mod messages;
 pub mod provider;
 pub mod response_format;


### PR DESCRIPTION
## Summary
- add `api::guardrails` with full endpoint coverage for guardrail CRUD and key/member assignments
- add `OpenRouterClient` wrappers for all guardrails endpoints using `.provisioning_key(...)`
- add unit tests for request/response typing and key request-path behaviors
- update README and changelog for guardrails coverage

## OpenAPI Alignment
Validated against latest official OpenAPI (`https://openrouter.ai/openapi.json`) for:
- endpoint coverage (`/guardrails*`)
- request/response field parity for all guardrails models and assignment payloads
- client wrapper coverage for all guardrails operations

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo check --examples`

Closes #32
