### PR TITLE
chore: disable PR-triggered live integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,6 @@
 name: Integration Tests
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       tier:


### PR DESCRIPTION
## Summary
- remove `pull_request` trigger from `Integration Tests` workflow
- keep `workflow_dispatch` and weekly `schedule` triggers unchanged

## Why
Live integration tests hit paid OpenRouter endpoints; running on every PR materially increases cost.
This change keeps routine cost bounded while preserving:
- manual execution for on-demand validation
- scheduled weekly hot-tier coverage

## Validation
- workflow YAML updated in `.github/workflows/integration.yml`
