### PR TITLE
feat!: rename provisioning_key API surface to management_key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 OPENROUTER_API_KEY=sk-your-openrouter-api-key
-OPENROUTER_PROVISIONING_KEY=sk-your-openrouter-provisioning-key
+OPENROUTER_MANAGEMENT_KEY=sk-your-openrouter-management-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discovery and activity endpoint support:
   - `api::discovery` module for `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`, `/activity`
   - `OpenRouterClient` wrappers for each endpoint
-  - management-key requirement documented for `GET /activity` (`.provisioning_key(...)`)
+  - management-key requirement documented for `GET /activity` (`.management_key(...)`)
 - OAuth auth-code creation support:
   - add `POST /auth/keys/code` request/response types and client wrapper (`create_auth_code`)
   - add PKCE end-to-end doc snippet (`create_auth_code` -> `exchange_code_for_api_key`)
 - Guardrails endpoint support:
   - `api::guardrails` module for `/guardrails` and all guardrail assignment endpoints
   - `OpenRouterClient` wrappers for create/read/update/delete and key/member assignment flows
-  - management-key requirement documented for guardrail endpoints (`.provisioning_key(...)`)
+  - management-key requirement documented for guardrail endpoints (`.management_key(...)`)
+- Management-key naming alignment:
+  - renamed `OpenRouterClient` builder/config surface from `provisioning_key` to `management_key`
+  - renamed management-key helpers to `set_management_key` / `clear_management_key`
+  - API-key management and governance endpoints consistently require `management_key`
 
 ## [0.5.1] - 2026-02-28
 
@@ -34,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended reasoning effort support to include `xhigh`, `minimal`, and `none`.
 
 ### Fixed
-- Updated examples to read `OPENROUTER_API_KEY` and `OPENROUTER_PROVISIONING_KEY` at runtime (instead of compile-time `.env` macro expansion), preventing CI/build failures.
+- Updated examples to read `OPENROUTER_API_KEY` and `OPENROUTER_MANAGEMENT_KEY` at runtime (instead of compile-time `.env` macro expansion), preventing CI/build failures.
 - Bumped `bytes` from `1.10.1` to `1.11.1` to address `GHSA-434x-w66g-qw3r` (`CVE-2026-25541`).
 
 ## [0.5.0] - 2026-02-25

--- a/README.md
+++ b/README.md
@@ -274,8 +274,9 @@ let key = client
 | Credit Management | ✅ | [`api::credits`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/credits/) |
 | Authentication | ✅ | [`api::auth`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/auth/) |
 
-`/activity` requires a management key; in this SDK set it with `.provisioning_key(...)`.
-`/guardrails*` endpoints also require a management key; in this SDK set it with `.provisioning_key(...)`.
+`/activity` requires a management key; in this SDK set it with `.management_key(...)`.
+`/guardrails*` endpoints also require a management key; in this SDK set it with `.management_key(...)`.
+Management-key examples in this repo use `OPENROUTER_MANAGEMENT_KEY`.
 
 ## 🎯 More Examples
 

--- a/examples/create_api_key.rs
+++ b/examples/create_api_key.rs
@@ -2,10 +2,10 @@ use openrouter_rs::OpenRouterClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let provisioning_key = std::env::var("OPENROUTER_PROVISIONING_KEY")
-        .expect("OPENROUTER_PROVISIONING_KEY must be set");
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
     let client = OpenRouterClient::builder()
-        .provisioning_key(provisioning_key)
+        .management_key(management_key)
         .build()?;
 
     let new_api_key = client.create_api_key("My New API Key", Some(100.0)).await?;

--- a/examples/delete_api_key.rs
+++ b/examples/delete_api_key.rs
@@ -2,10 +2,10 @@ use openrouter_rs::OpenRouterClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let provisioning_key = std::env::var("OPENROUTER_PROVISIONING_KEY")
-        .expect("OPENROUTER_PROVISIONING_KEY must be set");
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
     let client = OpenRouterClient::builder()
-        .provisioning_key(provisioning_key)
+        .management_key(management_key)
         .build()?;
 
     let delete_result = client.delete_api_key("your_exposed_key_hash").await?;

--- a/examples/get_api_key.rs
+++ b/examples/get_api_key.rs
@@ -2,10 +2,10 @@ use openrouter_rs::OpenRouterClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let provisioning_key = std::env::var("OPENROUTER_PROVISIONING_KEY")
-        .expect("OPENROUTER_PROVISIONING_KEY must be set");
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
     let client = OpenRouterClient::builder()
