### PR TITLE
feat: implement OR-20 CLI discovery commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - added command bootstrap with `--help`, `profile show`, and `config show/path`
   - added deterministic config/auth resolution order: flags > env > profile config > defaults
   - added profile/config path conventions and CLI-specific tests
+  - added OR-20 discovery commands:
+    - `models list|show|endpoints`
+    - `providers list`
+    - `models list` supports `--category` and `--supported-parameter` filters
+  - discovery command output now supports both machine-readable JSON and human-readable table text
 
 ### Changed
 - Breaking (planned for `0.6.0`) legacy completions isolation:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,10 +1416,12 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "openrouter-rs",
  "predicates",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "toml",
 ]
 

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -10,8 +10,10 @@ repository = "https://github.com/realmorrisliu/openrouter-rs"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
+openrouter-rs = { path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1", features = ["full"] }
 toml = "0.8.20"
 
 [dev-dependencies]

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -2,11 +2,10 @@
 
 `openrouter-cli` is a workspace CLI companion for `openrouter-rs`.
 
-## Current Scope (OR-19)
+## Current Scope
 
-- Command bootstrap and help surface
-- Profile/config resolution
-- Deterministic auth resolution priority
+- OR-19: command bootstrap and config/profile resolution
+- OR-20: discovery commands for models/providers/endpoints
 
 ## Config And Profile Convention
 
@@ -46,3 +45,33 @@ For profile selection:
 2. `OPENROUTER_PROFILE`
 3. `default_profile` in config
 4. `"default"`
+
+## Discovery Commands (OR-20)
+
+`openrouter-cli` now supports discovery workflows:
+
+- `models list` with optional filters:
+  - `--category`
+  - `--supported-parameter`
+- `models show <model_id>`
+- `models endpoints <model_id>`
+- `providers list`
+
+Examples:
+
+```bash
+# List models in a category
+openrouter-cli --api-key "$OPENROUTER_API_KEY" models list --category programming
+
+# List models supporting tool-calling parameter
+openrouter-cli --api-key "$OPENROUTER_API_KEY" models list --supported-parameter tools
+
+# Show one model
+openrouter-cli --api-key "$OPENROUTER_API_KEY" models show openai/gpt-4.1
+
+# Show endpoints for one model
+openrouter-cli --api-key "$OPENROUTER_API_KEY" models endpoints openai/gpt-4.1
+
+# List providers
+openrouter-cli --api-key "$OPENROUTER_API_KEY" providers list
+```

--- a/crates/openrouter-cli/src/cli.rs
+++ b/crates/openrouter-cli/src/cli.rs
@@ -49,6 +49,106 @@ pub enum ConfigCommands {
     Path,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub enum ModelCategoryArg {
+    Roleplay,
+    Programming,
+    Marketing,
+    #[value(name = "marketing/seo", alias = "marketing-seo")]
+    MarketingSeo,
+    Technology,
+    Science,
+    Translation,
+    Legal,
+    Finance,
+    Health,
+    Trivia,
+    Academia,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub enum SupportedParameterArg {
+    #[value(name = "tools")]
+    Tools,
+    #[value(name = "temperature")]
+    Temperature,
+    #[value(name = "top_p")]
+    TopP,
+    #[value(name = "top_k")]
+    TopK,
+    #[value(name = "min_p")]
+    MinP,
+    #[value(name = "top_a")]
+    TopA,
+    #[value(name = "frequency_penalty")]
+    FrequencyPenalty,
+    #[value(name = "presence_penalty")]
+    PresencePenalty,
+    #[value(name = "repetition_penalty")]
+    RepetitionPenalty,
+    #[value(name = "max_tokens")]
+    MaxTokens,
+    #[value(name = "logit_bias")]
+    LogitBias,
+    #[value(name = "logprobs")]
+    Logprobs,
+    #[value(name = "top_logprobs")]
+    TopLogprobs,
+    #[value(name = "seed")]
+    Seed,
+    #[value(name = "response_format")]
+    ResponseFormat,
+    #[value(name = "structured_outputs")]
+    StructuredOutputs,
+    #[value(name = "stop")]
+    Stop,
+    #[value(name = "include_reasoning")]
+    IncludeReasoning,
+    #[value(name = "reasoning")]
+    Reasoning,
+    #[value(name = "web_search_options")]
+    WebSearchOptions,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ModelsListArgs {
+    /// Filter models by category.
+    #[arg(long, value_enum, conflicts_with = "supported_parameter")]
+    pub category: Option<ModelCategoryArg>,
+
+    /// Filter models by supported parameter.
+    #[arg(long, value_enum, conflicts_with = "category")]
+    pub supported_parameter: Option<SupportedParameterArg>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ModelsShowArgs {
+    /// Model ID (for example: openai/gpt-4.1).
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ModelsEndpointsArgs {
+    /// Model ID (for example: openai/gpt-4.1).
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ModelsCommands {
+    /// List models.
+    List(ModelsListArgs),
+    /// Show a single model by model ID.
+    Show(ModelsShowArgs),
+    /// List endpoints for a specific model.
+    Endpoints(ModelsEndpointsArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ProvidersCommands {
+    /// List providers.
+    List,
+}
+
 #[derive(Debug, Clone, Subcommand)]
 pub enum Commands {
     /// Profile-related commands.
@@ -61,8 +161,16 @@ pub enum Commands {
         #[command(subcommand)]
         command: ConfigCommands,
     },
-    /// Discovery command group placeholder (planned in OR-20).
-    Models,
+    /// Model discovery commands.
+    Models {
+        #[command(subcommand)]
+        command: ModelsCommands,
+    },
+    /// Provider discovery commands.
+    Providers {
+        #[command(subcommand)]
+        command: ProvidersCommands,
+    },
     /// Management command group placeholder (planned in OR-21).
     Keys,
     /// Guardrail command group placeholder (planned in OR-21).

--- a/crates/openrouter-cli/src/main.rs
+++ b/crates/openrouter-cli/src/main.rs
@@ -1,12 +1,20 @@
 mod cli;
 mod config;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use clap::Parser;
+use openrouter_rs::{
+    OpenRouterClient,
+    api::{discovery, models},
+    types::{ModelCategory, SupportedParameters},
+};
 use serde::Serialize;
 
 use crate::{
-    cli::{Cli, Commands, ConfigCommands, OutputFormat, ProfileCommands},
+    cli::{
+        Cli, Commands, ConfigCommands, ModelCategoryArg, ModelsCommands, OutputFormat,
+        ProfileCommands, ProvidersCommands, SupportedParameterArg,
+    },
     config::{Environment, ResolvedProfile, resolve_profile},
 };
 
@@ -66,7 +74,225 @@ fn print_snapshot(snapshot: &ConfigSnapshot<'_>, output: OutputFormat) -> Result
     Ok(())
 }
 
-fn run() -> Result<()> {
+fn print_json<T: Serialize + ?Sized>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn print_table(headers: &[&str], rows: &[Vec<String>]) {
+    if rows.is_empty() {
+        println!("(empty)");
+        return;
+    }
+
+    let mut widths: Vec<usize> = headers.iter().map(|header| header.len()).collect();
+    for row in rows {
+        for (index, value) in row.iter().enumerate() {
+            widths[index] = widths[index].max(value.len());
+        }
+    }
+
+    let header_line = headers
+        .iter()
+        .enumerate()
+        .map(|(index, value)| format!("{value:<width$}", width = widths[index]))
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("{header_line}");
+    println!(
+        "{}",
+        widths
+            .iter()
+            .map(|width| "-".repeat(*width))
+            .collect::<Vec<_>>()
+            .join("  ")
+    );
+
+    for row in rows {
+        let line = row
+            .iter()
+            .enumerate()
+            .map(|(index, value)| format!("{value:<width$}", width = widths[index]))
+            .collect::<Vec<_>>()
+            .join("  ");
+        println!("{line}");
+    }
+}
+
+fn model_category(value: ModelCategoryArg) -> ModelCategory {
+    match value {
+        ModelCategoryArg::Roleplay => ModelCategory::Roleplay,
+        ModelCategoryArg::Programming => ModelCategory::Programming,
+        ModelCategoryArg::Marketing => ModelCategory::Marketing,
+        ModelCategoryArg::MarketingSeo => ModelCategory::MarketingSeo,
+        ModelCategoryArg::Technology => ModelCategory::Technology,
+        ModelCategoryArg::Science => ModelCategory::Science,
+        ModelCategoryArg::Translation => ModelCategory::Translation,
+        ModelCategoryArg::Legal => ModelCategory::Legal,
+        ModelCategoryArg::Finance => ModelCategory::Finance,
+        ModelCategoryArg::Health => ModelCategory::Health,
+        ModelCategoryArg::Trivia => ModelCategory::Trivia,
+        ModelCategoryArg::Academia => ModelCategory::Academia,
+    }
+}
+
+fn supported_parameter(value: SupportedParameterArg) -> SupportedParameters {
+    match value {
+        SupportedParameterArg::Tools => SupportedParameters::Tools,
+        SupportedParameterArg::Temperature => SupportedParameters::Temperature,
+        SupportedParameterArg::TopP => SupportedParameters::TopP,
+        SupportedParameterArg::TopK => SupportedParameters::TopK,
+        SupportedParameterArg::MinP => SupportedParameters::MinP,
+        SupportedParameterArg::TopA => SupportedParameters::TopA,
+        SupportedParameterArg::FrequencyPenalty => SupportedParameters::FrequencyPenalty,
+        SupportedParameterArg::PresencePenalty => SupportedParameters::PresencePenalty,
+        SupportedParameterArg::RepetitionPenalty => SupportedParameters::RepetitionPenalty,
+        SupportedParameterArg::MaxTokens => SupportedParameters::MaxTokens,
+        SupportedParameterArg::LogitBias => SupportedParameters::LogitBias,
+        SupportedParameterArg::Logprobs => SupportedParameters::Logprobs,
+        SupportedParameterArg::TopLogprobs => SupportedParameters::TopLogprobs,
+        SupportedParameterArg::Seed => SupportedParameters::Seed,
+        SupportedParameterArg::ResponseFormat => SupportedParameters::ResponseFormat,
+        SupportedParameterArg::StructuredOutputs => SupportedParameters::StructuredOutputs,
+        SupportedParameterArg::Stop => SupportedParameters::Stop,
+        SupportedParameterArg::IncludeReasoning => SupportedParameters::IncludeReasoning,
+        SupportedParameterArg::Reasoning => SupportedParameters::Reasoning,
+        SupportedParameterArg::WebSearchOptions => SupportedParameters::WebSearchOptions,
+    }
+}
+
+fn parse_model_id(model_id: &str) -> Result<(&str, &str)> {
+    let (author, slug) = model_id
+        .split_once('/')
+        .ok_or_else(|| anyhow!("model id must be in '<author>/<slug>' format"))?;
+    Ok((author, slug))
+}
+
+fn build_api_client(resolved: &ResolvedProfile) -> Result<OpenRouterClient> {
+    let Some(api_key) = resolved.api_key.as_deref() else {
+        bail!("api key is required; set --api-key, OPENROUTER_API_KEY, or profile.api_key");
+    };
+
+    let mut builder = OpenRouterClient::builder();
+    builder.base_url(resolved.base_url.clone());
+    builder.api_key(api_key);
+    if let Some(management_key) = resolved.management_key.as_deref() {
+        builder.management_key(management_key);
+    }
+    Ok(builder.build()?)
+}
+
+fn print_models(models: &[models::Model], output: OutputFormat) -> Result<()> {
+    match output {
+        OutputFormat::Json => print_json(models)?,
+        OutputFormat::Text => {
+            let rows = models
+                .iter()
+                .map(|model| {
+                    vec![
+                        model.id.clone(),
+                        model.name.clone(),
+                        model.context_length.to_string(),
+                        model.pricing.prompt.clone(),
+                        model.pricing.completion.clone(),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            print_table(
+                &[
+                    "id",
+                    "name",
+                    "context_length",
+                    "prompt_price",
+                    "completion_price",
+                ],
+                &rows,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn print_model(model: &models::Model, output: OutputFormat) -> Result<()> {
+    match output {
+        OutputFormat::Json => print_json(model)?,
+        OutputFormat::Text => {
+            println!("id: {}", model.id);
+            println!("name: {}", model.name);
+            println!("created: {}", model.created);
+            println!("context_length: {}", model.context_length);
+            println!("description: {}", model.description);
+            println!("modality: {}", model.architecture.modality);
+            println!("tokenizer: {}", model.architecture.tokenizer);
+            println!("prompt_price: {}", model.pricing.prompt);
+            println!("completion_price: {}", model.pricing.completion);
+        }
+    }
+    Ok(())
+}
+
+fn print_endpoints(response: &models::EndpointData, output: OutputFormat) -> Result<()> {
+    match output {
+        OutputFormat::Json => print_json(response)?,
+        OutputFormat::Text => {
+            let rows = response
+                .endpoints
+                .iter()
+                .map(|endpoint| {
+                    vec![
+                        endpoint.name.clone(),
+                        endpoint.provider_name.clone(),
+                        endpoint.context_length.to_string(),
+                        endpoint.pricing.prompt.clone(),
+                        endpoint.pricing.completion.clone(),
+                        endpoint
+                            .status
+                            .as_ref()
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| "-".to_string()),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            print_table(
+                &[
+                    "name",
+                    "provider",
+                    "context_length",
+                    "prompt_price",
+                    "completion_price",
+                    "status",
+                ],
+                &rows,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn print_providers(providers: &[discovery::Provider], output: OutputFormat) -> Result<()> {
+    match output {
+        OutputFormat::Json => print_json(providers)?,
+        OutputFormat::Text => {
+            let rows = providers
+                .iter()
+                .map(|provider| {
+                    vec![
+                        provider.name.clone(),
+                        provider.slug.clone(),
+                        provider
+                            .status_page_url
+                            .clone()
+                            .unwrap_or_else(|| "-".to_string()),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            print_table(&["name", "slug", "status_page_url"], &rows);
+        }
+    }
+    Ok(())
+}
+
+async fn run() -> Result<()> {
     let cli = Cli::parse();
     let env = Environment::from_process();
     let resolved = resolve_profile(&cli.global, &env)?;
@@ -97,8 +323,48 @@ fn run() -> Result<()> {
                 }
             },
         },
-        Commands::Models => {
-            println!("models command group is not implemented yet (planned in OR-20)");
+        Commands::Models { command } => {
+            let client = build_api_client(&resolved)?;
+            let models_client = client.models();
+            match command {
+                ModelsCommands::List(args) => {
+                    let response = if let Some(category) = args.category {
+                        models_client
+                            .list_by_category(model_category(category))
+                            .await?
+                    } else if let Some(parameter) = args.supported_parameter {
+                        models_client
+                            .list_by_parameters(supported_parameter(parameter))
+                            .await?
+                    } else {
+                        models_client.list().await?
+                    };
+                    print_models(&response, cli.global.output)?;
+                }
+                ModelsCommands::Show(args) => {
+                    let models = models_client.list().await?;
+                    let model = models
+                        .iter()
+                        .find(|model| model.id == args.model_id)
+                        .ok_or_else(|| anyhow!("model not found: {}", args.model_id))?;
+                    print_model(model, cli.global.output)?;
+                }
+                ModelsCommands::Endpoints(args) => {
+                    let (author, slug) = parse_model_id(&args.model_id)?;
+                    let response = models_client.list_endpoints(author, slug).await?;
+                    print_endpoints(&response, cli.global.output)?;
+                }
+            }
+        }
+        Commands::Providers { command } => {
+            let client = build_api_client(&resolved)?;
+            let models_client = client.models();
+            match command {
+                ProvidersCommands::List => {
+                    let providers = models_client.list_providers().await?;
+                    print_providers(&providers, cli.global.output)?;
+                }
+            }
         }
         Commands::Keys => {
             println!("keys command group is not implemented yet (planned in OR-21)");
@@ -114,8 +380,9 @@ fn run() -> Result<()> {
     Ok(())
 }
 
-fn main() {
-    if let Err(error) = run() {
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
         eprintln!("error: {error:#}");
         std::process::exit(1);
     }

--- a/crates/openrouter-cli/tests/discovery_commands.rs
+++ b/crates/openrouter-cli/tests/discovery_commands.rs
@@ -1,0 +1,341 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::str::contains;
+use serde_json::{Value, json};
+
+struct CapturedRequest {
+    request_line: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_line = String::from_utf8_lossy(&request_bytes)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        tx.send(CapturedRequest { request_line })
+            .expect("captured request should send");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+fn base_cmd(base_url: &str, output: &str) -> assert_cmd::Command {
+    let mut cmd = cargo_bin_cmd!("openrouter-cli");
+    cmd.arg("--api-key")
+        .arg("api-test-key")
+        .arg("--base-url")
+        .arg(base_url)
+        .arg("--output")
+        .arg(output)
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("OPENROUTER_MANAGEMENT_KEY")
+        .env_remove("OPENROUTER_BASE_URL")
+        .env_remove("OPENROUTER_PROFILE")
+        .env_remove("OPENROUTER_CLI_CONFIG");
+    cmd
+}
+
+fn sample_models_response() -> &'static str {
+    r#"{
+      "data": [
+        {
+          "id": "openai/gpt-4.1",
+          "name": "GPT-4.1",
+          "created": 1710000000,
+          "description": "Test model",
+          "context_length": 128000,
+          "architecture": {
+            "modality": "text->text",
+            "tokenizer": "GPT",
+            "instruct_type": "chatml"
+          },
+          "top_provider": {
+            "context_length": 128000,
+            "max_completion_tokens": 16384,
+            "is_moderated": true
+          },
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000008",
+            "image": null,
+            "request": null,
+            "input_cache_read": null,
+            "input_cache_write": null,
+            "web_search": null,
+            "internal_reasoning": null
+          },
+          "per_request_limits": null
+        }
+      ]
+    }"#
+}
+
+#[test]
+fn test_models_list_json_snapshot() {
+    let (base_url, rx, server) = spawn_json_server(sample_models_response());
+
+    let mut cmd = base_cmd(&base_url, "json");
+    cmd.arg("models")
+        .arg("list")
+        .arg("--category")
+        .arg("programming");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    let expected = json!([{
+        "id": "openai/gpt-4.1",
+        "name": "GPT-4.1",
+        "created": 1710000000.0,
+        "description": "Test model",
+        "context_length": 128000.0,
+        "architecture": {
+            "modality": "text->text",
+            "tokenizer": "GPT",
+            "instruct_type": "chatml"
+        },
+        "top_provider": {
+            "context_length": 128000.0,
+            "max_completion_tokens": 16384.0,
+            "is_moderated": true
+        },
+        "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000008",
+            "image": null,
+            "request": null,
+            "input_cache_read": null,
+            "input_cache_write": null,
+            "web_search": null,
+            "internal_reasoning": null
+        },
+        "per_request_limits": null
+    }]);
+    assert_eq!(parsed, expected);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/models?category=programming HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_models_list_supported_parameter_filter_path() {
+    let (base_url, rx, server) = spawn_json_server(sample_models_response());
+
+    let mut cmd = base_cmd(&base_url, "json");
+    cmd.arg("models")
+        .arg("list")
+        .arg("--supported-parameter")
+        .arg("tools");
+    cmd.assert().success();
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/models?supported_parameters=tools HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_models_show_json_snapshot() {
+    let (base_url, rx, server) = spawn_json_server(sample_models_response());
+
+    let mut cmd = base_cmd(&base_url, "json");
+    cmd.arg("models").arg("show").arg("openai/gpt-4.1");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(
+        parsed.get("id").and_then(Value::as_str),
+        Some("openai/gpt-4.1")
+    );
+    assert_eq!(parsed.get("name").and_then(Value::as_str), Some("GPT-4.1"));
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(captured.request_line, "GET /api/v1/models HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_models_endpoints_json_snapshot() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{
+          "data": {
+            "id": "openai/gpt-4.1",
+            "name": "GPT-4.1",
+            "created": 1710000000,
+            "description": "Test model",
+            "architecture": {
+              "tokenizer": "GPT",
+              "instruct_type": "chatml",
+              "modality": "text->text"
+            },
+            "endpoints": [
+              {
+                "name": "OpenAI: GPT-4.1",
+                "context_length": 128000,
+                "pricing": {
+                  "request": "0",
+                  "image": "0",
+                  "prompt": "0.000002",
+                  "completion": "0.000008"
+                },
+                "provider_name": "OpenAI",
+                "supported_parameters": ["tools", "temperature"],
+                "quantization": null,
+                "max_completion_tokens": 16384,
+                "max_prompt_tokens": 128000,
+                "status": {"state":"up"}
+              }
+            ]
+          }
+        }"#,
+    );
+
+    let mut cmd = base_cmd(&base_url, "json");
+    cmd.arg("models").arg("endpoints").arg("openai/gpt-4.1");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(
+        parsed
+            .get("endpoints")
+            .and_then(Value::as_array)
+            .and_then(|values| values.first())
+            .and_then(|item| item.get("provider_name"))
+            .and_then(Value::as_str),
+        Some("OpenAI")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/models/openai/gpt-4.1/endpoints HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_providers_list_json_snapshot() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{
+          "data": [
+            {
+              "name": "OpenAI",
+              "slug": "openai",
+              "privacy_policy_url": "https://openai.com/privacy",
+              "terms_of_service_url": "https://openai.com/terms",
+              "status_page_url": "https://status.openai.com"
+            }
+          ]
+        }"#,
+    );
+
+    let mut cmd = base_cmd(&base_url, "json");
+    cmd.arg("providers").arg("list");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed.get(0).and_then(|item| item.get("slug")),
+        Some(&json!("openai"))
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(captured.request_line, "GET /api/v1/providers HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_models_list_text_table_output() {
+    let (base_url, _rx, server) = spawn_json_server(sample_models_response());
+
+    let mut cmd = base_cmd(&base_url, "text");
+    cmd.arg("models").arg("list");
+    cmd.assert()
+        .success()
+        .stdout(contains("id"))
+        .stdout(contains("prompt_price"))
+        .stdout(contains("openai/gpt-4.1"));
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_models_show_missing_model_exits_nonzero() {
+    let (base_url, _rx, server) = spawn_json_server(r#"{"data":[]}"#);
+
+    let mut cmd = base_cmd(&base_url, "json");
+    cmd.arg("models").arg("show").arg("missing/model");
+    cmd.assert()
+        .failure()
+        .code(1)
+        .stderr(contains("model not found"));
+
+    server.join().expect("server thread should finish");
+}

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -148,7 +148,6 @@ pub async fn list_model_endpoints(
     let encoded_author = encode(author);
     let encoded_slug = encode(slug);
     let url = format!("{base_url}/models/{encoded_author}/{encoded_slug}/endpoints");
-    println!("URL: {url}");
 
     let mut response = surf::get(&url)
         .header(AUTHORIZATION, format!("Bearer {api_key}"))


### PR DESCRIPTION
## Summary
- add discovery command surface to openrouter-cli:
  - models list/show/endpoints
  - providers list
- support models list filters: --category and --supported-parameter (mutually exclusive)
- add output contracts for discovery commands:
  - JSON mode: machine-readable serialized payloads
  - text mode: human-readable table output
- add script-friendly nonzero behavior test for missing model in models show
- add integration tests for command->endpoint mapping and JSON output snapshots
- remove debug URL print from models endpoints SDK call to keep CLI output clean

## Official API Alignment
Validated CLI command routing against OpenRouter docs paths/params:
- GET /models with category and supported_parameters query filters
- GET /models/{author}/{slug}/endpoints
- GET /providers

## Validation
- cargo fmt --all
- cargo test -p openrouter-cli
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test unit

Closes #53