### PR TITLE
feat: implement OR-21 CLI management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `providers list`
     - `models list` supports `--category` and `--supported-parameter` filters
   - discovery command output now supports both machine-readable JSON and human-readable table text
+  - added OR-21 management commands:
+    - `keys`: `list/create/get/update/delete`
+    - `guardrails`: `list/create/get/update/delete`
+    - `guardrails assignments`: `keys|members` with `list/assign/unassign`
 
 ### Changed
 - Breaking (planned for `0.6.0`) legacy completions isolation:
@@ -66,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Unified messages tool-start events now preserve `content_block_start.index` to keep tool chunks correlatable.
 - Unified responses stream now only terminates on `response.completed` (avoids premature close on non-terminal `*.completed` events).
+- `guardrails update` now supports explicit allowlist clearing via `--clear-allowed-providers` and `--clear-allowed-models`.
 
 ## [0.5.1] - 2026-02-28
 

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -6,6 +6,7 @@
 
 - OR-19: command bootstrap and config/profile resolution
 - OR-20: discovery commands for models/providers/endpoints
+- OR-21: management commands for API keys and guardrails
 
 ## Config And Profile Convention
 
@@ -74,4 +75,30 @@ openrouter-cli --api-key "$OPENROUTER_API_KEY" models endpoints openai/gpt-4.1
 
 # List providers
 openrouter-cli --api-key "$OPENROUTER_API_KEY" providers list
