### PR TITLE
feat: add unified streaming event abstraction (OR-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - introduced shared `types::PaginationOptions` for paginated endpoints
   - updated paginated API signatures (`api_keys`, `guardrails`, client wrappers) to use `PaginationOptions`
 
+### Added
+- Unified streaming abstraction across chat/responses/messages:
+  - new `types::stream::{UnifiedStreamEvent, UnifiedStreamSource, UnifiedStream}`
+  - adapters: `adapt_chat_stream`, `adapt_responses_stream`, `adapt_messages_stream`
+  - new domain methods: `chat().stream_unified(...)`, `responses().stream_unified(...)`, `messages().stream_unified(...)`
+
 ## [0.5.1] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A **type-safe**, **async** Rust SDK for the [OpenRouter API](https://openrouter.
 - **🛠️ Tool Calling**: Function calling with typed tools and automatic JSON schema generation
 - **🖼️ Vision Support**: Multi-modal content for image analysis with vision models
 - **📡 Streaming**: Real-time response streaming with `futures`
+- **🧩 Unified Streaming Events**: One event model across chat/responses/messages streams
 - **🏗️ Builder Pattern**: Ergonomic client and request construction
 - **⚙️ Smart Presets**: Curated model groups for programming, reasoning, and free tiers
 - **🎯 Complete Coverage**: All OpenRouter API endpoints supported
@@ -88,6 +89,28 @@ Available domains:
 - `client.models()`
 - `client.management()`
 - `client.legacy()` (requires `legacy-completions` feature)
+
+### 🧩 Unified Streaming Events
+
+```rust
+use futures_util::StreamExt;
+use openrouter_rs::types::stream::UnifiedStreamEvent;
+
+let mut stream = client.chat().stream_unified(&request).await?;
+
+while let Some(event) = stream.next().await {
+    match event {
+        UnifiedStreamEvent::ContentDelta(text) => print!("{text}"),
+        UnifiedStreamEvent::ReasoningDelta(text) => eprint!("[reasoning]{text}"),
+        UnifiedStreamEvent::Done { .. } => break,
+        UnifiedStreamEvent::Error(err) => {
+            eprintln!("stream error: {err}");
+            break;
+        }
+        _ => {}
+    }
+}
+```
 
 ### 🧱 Legacy Completions (Feature-Gated)
 
@@ -322,6 +345,7 @@ let key = client.management()
 | **Multi-Modal/Vision** | ✅ | [`api::chat`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/chat/) |
 | **Reasoning Tokens** | ✅ | [`api::chat`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/chat/) |
 | Streaming Responses | ✅ | [`api::chat`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/chat/) |
+| Unified Streaming Events | ✅ | [`types::stream`](https://docs.rs/openrouter-rs/latest/openrouter_rs/types/stream/) |
 | **Streaming Tool Calls** | ✅ | [`types::stream`](https://docs.rs/openrouter-rs/latest/openrouter_rs/types/stream/) |
 | Responses API | ✅ | [`api::responses`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/responses/) |
 | Anthropic Messages API | ✅ | [`api::messages`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/messages/) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! - **🏗️ Builder Pattern**: Ergonomic client and request construction
 //! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `models()`, `management()`
 //! - **📡 Streaming Support**: Real-time response streaming with `futures`
+//! - **🧩 Unified Streaming Events**: Shared stream event model across chat/responses/messages
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
 //! - **⚙️ Model Presets**: Pre-configured model groups for different use cases
 //! - **🎯 Full API Coverage**: Complete OpenRouter API endpoint support
@@ -146,6 +147,7 @@
 //! | Legacy Text Completions (`legacy-completions`) | ✅ | `api::legacy::completion` |
 //! | Model Information | ✅ | [`api::models`] |
 //! | Streaming | ✅ | [`api::chat`] |
+//! | Unified Streaming Events | ✅ | [`types::stream`] |
 //! | Reasoning Tokens | ✅ | [`api::chat`] |
 //! | API Key Management | ✅ | [`api::api_keys`] |
 //! | Credit Management | ✅ | [`api::credits`] |

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -48,17 +48,24 @@
 //! # }
 //! ```
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_util::stream::BoxStream;
 use futures_util::{Stream, StreamExt};
+use serde_json::Value;
 
 use crate::error::OpenRouterError;
 use crate::types::completion::{
-    CompletionsResponse, FinishReason, FunctionCall, PartialToolCall, ReasoningDetail,
-    ResponseUsage, ToolCall,
+    CompletionsResponse, FunctionCall, PartialToolCall, ReasoningDetail, ResponseUsage, ToolCall,
+};
+use crate::{
+    api::{
+        messages::{AnthropicContentPart, AnthropicMessagesSseEvent, AnthropicMessagesStreamEvent},
+        responses::ResponsesStreamEvent,
+    },
+    types::completion::FinishReason,
 };
 
 /// Events emitted by [`ToolAwareStream`].
@@ -326,4 +333,428 @@ impl Stream for ToolAwareStream {
             Poll::Pending => Poll::Pending,
         }
     }
+}
+
+/// Source stream family for a [`UnifiedStreamEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnifiedStreamSource {
+    Chat,
+    Responses,
+    Messages,
+}
+
+/// Unified stream event model across chat/responses/messages APIs.
+#[derive(Debug)]
+pub enum UnifiedStreamEvent {
+    /// Text content delta from the model.
+    ContentDelta(String),
+    /// Reasoning/thinking delta.
+    ReasoningDelta(String),
+    /// Structured reasoning detail blocks (chat stream only).
+    ReasoningDetailsDelta(Vec<ReasoningDetail>),
+    /// Tool-related delta payload (format depends on source API).
+    ToolDelta(Value),
+    /// Source-specific event payload when no common projection applies.
+    Raw {
+        source: UnifiedStreamSource,
+        event_type: String,
+        data: Value,
+    },
+    /// Terminal event for a stream source.
+    Done {
+        source: UnifiedStreamSource,
+        id: Option<String>,
+        model: Option<String>,
+        finish_reason: Option<String>,
+        usage: Option<Value>,
+    },
+    /// Transport/parsing/runtime error from the underlying stream.
+    Error(OpenRouterError),
+}
+
+/// A unified stream type across all streaming APIs.
+pub type UnifiedStream = BoxStream<'static, UnifiedStreamEvent>;
+
+#[derive(Debug, Default)]
+struct StreamMeta {
+    id: Option<String>,
+    model: Option<String>,
+    finish_reason: Option<String>,
+    usage: Option<Value>,
+}
+
+fn finish_reason_to_string(reason: &FinishReason) -> &'static str {
+    match reason {
+        FinishReason::ToolCalls => "tool_calls",
+        FinishReason::Stop => "stop",
+        FinishReason::Length => "length",
+        FinishReason::ContentFilter => "content_filter",
+        FinishReason::Error => "error",
+    }
+}
+
+/// Adapt a chat-completions SSE stream to [`UnifiedStreamEvent`].
+pub fn adapt_chat_stream(
+    inner: BoxStream<'static, Result<CompletionsResponse, OpenRouterError>>,
+) -> UnifiedStream {
+    struct State {
+        inner: BoxStream<'static, Result<CompletionsResponse, OpenRouterError>>,
+        pending: VecDeque<UnifiedStreamEvent>,
+        done_emitted: bool,
+        meta: StreamMeta,
+    }
+
+    let state = State {
+        inner,
+        pending: VecDeque::new(),
+        done_emitted: false,
+        meta: StreamMeta::default(),
+    };
+
+    futures_util::stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(event) = state.pending.pop_front() {
+                return Some((event, state));
+            }
+
+            if state.done_emitted {
+                return None;
+            }
+
+            match state.inner.next().await {
+                Some(Ok(response)) => {
+                    state.meta.id = Some(response.id.clone());
+                    state.meta.model = Some(response.model.clone());
+                    if let Some(usage) = response.usage {
+                        state.meta.usage = serde_json::to_value(usage).ok();
+                    }
+
+                    for choice in &response.choices {
+                        if let Some(content) = choice.content() {
+                            if !content.is_empty() {
+                                state.pending.push_back(UnifiedStreamEvent::ContentDelta(
+                                    content.to_string(),
+                                ));
+                            }
+                        }
+
+                        if let Some(reasoning) = choice.reasoning() {
+                            if !reasoning.is_empty() {
+                                state.pending.push_back(UnifiedStreamEvent::ReasoningDelta(
+                                    reasoning.to_string(),
+                                ));
+                            }
+                        }
+
+                        if let Some(reasoning_details) = choice.reasoning_details() {
+                            if !reasoning_details.is_empty() {
+                                state
+                                    .pending
+                                    .push_back(UnifiedStreamEvent::ReasoningDetailsDelta(
+                                        reasoning_details.to_vec(),
+                                    ));
+                            }
+                        }
+
+                        if let Some(partials) = choice.partial_tool_calls() {
+                            for partial in partials {
+                                state.pending.push_back(UnifiedStreamEvent::ToolDelta(
+                                    serde_json::to_value(partial).unwrap_or(Value::Null),
+                                ));
+                            }
+                        }
+
+                        if let Some(reason) = choice.finish_reason() {
+                            state.meta.finish_reason =
+                                Some(finish_reason_to_string(reason).to_string());
+                        }
+                    }
+                }
+                Some(Err(error)) => {
+                    state.pending.push_back(UnifiedStreamEvent::Error(error));
+                }
+                None => {
+                    state.done_emitted = true;
+                    state.pending.push_back(UnifiedStreamEvent::Done {
+                        source: UnifiedStreamSource::Chat,
+                        id: state.meta.id.take(),
+                        model: state.meta.model.take(),
+                        finish_reason: state.meta.finish_reason.take(),
+                        usage: state.meta.usage.take(),
+                    });
+                }
+            }
+        }
+    })
+    .boxed()
+}
+
+/// Adapt a Responses API SSE stream to [`UnifiedStreamEvent`].
+pub fn adapt_responses_stream(
+    inner: BoxStream<'static, Result<ResponsesStreamEvent, OpenRouterError>>,
+) -> UnifiedStream {
+    struct State {
+        inner: BoxStream<'static, Result<ResponsesStreamEvent, OpenRouterError>>,
+        pending: VecDeque<UnifiedStreamEvent>,
+        done_emitted: bool,
+        meta: StreamMeta,
+    }
+
+    let state = State {
+        inner,
+        pending: VecDeque::new(),
+        done_emitted: false,
+        meta: StreamMeta::default(),
+    };
+
+    futures_util::stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(event) = state.pending.pop_front() {
+                return Some((event, state));
+            }
+
+            if state.done_emitted {
+                return None;
+            }
+
+            match state.inner.next().await {
+                Some(Ok(event)) => {
+                    let event_type = event.event_type.clone();
+                    let data_value = serde_json::to_value(&event.data).unwrap_or(Value::Null);
+                    let mut emitted = false;
+
+                    if let Some(response) = event.data.get("response") {
+                        if let Some(id) = response.get("id").and_then(Value::as_str) {
+                            state.meta.id = Some(id.to_string());
+                        }
+                        if let Some(model) = response.get("model").and_then(Value::as_str) {
+                            state.meta.model = Some(model.to_string());
+                        }
+                        if let Some(status) = response.get("status").and_then(Value::as_str) {
+                            state.meta.finish_reason = Some(status.to_string());
+                        }
+                        if let Some(usage) = response.get("usage") {
+                            state.meta.usage = Some(usage.clone());
+                        }
+                    }
+
+                    if event_type.contains("output_text.delta") {
+                        if let Some(delta) = event.data.get("delta").and_then(Value::as_str) {
+                            state
+                                .pending
+                                .push_back(UnifiedStreamEvent::ContentDelta(delta.to_string()));
+                            emitted = true;
+                        }
+                    }
+
+                    if !emitted && event_type.contains("reasoning") {
+                        let reasoning = event
+                            .data
+                            .get("delta")
+                            .and_then(Value::as_str)
+                            .or_else(|| event.data.get("text").and_then(Value::as_str))
+                            .or_else(|| event.data.get("reasoning").and_then(Value::as_str));
+                        if let Some(reasoning) = reasoning {
+                            state.pending.push_back(UnifiedStreamEvent::ReasoningDelta(
+                                reasoning.to_string(),
+                            ));
+                            emitted = true;
+                        }
+                    }
+
+                    if !emitted && event_type.contains("tool") {
+                        state
+                            .pending
+                            .push_back(UnifiedStreamEvent::ToolDelta(data_value.clone()));
+                        emitted = true;
+                    }
+
+                    if event_type == "response.completed" || event_type.ends_with(".completed") {
+                        state.done_emitted = true;
+                        state.pending.push_back(UnifiedStreamEvent::Done {
+                            source: UnifiedStreamSource::Responses,
+                            id: state.meta.id.take(),
+                            model: state.meta.model.take(),
+                            finish_reason: state.meta.finish_reason.take(),
+                            usage: state.meta.usage.take(),
+                        });
+                        continue;
+                    }
+
+                    if !emitted {
+                        state.pending.push_back(UnifiedStreamEvent::Raw {
+                            source: UnifiedStreamSource::Responses,
+                            event_type,
+                            data: data_value,
+                        });
+                    }
+                }
+                Some(Err(error)) => {
+                    state.pending.push_back(UnifiedStreamEvent::Error(error));
+                }
+                None => {
+                    state.done_emitted = true;
+                    state.pending.push_back(UnifiedStreamEvent::Done {
+                        source: UnifiedStreamSource::Responses,
+                        id: state.meta.id.take(),
+                        model: state.meta.model.take(),
+                        finish_reason: state.meta.finish_reason.take(),
+                        usage: state.meta.usage.take(),
+                    });
+                }
+            }
+        }
+    })
+    .boxed()
+}
+
+/// Adapt a Messages API SSE stream to [`UnifiedStreamEvent`].
+pub fn adapt_messages_stream(
+    inner: BoxStream<'static, Result<AnthropicMessagesSseEvent, OpenRouterError>>,
+) -> UnifiedStream {
+    struct State {
+        inner: BoxStream<'static, Result<AnthropicMessagesSseEvent, OpenRouterError>>,
+        pending: VecDeque<UnifiedStreamEvent>,
+        done_emitted: bool,
+        meta: StreamMeta,
+    }
+
+    let state = State {
+        inner,
+        pending: VecDeque::new(),
+        done_emitted: false,
+        meta: StreamMeta::default(),
+    };
+
+    futures_util::stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(event) = state.pending.pop_front() {
+                return Some((event, state));
+            }
+
+            if state.done_emitted {
+                return None;
+            }
+
+            match state.inner.next().await {
+                Some(Ok(event)) => {
+                    let event_name = event.event.clone();
+                    match event.data {
+                        AnthropicMessagesStreamEvent::MessageStart { message } => {
+                            state.meta.id = message.id.clone();
+                            state.meta.model = message.model.clone();
+                            if let Some(usage) = message.usage {
+                                state.meta.usage = serde_json::to_value(usage).ok();
+                            }
+                        }
+                        AnthropicMessagesStreamEvent::MessageDelta { delta, usage } => {
+                            state.meta.usage = Some(usage);
+                            if let Some(reason) = delta.get("stop_reason").and_then(Value::as_str) {
+                                state.meta.finish_reason = Some(reason.to_string());
+                            }
+                            let text = delta
+                                .get("text")
+                                .and_then(Value::as_str)
+                                .or_else(|| delta.get("output_text").and_then(Value::as_str));
+                            if let Some(text) = text {
+                                state
+                                    .pending
+                                    .push_back(UnifiedStreamEvent::ContentDelta(text.to_string()));
+                            }
+                        }
+                        AnthropicMessagesStreamEvent::ContentBlockStart {
+                            content_block, ..
+                        } => match *content_block {
+                            AnthropicContentPart::Thinking { thinking, .. } => {
+                                state
+                                    .pending
+                                    .push_back(UnifiedStreamEvent::ReasoningDelta(thinking));
+                            }
+                            AnthropicContentPart::ToolUse { .. }
+                            | AnthropicContentPart::ServerToolUse { .. } => {
+                                state.pending.push_back(UnifiedStreamEvent::ToolDelta(
+                                    serde_json::to_value(content_block).unwrap_or(Value::Null),
+                                ));
+                            }
+                            _ => {}
+                        },
+                        AnthropicMessagesStreamEvent::ContentBlockDelta { delta, .. } => {
+                            let delta_type = delta
+                                .get("type")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default();
+                            if delta_type.contains("text_delta") {
+                                if let Some(text) = delta.get("text").and_then(Value::as_str) {
+                                    state.pending.push_back(UnifiedStreamEvent::ContentDelta(
+                                        text.to_string(),
+                                    ));
+                                }
+                            } else if delta_type.contains("thinking") {
+                                let reasoning = delta
+                                    .get("thinking")
+                                    .and_then(Value::as_str)
+                                    .or_else(|| delta.get("text").and_then(Value::as_str));
+                                if let Some(reasoning) = reasoning {
+                                    state.pending.push_back(UnifiedStreamEvent::ReasoningDelta(
+                                        reasoning.to_string(),
+                                    ));
+                                }
+                            } else if delta_type.contains("tool")
+                                || delta_type.contains("json")
+                                || delta.get("partial_json").is_some()
+                            {
+                                state
+                                    .pending
+                                    .push_back(UnifiedStreamEvent::ToolDelta(delta));
+                            } else {
+                                state.pending.push_back(UnifiedStreamEvent::Raw {
+                                    source: UnifiedStreamSource::Messages,
+                                    event_type: event_name,
+                                    data: delta,
+                                });
+                            }
+                        }
+                        AnthropicMessagesStreamEvent::MessageStop => {
+                            state.done_emitted = true;
+                            state.pending.push_back(UnifiedStreamEvent::Done {
+                                source: UnifiedStreamSource::Messages,
+                                id: state.meta.id.take(),
+                                model: state.meta.model.take(),
+                                finish_reason: state.meta.finish_reason.take(),
+                                usage: state.meta.usage.take(),
+                            });
+                        }
+                        AnthropicMessagesStreamEvent::Error { error } => {
+                            let message = error
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .map(ToOwned::to_owned)
+                                .unwrap_or_else(|| error.to_string());
+                            state.pending.push_back(UnifiedStreamEvent::Error(
+                                OpenRouterError::Unknown(format!(
+                                    "messages stream error event: {message}"
+                                )),
+                            ));
+                        }
+                        AnthropicMessagesStreamEvent::ContentBlockStop { .. }
+                        | AnthropicMessagesStreamEvent::Ping => {}
+                    }
+                }
+                Some(Err(error)) => {
+                    state.pending.push_back(UnifiedStreamEvent::Error(error));
+                }
+                None => {
+                    state.done_emitted = true;
+                    state.pending.push_back(UnifiedStreamEvent::Done {
+                        source: UnifiedStreamSource::Messages,
+                        id: state.meta.id.take(),
+                        model: state.meta.model.take(),
+                        finish_reason: state.meta.finish_reason.take(),
+                        usage: state.meta.usage.take(),
+                    });
+                }
+            }
+        }
+    })
+    .boxed()
 }

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -18,6 +18,12 @@ async fn test_chat_domain_requires_api_key() {
 
     let result = client.chat().create(&request).await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+
+    let stream_result = client.chat().stream_unified(&request).await;
+    assert!(matches!(
+        stream_result,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 }
 
 #[tokio::test]
@@ -33,6 +39,12 @@ async fn test_responses_domain_requires_api_key() {
 
     let result = client.responses().create(&request).await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+
+    let stream_result = client.responses().stream_unified(&request).await;
+    assert!(matches!(
+        stream_result,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 }
 
 #[tokio::test]
@@ -49,6 +61,12 @@ async fn test_messages_domain_requires_api_key() {
 
     let result = client.messages().create(&request).await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+
+    let stream_result = client.messages().stream_unified(&request).await;
+    assert!(matches!(
+        stream_result,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 }
 
 #[tokio::test]
@@ -68,10 +86,16 @@ async fn test_models_domain_renamed_methods_require_api_key() {
         .expect("client should build");
 
     let user_models = client.models().list_user_models().await;
-    assert!(matches!(user_models, Err(OpenRouterError::KeyNotConfigured)));
+    assert!(matches!(
+        user_models,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 
     let model_count = client.models().get_model_count().await;
-    assert!(matches!(model_count, Err(OpenRouterError::KeyNotConfigured)));
+    assert!(matches!(
+        model_count,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 }
 
 #[tokio::test]

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -21,3 +21,4 @@ pub mod provider;
 pub mod response_format;
 pub mod responses;
 pub mod stream;
+pub mod unified_stream;

--- a/tests/unit/unified_stream.rs
+++ b/tests/unit/unified_stream.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+
+use futures_util::{StreamExt, stream};
+use openrouter_rs::{
+    api::{
+        messages::{
+            AnthropicContentPart, AnthropicMessagesResponse, AnthropicMessagesSseEvent,
+            AnthropicMessagesStreamEvent, AnthropicMessagesUsage,
+        },
+        responses::ResponsesStreamEvent,
+    },
+    error::OpenRouterError,
+    types::{
+        completion::{
+            Choice, CompletionsResponse, Delta, FinishReason, ObjectType, PartialFunctionCall,
+            PartialToolCall, ResponseUsage, StreamingChoice,
+        },
+        stream::{
+            UnifiedStreamEvent, UnifiedStreamSource, adapt_chat_stream, adapt_messages_stream,
+            adapt_responses_stream,
+        },
+    },
+};
+use serde_json::json;
+
+fn chat_chunk(
+    id: &str,
+    model: &str,
+    content: Option<&str>,
+    reasoning: Option<&str>,
+    partial_tool: Option<PartialToolCall>,
+    finish_reason: Option<FinishReason>,
+    usage: Option<ResponseUsage>,
+) -> CompletionsResponse {
+    CompletionsResponse {
+        id: id.to_string(),
+        choices: vec![Choice::Streaming(StreamingChoice {
+            finish_reason,
+            native_finish_reason: None,
+            delta: Delta {
+                content: content.map(ToOwned::to_owned),
+                role: None,
+                tool_calls: partial_tool.map(|p| vec![p]),
+                reasoning: reasoning.map(ToOwned::to_owned),
+                reasoning_details: None,
+                audio: None,
+                refusal: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        })],
+        created: 1_700_000_000,
+        model: model.to_string(),
+        object_type: ObjectType::ChatCompletionChunk,
+        provider: None,
+        system_fingerprint: None,
+        usage,
+    }
+}
+
+fn responses_event(event_type: &str, data: serde_json::Value) -> ResponsesStreamEvent {
+    let mut map = HashMap::new();
+    if let Some(obj) = data.as_object() {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+    ResponsesStreamEvent {
+        event_type: event_type.to_string(),
+        sequence_number: None,
+        data: map,
+    }
+}
+
+#[tokio::test]
+async fn test_unified_chat_stream_mixed_sequence() {
+    let chunks = vec![
+        Ok(chat_chunk(
+            "gen_1",
+            "test-model",
+            Some("Hello "),
+            Some("thinking"),
+            Some(PartialToolCall {
+                id: Some("call_1".to_string()),
+                type_: Some("function".to_string()),
+                function: Some(PartialFunctionCall {
+                    name: Some("get_weather".to_string()),
+                    arguments: Some("{\"location\":\"SF\"}".to_string()),
+                }),
+                index: Some(0),
+            }),
+            None,
+            None,
+        )),
+        Ok(chat_chunk(
+            "gen_1",
+            "test-model",
+            None,
+            None,
+            None,
+            Some(FinishReason::Stop),
+            Some(ResponseUsage {
+                prompt_tokens: 5,
+                completion_tokens: 7,
+                total_tokens: 12,
+            }),
+        )),
+    ];
+
+    let mut stream = adapt_chat_stream(stream::iter(chunks).boxed());
+    let events: Vec<UnifiedStreamEvent> = stream.by_ref().collect().await;
+
+    assert_eq!(events.len(), 4);
+    assert!(matches!(events[0], UnifiedStreamEvent::ContentDelta(_)));
+    assert!(matches!(events[1], UnifiedStreamEvent::ReasoningDelta(_)));
+    assert!(matches!(events[2], UnifiedStreamEvent::ToolDelta(_)));
+    match &events[3] {
+        UnifiedStreamEvent::Done {
+            source,
+            id,
+            model,
+            finish_reason,
+            usage,
+        } => {
+            assert_eq!(*source, UnifiedStreamSource::Chat);
+            assert_eq!(id.as_deref(), Some("gen_1"));
+            assert_eq!(model.as_deref(), Some("test-model"));
+            assert_eq!(finish_reason.as_deref(), Some("stop"));
+            assert!(usage.is_some());
+        }
+        other => panic!("expected Done event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_unified_chat_stream_error_propagation() {
+    let chunks = vec![
+        Ok(chat_chunk(
+            "gen_2",
+            "test-model",
+            Some("hello"),
+            None,
+            None,
+            None,
+            None,
+        )),
+        Err(OpenRouterError::Unknown("stream-failed".to_string())),
+    ];
+
+    let mut stream = adapt_chat_stream(stream::iter(chunks).boxed());
+    let events: Vec<UnifiedStreamEvent> = stream.by_ref().collect().await;
+
+    assert_eq!(events.len(), 3);
+    assert!(matches!(events[0], UnifiedStreamEvent::ContentDelta(_)));
+    assert!(matches!(events[1], UnifiedStreamEvent::Error(_)));
+    assert!(matches!(events[2], UnifiedStreamEvent::Done { .. }));
+}
+
+#[tokio::test]
+async fn test_unified_responses_stream_mixed_sequence() {
+    let events = vec![
+        Ok(responses_event(
+            "response.output_text.delta",
+            json!({ "delta": "Hi" }),
+        )),
+        Ok(responses_event(
+            "response.reasoning.delta",
+            json!({ "delta": "step-by-step" }),
+        )),
+        Ok(responses_event(
+            "response.output_tool_call.delta",
+            json!({ "delta": { "arguments": "{\"city\":\"SF\"}" } }),
+        )),
+        Ok(responses_event(
+            "response.completed",
+            json!({
+                "response": {
+                    "id": "resp_1",
+                    "model": "openai/gpt-5",
+                    "status": "completed",
+                    "usage": { "total_tokens": 10 }
+                }
+            }),
+        )),
+    ];
+
+    let mut stream = adapt_responses_stream(stream::iter(events).boxed());
+    let unified: Vec<UnifiedStreamEvent> = stream.by_ref().collect().await;
+
+    assert_eq!(unified.len(), 4);
+    assert!(matches!(unified[0], UnifiedStreamEvent::ContentDelta(_)));
+    assert!(matches!(unified[1], UnifiedStreamEvent::ReasoningDelta(_)));
+    assert!(matches!(unified[2], UnifiedStreamEvent::ToolDelta(_)));
+    match &unified[3] {
+        UnifiedStreamEvent::Done {
+            source,
+            id,
+            model,
+            finish_reason,
+            usage,
+        } => {
+            assert_eq!(*source, UnifiedStreamSource::Responses);
+            assert_eq!(id.as_deref(), Some("resp_1"));
+            assert_eq!(model.as_deref(), Some("openai/gpt-5"));
+            assert_eq!(finish_reason.as_deref(), Some("completed"));
+            assert_eq!(
+                usage
+                    .as_ref()
+                    .and_then(|u| u.get("total_tokens"))
+                    .and_then(|v| v.as_u64()),
+                Some(10)
+            );
+        }
+        other => panic!("expected Done event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_unified_messages_stream_mixed_sequence() {
+    let events = vec![
+        Ok(AnthropicMessagesSseEvent {
+            event: "message_start".to_string(),
+            data: AnthropicMessagesStreamEvent::MessageStart {
+                message: Box::new(AnthropicMessagesResponse {
+                    id: Some("msg_1".to_string()),
+                    object_type: Some("message".to_string()),
+                    role: Some("assistant".to_string()),
+                    content: Vec::new(),
+                    model: Some("anthropic/claude-sonnet-4".to_string()),
+                    stop_reason: None,
+                    stop_sequence: None,
+                    usage: Some(AnthropicMessagesUsage {
+                        input_tokens: Some(5),
+                        output_tokens: Some(0),
+                        cache_creation_input_tokens: None,
+                        cache_read_input_tokens: None,
+                        service_tier: None,
+                        extra: HashMap::new(),
+                    }),
+                    extra: HashMap::new(),
+                }),
+            },
+        }),
+        Ok(AnthropicMessagesSseEvent {
+            event: "content_block_delta".to_string(),
+            data: AnthropicMessagesStreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: json!({ "type": "text_delta", "text": "Hello" }),
+            },
+        }),
+        Ok(AnthropicMessagesSseEvent {
+            event: "content_block_delta".to_string(),
+            data: AnthropicMessagesStreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: json!({ "type": "thinking_delta", "thinking": "plan" }),
+            },
+        }),
+        Ok(AnthropicMessagesSseEvent {
+            event: "content_block_start".to_string(),
+            data: AnthropicMessagesStreamEvent::ContentBlockStart {
+                index: 1,
+                content_block: Box::new(AnthropicContentPart::ToolUse {
+                    id: "toolu_1".to_string(),
+                    name: "get_weather".to_string(),
+                    input: Some(json!({ "city": "SF" })),
+                    cache_control: None,
+                }),
+            },
+        }),
+        Ok(AnthropicMessagesSseEvent {
+            event: "message_stop".to_string(),
+            data: AnthropicMessagesStreamEvent::MessageStop,
+        }),
+    ];
+
+    let mut stream = adapt_messages_stream(stream::iter(events).boxed());
+    let unified: Vec<UnifiedStreamEvent> = stream.by_ref().collect().await;
+
+    assert_eq!(unified.len(), 4);
+    assert!(matches!(unified[0], UnifiedStreamEvent::ContentDelta(_)));
+    assert!(matches!(unified[1], UnifiedStreamEvent::ReasoningDelta(_)));
+    assert!(matches!(unified[2], UnifiedStreamEvent::ToolDelta(_)));
+    match &unified[3] {
+        UnifiedStreamEvent::Done {
+            source, id, model, ..
+        } => {
+            assert_eq!(*source, UnifiedStreamSource::Messages);
+            assert_eq!(id.as_deref(), Some("msg_1"));
+            assert_eq!(model.as_deref(), Some("anthropic/claude-sonnet-4"));
+        }
+        other => panic!("expected Done event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_unified_messages_stream_error_then_done() {
+    let events = vec![Err(OpenRouterError::Unknown("io boom".to_string()))];
+    let mut stream = adapt_messages_stream(stream::iter(events).boxed());
+    let unified: Vec<UnifiedStreamEvent> = stream.by_ref().collect().await;
+
+    assert_eq!(unified.len(), 2);
+    assert!(matches!(unified[0], UnifiedStreamEvent::Error(_)));
+    assert!(matches!(unified[1], UnifiedStreamEvent::Done { .. }));
+}


### PR DESCRIPTION
## Summary
- add a shared streaming event abstraction across chat/responses/messages
- introduce in `types::stream`:
  - `UnifiedStreamSource`
  - `UnifiedStreamEvent`
  - `UnifiedStream` type alias
  - adapters:
    - `adapt_chat_stream(...)`
    - `adapt_responses_stream(...)`
    - `adapt_messages_stream(...)`
- keep existing endpoint-specific streaming APIs intact
- keep existing tool-aware chat streaming intact (`ToolAwareStream` unchanged)
- add domain methods for unified path:
  - `chat().stream_unified(...)`
  - `responses().stream_unified(...)`
  - `messages().stream_unified(...)`
- add unit coverage for mixed event sequencing and error propagation across all three adapters

## OpenAPI alignment check
Compared against official `https://openrouter.ai/openapi.json` fetched on 2026-03-01:
- `POST /chat/completions`
- `POST /responses`
- `POST /messages`

Unified streaming adapters are implemented exactly for these three streaming-capable endpoint families.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo test --test unit --features legacy-completions`
- `cargo check --examples`
- `cargo check --examples --features legacy-completions`

Closes #50
