### PR TITLE
chore: prepare 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-03-01
+
 ### Added
 - Anthropic-compatible `/messages` API support:
   - `api::messages` module with typed request/response models
@@ -69,6 +71,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - added `scripts/check_migration_docs.sh` to validate migration mapping sections/snippets in docs
   - CI now runs a dedicated `Migration Smoke Checks` job (`docs check + cargo test --test migration_smoke --all-features`)
   - documented migration validation commands in README for contributors
+- Unified streaming abstraction across chat/responses/messages:
+  - new `types::stream::{UnifiedStreamEvent, UnifiedStreamSource, UnifiedStream}`
+  - adapters: `adapt_chat_stream`, `adapt_responses_stream`, `adapt_messages_stream`
+  - new domain methods: `chat().stream_unified(...)`, `responses().stream_unified(...)`, `messages().stream_unified(...)`
+- Normalized API error model:
+  - new `error::{ApiErrorContext, ApiErrorKind}`
+  - `OpenRouterError::Api(...)` now consistently carries status/api_code/message/request_id
+  - added retryability helpers via `ApiErrorContext::is_retryable()`
+- CI now runs `cargo test -p openrouter-cli` for CLI startup/config coverage
 
 ### Changed
 - Breaking (planned for `0.6.0`) legacy completions isolation:
@@ -82,22 +93,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI output modes standardized on `table|json` (`table` default, `text` alias retained)
 - JSON CLI outputs now use versioned envelopes (`schema_version: "0.1"`) with structured JSON error payloads
 - deprecation warnings now point to concrete replacement APIs and planned removal in `0.6.0`
-
-### Added
-- Unified streaming abstraction across chat/responses/messages:
-  - new `types::stream::{UnifiedStreamEvent, UnifiedStreamSource, UnifiedStream}`
-  - adapters: `adapt_chat_stream`, `adapt_responses_stream`, `adapt_messages_stream`
-  - new domain methods: `chat().stream_unified(...)`, `responses().stream_unified(...)`, `messages().stream_unified(...)`
-- Normalized API error model:
-  - new `error::{ApiErrorContext, ApiErrorKind}`
-  - `OpenRouterError::Api(...)` now consistently carries status/api_code/message/request_id
-  - added retryability helpers via `ApiErrorContext::is_retryable()`
-- CI now runs `cargo test -p openrouter-cli` for CLI startup/config coverage
+- integration tests now load `.env` automatically and allow model overrides via:
+  - `OPENROUTER_TEST_CHAT_MODEL`
+  - `OPENROUTER_TEST_REASONING_MODEL`
 
 ### Fixed
 - Unified messages tool-start events now preserve `content_block_start.index` to keep tool chunks correlatable.
 - Unified responses stream now only terminates on `response.completed` (avoids premature close on non-terminal `*.completed` events).
 - `guardrails update` now supports explicit allowlist clearing via `--clear-allowed-providers` and `--clear-allowed-models`.
+- integration API-key metadata assertions now accept sentinel rate-limit values from live API responses.
+- live chat/reasoning integration assertions no longer assume prompt echoing in model outputs.
 
 ## [0.5.1] - 2026-02-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-openrouter-rs = "0.5.1"
+openrouter-rs = "0.5.2"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -118,7 +118,7 @@ Legacy `POST /completions` support is isolated behind `legacy-completions` and e
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.5.1", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.5.2", features = ["legacy-completions"] }
 ```
 
 ```rust
@@ -570,7 +570,15 @@ This is a **third-party SDK** not officially affiliated with OpenRouter. Use at 
 
 ## 📈 Release History
 
-### Version 0.5.1 *(Latest)*
+### Version 0.5.2 *(Latest)*
+
+- 🧭 **Added**: Domain-oriented SDK surface and major OpenRouter coverage expansion (`messages`, discovery/activity, guardrails, auth code flow)
+- 🛠️ **Added**: `openrouter-cli v0.1` foundation with discovery, management, and usage/billing command groups
+- 🔁 **Added**: 0.5.x deprecation bridge + published `0.5.x -> 0.6.0` migration guide and migration smoke harness
+- 🌊 **Added**: Unified streaming abstraction across chat/responses/messages and normalized API error model
+- ✅ **Improved**: Live integration suite stability (standard `.env` loading, configurable test models, resilient assertions)
+
+### Version 0.5.1
 
 - 🧩 **New**: Multipart text `cache_control` helpers (`text_with_cache_control`, `cacheable_text`, `cacheable_text_with_ttl`)
 - 🧠 **Improved**: Reasoning effort now supports `xhigh`, `minimal`, and `none`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.5.1"
+//! openrouter-rs = "0.5.2"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- bump crate version to `0.5.2` in `Cargo.toml` and lockfile
- update pinned SDK version snippets to `0.5.2` in `README.md` and `src/lib.rs`
- cut `CHANGELOG.md` release section: `## [0.5.2] - 2026-03-01`
- keep `## [Unreleased]` at top for next cycle
- update README Release History with `### Version 0.5.2 *(Latest)*`

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test unit
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.5.2
- cargo test -p openrouter-cli
- cargo test --test migration_smoke --all-features