-        .provisioning_key(provisioning_key)
+        .management_key(management_key)
         .build()?;
 
     let specific_api_key = client.get_api_key("your_key_hash").await?;

--- a/examples/list_api_keys.rs
+++ b/examples/list_api_keys.rs
@@ -2,10 +2,10 @@ use openrouter_rs::OpenRouterClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let provisioning_key = std::env::var("OPENROUTER_PROVISIONING_KEY")
-        .expect("OPENROUTER_PROVISIONING_KEY must be set");
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
     let client = OpenRouterClient::builder()
-        .provisioning_key(provisioning_key)
+        .management_key(management_key)
         .build()?;
 
     let api_keys = client.list_api_keys(Some(0.0), Some(true)).await?;

--- a/examples/update_api_key.rs
+++ b/examples/update_api_key.rs
@@ -2,10 +2,10 @@ use openrouter_rs::OpenRouterClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let provisioning_key = std::env::var("OPENROUTER_PROVISIONING_KEY")
-        .expect("OPENROUTER_PROVISIONING_KEY must be set");
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
     let client = OpenRouterClient::builder()
-        .provisioning_key(provisioning_key)
+        .management_key(management_key)
         .build()?;
 
     let updated_api_key = client

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,7 +25,7 @@ pub struct OpenRouterClient {
     #[builder(setter(into, strip_option), default)]
     api_key: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    provisioning_key: Option<String>,
+    management_key: Option<String>,
     #[builder(setter(into, strip_option), default)]
     http_referer: Option<String>,
     #[builder(setter(into, strip_option), default)]
@@ -71,36 +71,36 @@ impl OpenRouterClient {
         self.api_key = None;
     }
 
-    /// Sets the provisioning key after client construction.
+    /// Sets the management key after client construction.
     ///
     /// # Arguments
     ///
-    /// * `provisioning_key` - The provisioning key to set
+    /// * `management_key` - The management key to set
     ///
     /// # Example
     ///
     /// ```
     /// let mut client = OpenRouterClient::builder().build();
-    /// client.set_provisioning_key("your_provisioning_key");
+    /// client.set_management_key("your_management_key");
     /// ```
-    pub fn set_provisioning_key(&mut self, provisioning_key: impl Into<String>) {
-        self.provisioning_key = Some(provisioning_key.into());
+    pub fn set_management_key(&mut self, management_key: impl Into<String>) {
+        self.management_key = Some(management_key.into());
     }
 
-    /// Clears the currently set provisioning key.
+    /// Clears the currently set management key.
     ///
     /// # Example
     ///
     /// ```
     /// let mut client = OpenRouterClient::builder().build();
-    /// client.set_provisioning_key("your_provisioning_key");
-    /// client.clear_provisioning_key();
+    /// client.set_management_key("your_management_key");
+    /// client.clear_management_key();
     /// ```
-    pub fn clear_provisioning_key(&mut self) {
-        self.provisioning_key = None;
+    pub fn clear_management_key(&mut self) {
+        self.management_key = None;
     }
 
-    /// Creates a new API key. Requires a Provisioning API key.
+    /// Creates a new API key. Requires a management API key.
     ///
     /// # Arguments
     ///
@@ -114,7 +114,7 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
     /// let api_key = client.create_api_key("New API Key", Some(100.0)).await?;
     /// println!("{:?}", api_key);
     /// ```
@@ -123,8 +123,8 @@ impl OpenRouterClient {
         name: &str,
         limit: Option<f64>,
     ) -> Result<api_keys::ApiKey, OpenRouterError> {
-        if let Some(api_key) = &self.api_key {
-            api_keys::create_api_key(&self.base_url, api_key, name, limit).await
+        if let Some(management_key) = &self.management_key {
+            api_keys::create_api_key(&self.base_url, management_key, name, limit).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -153,7 +153,7 @@ impl OpenRouterClient {
         }
     }
 
-    /// Deletes an API key. Requires a Provisioning API key.
+    /// Deletes an API key. Requires a management API key.
     ///
     /// # Arguments
     ///
@@ -166,19 +166,19 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let client = OpenRouterClient::builder().provisioning_key("your_provisioning_key").build();
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
     /// let success = client.delete_api_key("api_key_hash").await?;
     /// println!("Deletion successful: {}", success);
     /// ```
     pub async fn delete_api_key(&self, hash: &str) -> Result<bool, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            api_keys::delete_api_key(&self.base_url, provisioning_key, hash).await
+        if let Some(management_key) = &self.management_key {
+            api_keys::delete_api_key(&self.base_url, management_key, hash).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
     }
 
-    /// Updates an existing API key. Requires a Provisioning API key.
+    /// Updates an existing API key. Requires a management API key.
     ///
     /// # Arguments
     ///
@@ -194,7 +194,7 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let client = OpenRouterClient::builder().provisioning_key("your_provisioning_key").build();
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
     /// let updated_api_key = client.update_api_key("api_key_hash", Some("Updated Name".to_string()), Some(false), Some(200.0)).await?;
     /// println!("{:?}", updated_api_key);
     /// ```
@@ -205,22 +205,15 @@ impl OpenRouterClient {
         disabled: Option<bool>,
         limit: Option<f64>,
     ) -> Result<api_keys::ApiKey, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            api_keys::update_api_key(
-                &self.base_url,
-                provisioning_key,
-                hash,
-                name,
-                disabled,
-                limit,
-            )
-            .await
+        if let Some(management_key) = &self.management_key {
+            api_keys::update_api_key(&self.base_url, management_key, hash, name, disabled, limit)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
     }
 
-    /// Returns a list of all API keys associated with the account. Requires a Provisioning API key.
+    /// Returns a list of all API keys associated with the account. Requires a management API key.
     ///
     /// # Arguments
     ///
@@ -234,7 +227,7 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let client = OpenRouterClient::builder().provisioning_key("your_provisioning_key").build();
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
     /// let api_keys = client.list_api_keys(Some(0.0), Some(true)).await?;
     /// println!("{:?}", api_keys);
     /// ```
@@ -243,15 +236,14 @@ impl OpenRouterClient {
         offset: Option<f64>,
         include_disabled: Option<bool>,
     ) -> Result<Vec<api_keys::ApiKey>, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            api_keys::list_api_keys(&self.base_url, provisioning_key, offset, include_disabled)
-                .await
+        if let Some(management_key) = &self.management_key {
+            api_keys::list_api_keys(&self.base_url, management_key, offset, include_disabled).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
     }
 
-    /// Returns details about a specific API key. Requires a Provisioning API key.
+    /// Returns details about a specific API key. Requires a management API key.
     ///
     /// # Arguments
     ///
@@ -264,13 +256,13 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let client = OpenRouterClient::builder().provisioning_key("your_provisioning_key").build();
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
     /// let api_key = client.get_api_key("api_key_hash").await?;
     /// println!("{:?}", api_key);
     /// ```
     pub async fn get_api_key(&self, hash: &str) -> Result<api_keys::ApiKey, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            api_keys::get_api_key(&self.base_url, provisioning_key, hash).await
+        if let Some(management_key) = &self.management_key {
+            api_keys::get_api_key(&self.base_url, management_key, hash).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -330,8 +322,8 @@ impl OpenRouterClient {
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<guardrails::GuardrailListResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::list_guardrails(&self.base_url, provisioning_key, offset, limit).await
+        if let Some(management_key) = &self.management_key {
+            guardrails::list_guardrails(&self.base_url, management_key, offset, limit).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -342,8 +334,8 @@ impl OpenRouterClient {
         &self,
         request: &guardrails::CreateGuardrailRequest,
     ) -> Result<guardrails::Guardrail, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::create_guardrail(&self.base_url, provisioning_key, request).await
+        if let Some(management_key) = &self.management_key {
+            guardrails::create_guardrail(&self.base_url, management_key, request).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -351,8 +343,8 @@ impl OpenRouterClient {
 
     /// Get a guardrail by ID (`GET /guardrails/{id}`). Requires a management key.
     pub async fn get_guardrail(&self, id: &str) -> Result<guardrails::Guardrail, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::get_guardrail(&self.base_url, provisioning_key, id).await
+        if let Some(management_key) = &self.management_key {
+            guardrails::get_guardrail(&self.base_url, management_key, id).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -364,8 +356,8 @@ impl OpenRouterClient {
         id: &str,
         request: &guardrails::UpdateGuardrailRequest,
     ) -> Result<guardrails::Guardrail, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::update_guardrail(&self.base_url, provisioning_key, id, request).await
+        if let Some(management_key) = &self.management_key {
+            guardrails::update_guardrail(&self.base_url, management_key, id, request).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -373,8 +365,8 @@ impl OpenRouterClient {
 
     /// Delete a guardrail (`DELETE /guardrails/{id}`). Requires a management key.
     pub async fn delete_guardrail(&self, id: &str) -> Result<bool, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::delete_guardrail(&self.base_url, provisioning_key, id).await
+        if let Some(management_key) = &self.management_key {
+            guardrails::delete_guardrail(&self.base_url, management_key, id).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -387,10 +379,10 @@ impl OpenRouterClient {
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<guardrails::GuardrailKeyAssignmentsResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
+        if let Some(management_key) = &self.management_key {
             guardrails::list_guardrail_key_assignments(
                 &self.base_url,
-                provisioning_key,
+                management_key,
                 id,
                 offset,
                 limit,
@@ -407,8 +399,8 @@ impl OpenRouterClient {
         id: &str,
         request: &guardrails::BulkKeyAssignmentRequest,
     ) -> Result<guardrails::AssignedCountResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::bulk_assign_keys_to_guardrail(&self.base_url, provisioning_key, id, request)
+        if let Some(management_key) = &self.management_key {
+            guardrails::bulk_assign_keys_to_guardrail(&self.base_url, management_key, id, request)
                 .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
@@ -421,10 +413,10 @@ impl OpenRouterClient {
         id: &str,
         request: &guardrails::BulkKeyAssignmentRequest,
     ) -> Result<guardrails::UnassignedCountResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
+        if let Some(management_key) = &self.management_key {
             guardrails::bulk_unassign_keys_from_guardrail(
                 &self.base_url,
-                provisioning_key,
+                management_key,
                 id,
                 request,
             )
@@ -441,10 +433,10 @@ impl OpenRouterClient {
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<guardrails::GuardrailMemberAssignmentsResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
+        if let Some(management_key) = &self.management_key {
             guardrails::list_guardrail_member_assignments(
                 &self.base_url,
-                provisioning_key,
+                management_key,
                 id,
                 offset,
                 limit,
@@ -461,10 +453,10 @@ impl OpenRouterClient {
         id: &str,
         request: &guardrails::BulkMemberAssignmentRequest,
     ) -> Result<guardrails::AssignedCountResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
+        if let Some(management_key) = &self.management_key {
             guardrails::bulk_assign_members_to_guardrail(
                 &self.base_url,
-                provisioning_key,
+                management_key,
                 id,
                 request,
             )
@@ -480,10 +472,10 @@ impl OpenRouterClient {
         id: &str,
         request: &guardrails::BulkMemberAssignmentRequest,
     ) -> Result<guardrails::UnassignedCountResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
+        if let Some(management_key) = &self.management_key {
             guardrails::bulk_unassign_members_from_guardrail(
                 &self.base_url,
-                provisioning_key,
+                management_key,
                 id,
                 request,
             )
@@ -499,8 +491,8 @@ impl OpenRouterClient {
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<guardrails::GuardrailKeyAssignmentsResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::list_key_assignments(&self.base_url, provisioning_key, offset, limit).await
+        if let Some(management_key) = &self.management_key {
+            guardrails::list_key_assignments(&self.base_url, management_key, offset, limit).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -512,9 +504,8 @@ impl OpenRouterClient {
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<guardrails::GuardrailMemberAssignmentsResponse, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            guardrails::list_member_assignments(&self.base_url, provisioning_key, offset, limit)
-                .await
+        if let Some(management_key) = &self.management_key {
+            guardrails::list_member_assignments(&self.base_url, management_key, offset, limit).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1098,15 +1089,15 @@ impl OpenRouterClient {
     /// Equivalent to `GET /activity`.
     ///
     /// Requires a management API key. In this SDK, configure that via
-    /// `OpenRouterClientBuilder::provisioning_key(...)`.
+    /// `OpenRouterClientBuilder::management_key(...)`.
     ///
     /// `date` is optional and should be `YYYY-MM-DD`.
     pub async fn get_activity(
         &self,
         date: Option<&str>,
     ) -> Result<Vec<discovery::ActivityItem>, OpenRouterError> {
-        if let Some(provisioning_key) = &self.provisioning_key {
-            discovery::get_activity(&self.base_url, provisioning_key, date).await
+        if let Some(management_key) = &self.management_key {
+            discovery::get_activity(&self.base_url, management_key, date).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }

--- a/tests/unit/api_keys.rs
+++ b/tests/unit/api_keys.rs
@@ -6,7 +6,59 @@ use std::{
     time::Duration,
 };
 
-use openrouter_rs::api::api_keys;
+use openrouter_rs::api::api_keys::{self, ApiKeyDetails};
+
+#[test]
+fn test_api_key_details_deserializes_official_provisioning_field() {
+    let raw = r#"{
+        "label":"default",
+        "usage":1.5,
+        "is_free_tier":false,
+        "is_provisioning_key":true,
+        "rate_limit":{"requests":1000,"interval":"1m"},
+        "limit":100.0,
+        "limit_remaining":98.5
+    }"#;
+
+    let parsed: ApiKeyDetails =
+        serde_json::from_str(raw).expect("api key details should deserialize");
+    assert!(parsed.is_management_key);
+}
+
+#[test]
+fn test_api_key_details_deserializes_management_alias_field() {
+    let raw = r#"{
+        "label":"default",
+        "usage":1.5,
+        "is_free_tier":false,
+        "is_management_key":true,
+        "rate_limit":{"requests":1000,"interval":"1m"},
+        "limit":100.0,
+        "limit_remaining":98.5
+    }"#;
+
+    let parsed: ApiKeyDetails =
+        serde_json::from_str(raw).expect("api key details should deserialize from alias");
+    assert!(parsed.is_management_key);
+}
+
+#[test]
+fn test_api_key_details_deserializes_when_both_management_and_legacy_fields_exist() {
+    let raw = r#"{
+        "label":"default",
+        "usage":1.5,
+        "is_free_tier":false,
+        "is_management_key":true,
+        "is_provisioning_key":true,
+        "rate_limit":{"requests":1000,"interval":"1m"},
+        "limit":100.0,
+        "limit_remaining":98.5
+    }"#;
+
+    let parsed: ApiKeyDetails = serde_json::from_str(raw)
+        .expect("api key details should deserialize when both fields exist");
+    assert!(parsed.is_management_key);
+}
 
 #[tokio::test]
 async fn test_delete_api_key_uses_single_api_v1_prefix() {

--- a/tests/unit/client_management_key.rs
+++ b/tests/unit/client_management_key.rs
@@ -1,0 +1,58 @@
+use openrouter_rs::{OpenRouterClient, error::OpenRouterError};
+
+#[tokio::test]
+async fn test_create_api_key_requires_management_key() {
+    let client = OpenRouterClient::builder()
+        .api_key("user-api-key")
+        .build()
+        .expect("client should build");
+
+    let result = client.create_api_key("new-key", Some(10.0)).await;
+    assert!(
+        matches!(result, Err(OpenRouterError::KeyNotConfigured)),
+        "create_api_key should require management_key"
+    );
+}
+
+#[tokio::test]
+async fn test_guardrails_endpoints_require_management_key() {
+    let client = OpenRouterClient::builder()
+        .api_key("user-api-key")
+        .build()
+        .expect("client should build");
+
+    let result = client.list_guardrails(None, None).await;
+    assert!(
+        matches!(result, Err(OpenRouterError::KeyNotConfigured)),
+        "list_guardrails should require management_key"
+    );
+}
+
+#[tokio::test]
+async fn test_activity_endpoint_requires_management_key() {
+    let client = OpenRouterClient::builder()
+        .api_key("user-api-key")
+        .build()
+        .expect("client should build");
+
+    let result = client.get_activity(None).await;
+    assert!(
+        matches!(result, Err(OpenRouterError::KeyNotConfigured)),
+        "get_activity should require management_key"
+    );
+}
+
+#[tokio::test]
+async fn test_clear_management_key_removes_management_access() {
+    let mut client = OpenRouterClient::builder()
+        .management_key("mgmt-key")
+        .build()
+        .expect("client should build");
+    client.clear_management_key();
+
+    let result = client.delete_api_key("hash").await;
+    assert!(
+        matches!(result, Err(OpenRouterError::KeyNotConfigured)),
+        "delete_api_key should fail after clearing management_key"
+    );
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -6,6 +6,7 @@ fn dummy_test() {
 pub mod api_keys;
 pub mod auth;
 pub mod chat_request;
+pub mod client_management_key;
 pub mod completion;
 pub mod config;
 pub mod discovery;


### PR DESCRIPTION
## Summary
- rename the public client builder/config surface from `provisioning_key` to `management_key`
- rename runtime key helpers to `set_management_key` / `clear_management_key`
- require `management_key` consistently for management/governance endpoints, including `create_api_key`
- update docs/examples/env template to use `OPENROUTER_MANAGEMENT_KEY` and `.management_key(...)`
- add tests for management-key-required behavior and API-key-details compatibility mapping

## OpenAPI Alignment Verification
Validated against latest official OpenAPI (`https://openrouter.ai/openapi.json`):
- management/governance endpoints in this SDK now consistently gate on `management_key`:
  - `/keys` CRUD
  - `/guardrails*`
  - `/activity`
- `/key` schema currently includes both `is_management_key` and `is_provisioning_key`; SDK now robustly deserializes either or both without duplicate-field failures.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo check --examples`

Closes #46
