### PR TITLE
feat: introduce domain-oriented client surface (OR-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - renamed `OpenRouterClient` builder/config surface from `provisioning_key` to `management_key`
   - renamed management-key helpers to `set_management_key` / `clear_management_key`
   - API-key management and governance endpoints consistently require `management_key`
+- Domain-oriented client surface:
+  - added domain accessors: `chat()`, `responses()`, `messages()`, `models()`, `management()`
+  - added typed domain clients with endpoint methods grouped by API domain
+  - added domain-oriented examples for chat and management workflows
 
 ## [0.5.1] - 2026-02-28
 

--- a/examples/domain_chat_completion.rs
+++ b/examples/domain_chat_completion.rs
@@ -1,0 +1,23 @@
+use openrouter_rs::{OpenRouterClient, api::chat::*, types::Role};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = ChatCompletionRequest::builder()
+        .model("deepseek/deepseek-chat-v3-0324:free")
+        .messages(vec![Message::new(
+            Role::User,
+            "Reply with one short sentence about Rust.",
+        )])
+        .max_tokens(64)
+        .temperature(0.2)
+        .build()?;
+
+    let response = client.chat().create(&request).await?;
+    println!("{response:?}");
+
+    Ok(())
+}

--- a/examples/domain_management_api_keys.rs
+++ b/examples/domain_management_api_keys.rs
@@ -1,0 +1,19 @@
+use openrouter_rs::OpenRouterClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
+
+    let client = OpenRouterClient::builder()
+        .management_key(management_key)
+        .build()?;
+
+    let keys = client
+        .management()
+        .list_api_keys(Some(0.0), Some(false))
+        .await?;
+    println!("{keys:?}");
+
+    Ok(())
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,7 +40,7 @@
 //! use openrouter_rs::types::ModelCategory;
 //!
 //! // Get all models in the programming category
-//! let models = client.list_models_by_category(ModelCategory::Programming).await?;
+//! let models = client.models().list_by_category(ModelCategory::Programming).await?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -91,7 +91,7 @@
 //!     .messages(vec![Message::new(Role::User, "Hello!")])
 //!     .build()?;
 //!
-//! let response = client.send_chat_completion(&request).await?;
+//! let response = client.chat().create(&request).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -105,7 +105,7 @@
 //!     .api_key("your_key")
 //!     .build()?;
 //!
-//! let models = client.list_models().await?;
+//! let models = client.models().list().await?;
 //! println!("Found {} models", models.len());
 //! # Ok(())
 //! # }
@@ -119,7 +119,7 @@
 //! use openrouter_rs::error::OpenRouterError;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! match client.send_chat_completion(&request).await {
+//! match client.chat().create(&request).await {
 //!     Ok(response) => println!("Success: {:?}", response),
 //!     Err(OpenRouterError::RateLimitExceeded) => {
 //!         println!("Rate limit hit, retrying later...");

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@
 //!     .api_key("invalid_key")
 //!     .build()?;
 //!
-//! match client.list_models().await {
+//! match client.models().list().await {
 //!     Ok(models) => println!("Found {} models", models.len()),
 //!     Err(OpenRouterError::ApiError { code, message }) => {
 //!         eprintln!("API error {}: {}", code, message);
@@ -61,7 +61,7 @@
 //! use surf::StatusCode;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! match client.send_chat_completion(&request).await {
+//! match client.chat().create(&request).await {
 //!     Err(OpenRouterError::ApiError { code: StatusCode::TooManyRequests, .. }) => {
 //!         println!("Rate limited, retrying after delay...");
 //!         tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! - **🔒 Type Safety**: Leverages Rust's type system for compile-time error prevention
 //! - **⚡ Async/Await**: Built on `tokio` for high-performance async operations  
 //! - **🏗️ Builder Pattern**: Ergonomic client and request construction
+//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `models()`, `management()`
 //! - **📡 Streaming Support**: Real-time response streaming with `futures`
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
 //! - **⚙️ Model Presets**: Pre-configured model groups for different use cases
@@ -52,7 +53,7 @@
 //!         .build()?;
 //!
 //!     // Send request and get response
-//!     let response = client.send_chat_completion(&request).await?;
+//!     let response = client.chat().create(&request).await?;
 //!     println!("Response: {}", response.choices[0].content().unwrap_or(""));
 //!
 //!     Ok(())
@@ -75,7 +76,7 @@
 //!     .messages(vec![Message::new(Role::User, "Write a haiku about Rust")])
 //!     .build()?;
 //!
-//! let mut stream = client.stream_chat_completion(&request).await?;
+//! let mut stream = client.chat().stream(&request).await?;
 //!
 //! while let Some(result) = stream.next().await {
 //!     if let Ok(response) = result {
