### PR TITLE
feat: normalize API error model and metadata (OR-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - new `types::stream::{UnifiedStreamEvent, UnifiedStreamSource, UnifiedStream}`
   - adapters: `adapt_chat_stream`, `adapt_responses_stream`, `adapt_messages_stream`
   - new domain methods: `chat().stream_unified(...)`, `responses().stream_unified(...)`, `messages().stream_unified(...)`
+- Normalized API error model:
+  - new `error::{ApiErrorContext, ApiErrorKind}`
+  - `OpenRouterError::Api(...)` now consistently carries status/api_code/message/request_id
+  - added retryability helpers via `ApiErrorContext::is_retryable()`
 
 ## [0.5.1] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -293,15 +293,22 @@ println!("Available models: {:?}", config.get_resolved_models());
 ### 🛡️ Comprehensive Error Handling
 
 ```rust
-use openrouter_rs::error::OpenRouterError;
+use openrouter_rs::error::{ApiErrorKind, OpenRouterError};
 
 match client.chat().create(&request).await {
     Ok(response) => println!("Success!"),
-    Err(OpenRouterError::ModerationError { reasons, .. }) => {
-        eprintln!("Content flagged: {:?}", reasons);
-    }
-    Err(OpenRouterError::ApiError { code, message }) => {
-        eprintln!("API error {}: {}", code, message);
+    Err(OpenRouterError::Api(api_error)) => match &api_error.kind {
+        ApiErrorKind::Moderation { reasons, .. } => {
+            eprintln!("Content flagged: {:?}", reasons);
+        }
+        _ => {
+            eprintln!(
+                "API error {} (retryable={}): {}",
+                api_error.status,
+                api_error.is_retryable(),
+                api_error.message
+            );
+        }
     }
     Err(e) => eprintln!("Other error: {}", e),
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::{api::errors::ApiErrorResponse, error::OpenRouterError};
+use crate::{api::errors::parse_api_error, error::OpenRouterError};
 use surf::Response;
 
 #[macro_export]
@@ -37,18 +37,20 @@ macro_rules! strip_option_map_setter {
 
 pub async fn handle_error(mut response: Response) -> Result<(), OpenRouterError> {
     let status = response.status();
+    let request_id = response
+        .header("x-request-id")
+        .and_then(|values| values.get(0))
+        .map(|value| value.as_str().to_string())
+        .or_else(|| {
+            response
+                .header("request-id")
+                .and_then(|values| values.get(0))
+                .map(|value| value.as_str().to_string())
+        });
     let text = response
         .body_string()
         .await
         .unwrap_or_else(|_| "Failed to read response text".to_string());
-    let api_error_response: Result<ApiErrorResponse, _> = serde_json::from_str(&text);
 
-    if let Ok(api_error_response) = api_error_response {
-        Err(OpenRouterError::from(api_error_response))
-    } else {
-        Err(OpenRouterError::ApiError {
-            code: status,
-            message: text,
-        })
-    }
+    Err(parse_api_error(status, request_id, &text))
 }

--- a/tests/unit/error_model.rs
+++ b/tests/unit/error_model.rs
@@ -1,0 +1,235 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    thread,
+};
+
+use openrouter_rs::{
+    api::models,
+    error::{ApiErrorKind, OpenRouterError},
+};
+use surf::StatusCode;
+
+fn spawn_error_server(
+    status_line: &str,
+    body: &str,
+    request_id: Option<&str>,
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let status_line = status_line.to_string();
+    let body = body.to_string();
+    let request_id = request_id.map(ToOwned::to_owned);
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let mut headers = format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
+            body.len()
+        );
+        if let Some(request_id) = request_id {
+            headers.push_str(&format!("x-request-id: {request_id}\r\n"));
+        }
+        headers.push_str("\r\n");
+        let response = format!("{headers}{body}");
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), server)
+}
+
+#[tokio::test]
+async fn test_normalized_generic_api_error_shape() {
+    let (base_url, server) = spawn_error_server(
+        "429 Too Many Requests",
+        r#"{"error":{"code":429,"message":"Rate limit exceeded"}}"#,
+        Some("req_123"),
+    );
+
+    let result = models::list_models(&base_url, "test-key", None, None).await;
+    let error = result.expect_err("request should fail");
+    match error {
+        OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::TooManyRequests);
+            assert_eq!(api_error.api_code, Some(429));
+            assert_eq!(api_error.message, "Rate limit exceeded");
+            assert_eq!(api_error.request_id.as_deref(), Some("req_123"));
+            assert!(matches!(api_error.kind, ApiErrorKind::Generic));
+            assert!(api_error.is_retryable());
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+
+    server
+        .join()
+        .expect("server thread should join in reasonable time");
+}
+
+#[tokio::test]
+async fn test_normalized_provider_error_shape() {
+    let (base_url, server) = spawn_error_server(
+        "502 Bad Gateway",
+        r#"{
+            "error": {
+                "code": 502,
+                "message": "Provider overloaded",
+                "metadata": {
+                    "provider_name": "openai",
+                    "raw": {"upstream_code":"E_OVERLOAD"}
+                }
+            }
+        }"#,
+        Some("req_provider"),
+    );
+
+    let result = models::list_models(&base_url, "test-key", None, None).await;
+    let error = result.expect_err("request should fail");
+    match error {
+        OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::BadGateway);
+            assert_eq!(api_error.api_code, Some(502));
+            assert_eq!(api_error.request_id.as_deref(), Some("req_provider"));
+            assert!(api_error.is_retryable());
+            match api_error.kind {
+                ApiErrorKind::Provider { provider_name, raw } => {
+                    assert_eq!(provider_name, "openai");
+                    assert_eq!(
+                        raw.get("upstream_code").and_then(|value| value.as_str()),
+                        Some("E_OVERLOAD")
+                    );
+                }
+                other => panic!("expected provider kind, got {other:?}"),
+            }
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+
+    server
+        .join()
+        .expect("server thread should join in reasonable time");
+}
+
+#[tokio::test]
+async fn test_normalized_moderation_error_shape() {
+    let (base_url, server) = spawn_error_server(
+        "400 Bad Request",
+        r#"{
+            "error": {
+                "code": 400,
+                "message": "Moderation blocked",
+                "metadata": {
+                    "reasons": ["hate"],
+                    "flagged_input": "bad text",
+                    "provider_name": "openai",
+                    "model_slug": "gpt-4.1"
+                }
+            }
+        }"#,
+        Some("req_mod"),
+    );
+
+    let result = models::list_models(&base_url, "test-key", None, None).await;
+    let error = result.expect_err("request should fail");
+    match error {
+        OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::BadRequest);
+            assert_eq!(api_error.api_code, Some(400));
+            assert_eq!(api_error.request_id.as_deref(), Some("req_mod"));
+            assert!(!api_error.is_retryable());
+            match api_error.kind {
+                ApiErrorKind::Moderation {
+                    reasons,
+                    flagged_input,
+                    provider_name,
+                    model_slug,
+                } => {
+                    assert_eq!(reasons, vec!["hate"]);
+                    assert_eq!(flagged_input, "bad text");
+                    assert_eq!(provider_name, "openai");
+                    assert_eq!(model_slug, "gpt-4.1");
+                }
+                other => panic!("expected moderation kind, got {other:?}"),
+            }
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+
+    server
+        .join()
+        .expect("server thread should join in reasonable time");
+}
+
+#[tokio::test]
+async fn test_plain_text_error_is_still_normalized() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let body = "upstream timeout";
+        let response = format!(
+            "HTTP/1.1 504 Gateway Timeout\r\nContent-Type: text/plain\r\nx-request-id: req_plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let result = models::list_models(&base_url, "test-key", None, None).await;
+    let error = result.expect_err("request should fail");
+    match error {
+        OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::GatewayTimeout);
+            assert_eq!(api_error.api_code, Some(504));
+            assert_eq!(api_error.request_id.as_deref(), Some("req_plain"));
+            assert_eq!(api_error.message, "upstream timeout");
+            assert!(matches!(api_error.kind, ApiErrorKind::Generic));
+            assert!(api_error.is_retryable());
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+
+    server
+        .join()
+        .expect("server thread should join in reasonable time");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -14,6 +14,7 @@ pub mod completion;
 pub mod config;
 pub mod discovery;
 pub mod embeddings;
+pub mod error_model;
 pub mod guardrails;
 pub mod messages;
 pub mod pagination;


### PR DESCRIPTION
## Summary
- normalize API error hierarchy into a single predictable shape:
  - new `OpenRouterError::Api(Box<ApiErrorContext>)`
  - new `ApiErrorContext { status, api_code, message, request_id, metadata, kind }`
  - new `ApiErrorKind::{Generic, Moderation, Provider}`
- add retry classification helper:
  - `ApiErrorContext::is_retryable()`
- centralize API error parsing in `api::errors::parse_api_error(...)`
- update `utils::handle_error(...)` to capture `x-request-id`/`request-id` and feed normalized parser
- update docs/snippets to use normalized error handling and retry classification
- add unit tests for representative 4xx/5xx/provider/moderation/plain-text error shapes

## OpenAPI alignment check
Compared against official `https://openrouter.ai/openapi.json` (fetched on 2026-03-01):
- error schema fields include `code`, `message`, `metadata`
- parser now consistently extracts these fields into `ApiErrorContext`
- request identifier is captured from response headers when available (`x-request-id` / `request-id`)

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --test unit`
- `cargo test --test unit --features legacy-completions`
- `cargo check --examples`
- `cargo check --examples --features legacy-completions`

Closes #51