+```
+
+## Management Commands (OR-21)
+
+`openrouter-cli` supports management workflows:
+
+- `keys list|create|get|update|delete`
+- `guardrails list|create|get|update|delete`
+- `guardrails assignments keys list|assign|unassign`
+- `guardrails assignments members list|assign|unassign`
+
+Examples:
+
+```bash
+# List keys
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys list --include-disabled
+
+# Create and update key
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys create --name "ci-bot" --limit 100
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys update sk-or-v1-hash --disable
+
+# Delete key (requires explicit confirmation)
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys delete sk-or-v1-hash --yes
+
+# Update guardrail and clear allowlists
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" guardrails update gr_123 --clear-allowed-providers --clear-allowed-models
 ```

--- a/crates/openrouter-cli/src/cli.rs
+++ b/crates/openrouter-cli/src/cli.rs
@@ -149,6 +149,287 @@ pub enum ProvidersCommands {
     List,
 }
 
+#[derive(Debug, Clone, Args)]
+pub struct KeysListArgs {
+    /// Optional offset for key listing.
+    #[arg(long)]
+    pub offset: Option<u32>,
+
+    /// Include disabled keys.
+    #[arg(long)]
+    pub include_disabled: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeysCreateArgs {
+    /// Display name for the key.
+    #[arg(long)]
+    pub name: String,
+
+    /// Optional spending limit in USD.
+    #[arg(long)]
+    pub limit: Option<f64>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeysGetArgs {
+    /// Key hash.
+    pub hash: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeysUpdateArgs {
+    /// Key hash.
+    pub hash: String,
+
+    /// Optional new display name.
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Optional new spending limit in USD.
+    #[arg(long)]
+    pub limit: Option<f64>,
+
+    /// Disable this key.
+    #[arg(long, conflicts_with = "enable")]
+    pub disable: bool,
+
+    /// Enable this key.
+    #[arg(long, conflicts_with = "disable")]
+    pub enable: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeysDeleteArgs {
+    /// Key hash.
+    pub hash: String,
+
+    /// Confirm destructive action.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum KeysCommands {
+    /// List API keys.
+    List(KeysListArgs),
+    /// Create an API key.
+    Create(KeysCreateArgs),
+    /// Get a single API key.
+    Get(KeysGetArgs),
+    /// Update an API key.
+    Update(KeysUpdateArgs),
+    /// Delete an API key.
+    Delete(KeysDeleteArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct PaginationArgs {
+    /// Offset for pagination.
+    #[arg(long)]
+    pub offset: Option<u32>,
+
+    /// Limit for pagination.
+    #[arg(long)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GuardrailsGetArgs {
+    /// Guardrail ID.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GuardrailsDeleteArgs {
+    /// Guardrail ID.
+    pub id: String,
+
+    /// Confirm destructive action.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GuardrailsCreateArgs {
+    /// Guardrail name.
+    #[arg(long)]
+    pub name: String,
+
+    /// Optional guardrail description.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Optional spending cap in USD.
+    #[arg(long)]
+    pub limit_usd: Option<f64>,
+
+    /// Optional reset interval (for example: daily, monthly).
+    #[arg(long)]
+    pub reset_interval: Option<String>,
+
+    /// Allowed provider IDs.
+    #[arg(long = "allowed-provider")]
+    pub allowed_providers: Vec<String>,
+
+    /// Allowed model IDs.
+    #[arg(long = "allowed-model")]
+    pub allowed_models: Vec<String>,
+
+    /// Enforce ZDR.
+    #[arg(long)]
+    pub enforce_zdr: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GuardrailsUpdateArgs {
+    /// Guardrail ID.
+    pub id: String,
+
+    /// Optional new name.
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Optional new description.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Optional new spending cap in USD.
+    #[arg(long)]
+    pub limit_usd: Option<f64>,
+
+    /// Optional new reset interval.
+    #[arg(long)]
+    pub reset_interval: Option<String>,
+
+    /// Replace allowed provider IDs.
+    #[arg(long = "allowed-provider", conflicts_with = "clear_allowed_providers")]
+    pub allowed_providers: Vec<String>,
+
+    /// Replace allowed model IDs.
+    #[arg(long = "allowed-model", conflicts_with = "clear_allowed_models")]
+    pub allowed_models: Vec<String>,
+
+    /// Clear all allowed providers (send empty list).
+    #[arg(long)]
+    pub clear_allowed_providers: bool,
+
+    /// Clear all allowed models (send empty list).
+    #[arg(long)]
+    pub clear_allowed_models: bool,
+
+    /// Set `enforce_zdr=true`.
+    #[arg(long, conflicts_with = "no_enforce_zdr")]
+    pub enforce_zdr: bool,
+
+    /// Set `enforce_zdr=false`.
+    #[arg(long = "no-enforce-zdr", conflicts_with = "enforce_zdr")]
+    pub no_enforce_zdr: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AssignmentListArgs {
+    /// Optional guardrail ID. If omitted, lists global assignments.
+    #[arg(long)]
+    pub guardrail_id: Option<String>,
+
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeyAssignmentApplyArgs {
+    /// Guardrail ID.
+    pub guardrail_id: String,
+
+    /// One or more key hashes.
+    #[arg(value_name = "KEY_HASH", required = true, num_args = 1..)]
+    pub key_hashes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeyAssignmentUnassignArgs {
+    #[command(flatten)]
+    pub request: KeyAssignmentApplyArgs,
+
+    /// Confirm destructive action.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GuardrailKeyAssignmentCommands {
+    /// List key assignments.
+    List(AssignmentListArgs),
+    /// Assign keys to a guardrail.
+    Assign(KeyAssignmentApplyArgs),
+    /// Unassign keys from a guardrail.
+    Unassign(KeyAssignmentUnassignArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct MemberAssignmentApplyArgs {
+    /// Guardrail ID.
+    pub guardrail_id: String,
+
+    /// One or more member user IDs.
+    #[arg(value_name = "MEMBER_USER_ID", required = true, num_args = 1..)]
+    pub member_user_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct MemberAssignmentUnassignArgs {
+    #[command(flatten)]
+    pub request: MemberAssignmentApplyArgs,
+
+    /// Confirm destructive action.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GuardrailMemberAssignmentCommands {
+    /// List member assignments.
+    List(AssignmentListArgs),
+    /// Assign members to a guardrail.
+    Assign(MemberAssignmentApplyArgs),
+    /// Unassign members from a guardrail.
+    Unassign(MemberAssignmentUnassignArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GuardrailAssignmentCommands {
+    /// Key assignment operations.
+    Keys {
+        #[command(subcommand)]
+        command: GuardrailKeyAssignmentCommands,
+    },
+    /// Member assignment operations.
+    Members {
+        #[command(subcommand)]
+        command: GuardrailMemberAssignmentCommands,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GuardrailsCommands {
+    /// List guardrails.
+    List(PaginationArgs),
+    /// Create a guardrail.
+    Create(GuardrailsCreateArgs),
+    /// Get a guardrail.
+    Get(GuardrailsGetArgs),
+    /// Update a guardrail.
+    Update(GuardrailsUpdateArgs),
+    /// Delete a guardrail.
+    Delete(GuardrailsDeleteArgs),
+    /// Manage guardrail assignments.
+    Assignments {
+        #[command(subcommand)]
+        command: GuardrailAssignmentCommands,
+    },
+}
+
 #[derive(Debug, Clone, Subcommand)]
 pub enum Commands {
     /// Profile-related commands.
@@ -171,10 +452,16 @@ pub enum Commands {
         #[command(subcommand)]
         command: ProvidersCommands,
     },
-    /// Management command group placeholder (planned in OR-21).
-    Keys,
-    /// Guardrail command group placeholder (planned in OR-21).
-    Guardrails,
+    /// API key management commands.
+    Keys {
+        #[command(subcommand)]
+        command: KeysCommands,
+    },
+    /// Guardrail management commands.
+    Guardrails {
+        #[command(subcommand)]
+        command: GuardrailsCommands,
+    },
     /// Usage/billing command group placeholder (planned in OR-22).
     Usage,
 }

--- a/crates/openrouter-cli/tests/management_commands.rs
+++ b/crates/openrouter-cli/tests/management_commands.rs
@@ -1,0 +1,341 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::str::contains;
+use serde_json::Value;
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should include header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+
+        tx.send(CapturedRequest {
+            request_line,
+            request_text: format!("{header_text}{body_text}"),
+            body_text,
+        })
+        .expect("captured request should send");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+fn base_cmd(base_url: &str) -> assert_cmd::Command {
+    let mut cmd = cargo_bin_cmd!("openrouter-cli");
+    cmd.arg("--management-key")
+        .arg("mgmt-test-key")
+        .arg("--base-url")
+        .arg(base_url)
+        .arg("--output")
+        .arg("json")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("OPENROUTER_MANAGEMENT_KEY")
+        .env_remove("OPENROUTER_BASE_URL")
+        .env_remove("OPENROUTER_PROFILE")
+        .env_remove("OPENROUTER_CLI_CONFIG");
+    cmd
+}
+
+#[test]
+fn test_keys_list_happy_path() {
+    let (base_url, rx, server) =
+        spawn_json_server(r#"{"data":[{"name":"ops","hash":"key_hash_1","disabled":false}]}"#);
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("keys")
+        .arg("list")
+        .arg("--offset")
+        .arg("7")
+        .arg("--include-disabled");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert!(parsed.is_array(), "keys list should print array output");
+    assert_eq!(
+        parsed
+            .get(0)
+            .and_then(|entry| entry.get("hash"))
+            .and_then(Value::as_str),
+        Some("key_hash_1")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/keys?offset=7&include_disabled=true HTTP/1.1"
+    );
+    let lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        lower.contains("authorization: bearer mgmt-test-key")
+            || lower.contains("authorization:bearer mgmt-test-key"),
+        "request should include management authorization header: {}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_guardrails_create_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"gr_1","name":"Prod","created_at":"2026-03-01T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("guardrails")
+        .arg("create")
+        .arg("--name")
+        .arg("Prod")
+        .arg("--description")
+        .arg("Production guardrail")
+        .arg("--limit-usd")
+        .arg("100")
+        .arg("--reset-interval")
+        .arg("monthly")
+        .arg("--allowed-provider")
+        .arg("openai")
+        .arg("--allowed-model")
+        .arg("openai/gpt-4.1")
+        .arg("--enforce-zdr");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(parsed.get("id").and_then(Value::as_str), Some("gr_1"));
+    assert_eq!(parsed.get("name").and_then(Value::as_str), Some("Prod"));
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(captured.request_line, "POST /api/v1/guardrails HTTP/1.1");
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(body.get("name").and_then(Value::as_str), Some("Prod"));
+    assert_eq!(
+        body.get("description").and_then(Value::as_str),
+        Some("Production guardrail")
+    );
+    assert_eq!(body.get("limit_usd").and_then(Value::as_f64), Some(100.0));
+    assert_eq!(
+        body.get("allowed_providers")
+            .and_then(Value::as_array)
+            .and_then(|values| values.first())
+            .and_then(Value::as_str),
+        Some("openai")
+    );
+    assert_eq!(
+        body.get("allowed_models")
+            .and_then(Value::as_array)
+            .and_then(|values| values.first())
+            .and_then(Value::as_str),
+        Some("openai/gpt-4.1")
+    );
+    assert_eq!(body.get("enforce_zdr").and_then(Value::as_bool), Some(true));
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_guardrail_key_assignment_assign_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"assigned_count":2}"#);
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("guardrails")
+        .arg("assignments")
+        .arg("keys")
+        .arg("assign")
+        .arg("team/prod 1")
+        .arg("key_hash_a")
+        .arg("key_hash_b");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed.get("assigned_count").and_then(Value::as_f64),
+        Some(2.0)
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/guardrails/team%2Fprod%201/assignments/keys HTTP/1.1"
+    );
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(
+        body.get("key_hashes")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(2)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_guardrail_member_assignment_list_global_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"gma_1","user_id":"user_1","organization_id":"org_1","guardrail_id":"gr_1","assigned_by":"user_admin","created_at":"2026-03-01T00:00:00Z"}],"total_count":1}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("guardrails")
+        .arg("assignments")
+        .arg("members")
+        .arg("list")
+        .arg("--offset")
+        .arg("3")
+        .arg("--limit")
+        .arg("5");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(parsed.get("total_count").and_then(Value::as_f64), Some(1.0));
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/guardrails/assignments/members?offset=3&limit=5 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_guardrails_update_can_clear_allowlists() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"gr_1","name":"Prod","created_at":"2026-03-01T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("guardrails")
+        .arg("update")
+        .arg("gr_1")
+        .arg("--clear-allowed-providers")
+        .arg("--clear-allowed-models");
+    cmd.assert().success();
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "PATCH /api/v1/guardrails/gr_1 HTTP/1.1"
+    );
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(
+        body.get("allowed_providers")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(0)
+    );
+    assert_eq!(
+        body.get("allowed_models")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(0)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_keys_delete_requires_yes() {
+    let mut cmd = base_cmd("http://127.0.0.1:9/api/v1");
+    cmd.arg("keys").arg("delete").arg("key_hash_1");
+    cmd.assert().failure().stderr(contains("without --yes"));
+}
+
+#[test]
+fn test_guardrail_key_assignment_unassign_requires_yes() {
+    let mut cmd = base_cmd("http://127.0.0.1:9/api/v1");
+    cmd.arg("guardrails")
+        .arg("assignments")
+        .arg("keys")
+        .arg("unassign")
+        .arg("gr_1")
+        .arg("key_hash_1");
+    cmd.assert().failure().stderr(contains("without --yes"));
+}


### PR DESCRIPTION
## Summary
- implement openrouter-cli management command surface for keys/guardrails
- add guardrail assignment commands for keys and members (list/assign/unassign)
- enforce explicit --yes confirmation for destructive actions (delete/unassign)
- wire commands to SDK client.management() endpoints
- add CLI integration tests with local mock HTTP server to validate command->API mapping and confirmation behavior
- update CLI README and changelog for OR-21 scope

## Command Surface
- keys list/create/get/update/delete
- guardrails list/create/get/update/delete
- guardrails assignments keys list/assign/unassign
- guardrails assignments members list/assign/unassign

## Validation
- cargo fmt --all
- cargo test -p openrouter-cli
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test unit

Closes #54