@@ -105,7 +106,7 @@
 //!     .reasoning_max_tokens(1000)      // Limit reasoning tokens
 //!     .build()?;
 //!
-//! let response = client.send_chat_completion(&request).await?;
+//! let response = client.chat().create(&request).await?;
 //!
 //! println!("Reasoning: {}", response.choices[0].reasoning().unwrap_or(""));
 //! println!("Answer: {}", response.choices[0].content().unwrap_or(""));
@@ -140,6 +141,7 @@
 //!
 //! | Feature | Status | Module |
 //! |---------|--------|---------|
+//! | Domain-Oriented Client API | ✅ | [`client::OpenRouterClient`] |
 //! | Chat Completions | ✅ | [`api::chat`] |
 //! | Text Completions | ✅ | [`api::completion`] |
 //! | Model Information | ✅ | [`api::models`] |

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -28,7 +28,7 @@
 //! use openrouter_rs::types::stream::{ToolAwareStream, StreamEvent};
 //!
 //! # async fn example(client: openrouter_rs::OpenRouterClient, request: openrouter_rs::api::chat::ChatCompletionRequest) -> Result<(), Box<dyn std::error::Error>> {
-//! let raw_stream = client.stream_chat_completion(&request).await?;
+//! let raw_stream = client.chat().stream(&request).await?;
 //! let mut stream = ToolAwareStream::new(raw_stream);
 //!
 //! while let Some(event) = stream.next().await {
@@ -160,7 +160,7 @@ impl ToolCallAccumulator {
 /// # async fn example(client: openrouter_rs::OpenRouterClient, request: openrouter_rs::api::chat::ChatCompletionRequest) -> Result<(), Box<dyn std::error::Error>> {
 /// use openrouter_rs::types::stream::ToolAwareStream;
 ///
-/// let raw = client.stream_chat_completion(&request).await?;
+/// let raw = client.chat().stream(&request).await?;
 /// let stream = ToolAwareStream::new(raw);
 /// # Ok(())
 /// # }

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -1,0 +1,76 @@
+use openrouter_rs::{
+    OpenRouterClient,
+    api::{chat, messages, responses},
+    error::OpenRouterError,
+    types::Role,
+};
+
+#[tokio::test]
+async fn test_chat_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let request = chat::ChatCompletionRequest::builder()
+        .model("openai/gpt-4.1")
+        .messages(vec![chat::Message::new(Role::User, "hello")])
+        .build()
+        .expect("chat request should build");
+
+    let result = client.chat().create(&request).await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_responses_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let request = responses::ResponsesRequest::builder()
+        .model("openai/gpt-4.1")
+        .input("hello".into())
+        .build()
+        .expect("responses request should build");
+
+    let result = client.responses().create(&request).await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_messages_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let request = messages::AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(16)
+        .messages(vec![messages::AnthropicMessage::user("hello")])
+        .build()
+        .expect("messages request should build");
+
+    let result = client.messages().create(&request).await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_models_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+
+    let result = client.models().list().await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_management_domain_requires_management_key() {
+    let client = OpenRouterClient::builder()
+        .api_key("user-key")
+        .build()
+        .expect("client should build");
+
+    let result = client
+        .management()
+        .create_api_key("new-key", Some(10.0))
+        .await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -6,6 +6,7 @@ fn dummy_test() {
 pub mod api_keys;
 pub mod auth;
 pub mod chat_request;
+pub mod client_domains;
 pub mod client_management_key;
 pub mod completion;
 pub mod config;


### PR DESCRIPTION
## Summary
- add a new domain-oriented client surface on `OpenRouterClient`:
  - `chat()`
  - `responses()`
  - `messages()`
  - `models()`
  - `management()`
- introduce typed domain clients (`ChatClient`, `ResponsesClient`, `MessagesClient`, `ModelsClient`, `ManagementClient`) that delegate to shared transport logic
- keep existing flat methods as compatibility wrappers but hide them from top-level docs to reduce default surface area
- update docs/examples/changelog to use and explain domain usage
- add unit coverage for domain auth boundary behavior

## OpenAPI alignment check
Compared against current official `https://openrouter.ai/openapi.json` (fetched on 2026-03-01).

Stable paths in official spec are covered by domain clients:
- conversation: `/chat/completions`, `/responses`, `/messages`
- discovery/models: `/models`, `/models/{author}/{slug}/endpoints`, `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`, `/embeddings`, `/embeddings/models`
- management/governance: `/key`, `/keys`, `/keys/{hash}`, `/auth/keys`, `/auth/keys/code`, `/credits`, `/credits/coinbase`, `/generation`, `/activity`, `/guardrails` and assignment endpoints

Note: legacy `/completions` is intentionally not part of the new domain surface and is handled in #48.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo check --examples`

Closes #47
