### PR TITLE
test: add live Responses API integration coverage (OR-27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,9 @@ let key = client.management()
 | Credit Management | ✅ | [`api::credits`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/credits/) |
 | Authentication | ✅ | [`api::auth`](https://docs.rs/openrouter-rs/latest/openrouter_rs/api/auth/) |
 
+Detailed endpoint-level implementation and test status matrix:
+- [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md)
+
 `/activity` requires a management key; in this SDK set it with `.management_key(...)`.
 `/guardrails*` endpoints also require a management key; in this SDK set it with `.management_key(...)`.
 Management-key examples in this repo use `OPENROUTER_MANAGEMENT_KEY`.

--- a/docs/official-endpoint-test-matrix.md
+++ b/docs/official-endpoint-test-matrix.md
@@ -1,0 +1,84 @@
+# Official Endpoint Test Matrix
+
+Snapshot date: 2026-03-02  
+Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)
+
+## Coverage Summary
+
+- Official OpenAPI endpoints: `36` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `36 / 36` (`100%`).
+- Live integration coverage (`tests/integration`): `4 / 36` endpoints currently exercised.
+  - Covered live now: `POST /chat/completions`, `POST /responses`, `GET /models`, `GET /key`
+
+Legend:
+
+- `SDK`: endpoint implemented in `openrouter-rs`.
+- `Unit`: unit coverage depth.
+  - `Path` = test asserts HTTP method/path (often with header/body checks).
+  - `Contract` = serde/request-shape/parser coverage only.
+  - `None` = no direct unit coverage found.
+- `Live`: real OpenRouter API integration coverage.
+- `Priority`: recommended order for adding/improving live coverage.
+
+## Endpoint Matrix
+
+| Official endpoint | SDK surface | SDK | Unit | Live | Priority |
+| --- | --- | --- | --- | --- | --- |
+| `GET /activity` | `client.management().get_activity(...)` | Yes | Path | No | P1 |
+| `POST /auth/keys` | `client.management().create_api_key_from_auth_code(...)` | Yes | Path | No | P2 |
+| `POST /auth/keys/code` | `client.management().create_auth_code(...)` | Yes | Path | No | P2 |
+| `POST /chat/completions` | `client.chat().create(...)` / `client.chat().stream(...)` | Yes | Contract | Yes | Keep |
+| `GET /credits` | `client.get_credits()` / `client.management().get_credits()` | Yes | None | No | P2 |
+| `POST /credits/coinbase` | `client.create_coinbase_charge(...)` / `client.management().create_coinbase_charge(...)` | Yes | None | No | P2 |
+| `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | No | P1 |
+| `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | None | No | P1 |
+| `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | No | P1 |
+| `GET /generation` | `client.get_generation(...)` / `client.management().get_generation(...)` | Yes | None | No | P2 |
+| `GET /guardrails` | `client.management().list_guardrails(...)` | Yes | Path | No | P1 |
+| `POST /guardrails` | `client.management().create_guardrail(...)` | Yes | Contract | No | P1 |
+| `GET /guardrails/{id}` | `client.management().get_guardrail(...)` | Yes | Contract | No | P1 |
+| `PATCH /guardrails/{id}` | `client.management().update_guardrail(...)` | Yes | Contract | No | P1 |
+| `DELETE /guardrails/{id}` | `client.management().delete_guardrail(...)` | Yes | Path | No | P1 |
+| `GET /guardrails/{id}/assignments/keys` | `client.management().list_guardrail_key_assignments(...)` | Yes | Contract | No | P1 |
+| `POST /guardrails/{id}/assignments/keys` | `client.management().create_guardrail_key_assignments(...)` | Yes | Path | No | P1 |
+| `POST /guardrails/{id}/assignments/keys/remove` | `client.management().delete_guardrail_key_assignments(...)` | Yes | None | No | P1 |
+| `GET /guardrails/{id}/assignments/members` | `client.management().list_guardrail_member_assignments(...)` | Yes | Contract | No | P1 |
+| `POST /guardrails/{id}/assignments/members` | `client.management().create_guardrail_member_assignments(...)` | Yes | None | No | P1 |
+| `POST /guardrails/{id}/assignments/members/remove` | `client.management().delete_guardrail_member_assignments(...)` | Yes | None | No | P1 |
+| `GET /guardrails/assignments/keys` | `client.management().list_key_assignments(...)` | Yes | None | No | P1 |
+| `GET /guardrails/assignments/members` | `client.management().list_member_assignments(...)` | Yes | Path | No | P1 |
+| `GET /key` | `client.get_current_api_key_info()` / `client.management().get_current_api_key_info()` | Yes | Contract | Yes | Keep |
+| `GET /keys` | `client.list_api_keys(...)` / `client.management().list_api_keys(...)` | Yes | Path | No | P1 |
+| `POST /keys` | `client.create_api_key(...)` / `client.management().create_api_key(...)` | Yes | None | No | P1 |
+| `GET /keys/{hash}` | `client.get_api_key(...)` / `client.management().get_api_key(...)` | Yes | None | No | P1 |
+| `PATCH /keys/{hash}` | `client.update_api_key(...)` / `client.management().update_api_key(...)` | Yes | None | No | P1 |
+| `DELETE /keys/{hash}` | `client.delete_api_key(...)` / `client.management().delete_api_key(...)` | Yes | Path | No | P1 |
+| `GET /models` | `client.list_models()` / `client.models().list()` | Yes | Contract | Yes | Keep |
+| `GET /models/{author}/{slug}/endpoints` | `client.list_model_endpoints(...)` / `client.models().list_endpoints(...)` | Yes | None | No | P1 |
+| `GET /models/count` | `client.count_models()` / `client.models().get_model_count()` | Yes | Contract | No | P1 |
+| `GET /models/user` | `client.list_models_for_user()` / `client.models().list_user_models()` | Yes | Path | No | P1 |
+| `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | No | P1 |
+| `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | No | P0 |
+| `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
+
+## Supplemental (Legacy)
+
+The endpoint below is intentionally kept as legacy compatibility and is not part of current OpenAPI:
+
+| Endpoint | SDK surface | Notes |
+| --- | --- | --- |
+| `POST /completions` | `client.legacy().completions().create(...)` (feature `legacy-completions`) | Migration-only surface toward `chat`/`responses` |
+
+## Incremental Test Plan
+
+1. P0: add live integration tests for `/messages` (non-stream + stream).
+2. P1: add live integration tests for `/embeddings`, `/embeddings/models`, `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`.
+3. P1: add management-key live suite for guardrails and keys in a dedicated workflow gate (manual + weekly, no PR auto-trigger).
+4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
+
+## Reproduce Snapshot
+
+```bash
+curl -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.json
+jq -r '.paths | to_entries[] | .key as $p | (.value | keys[] | select(. != "parameters")) as $m | "\($m|ascii_upcase) \($p)"' /tmp/openrouter-openapi.json | sort
+```

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,6 +15,7 @@ The integration suite loads model selection in this order:
 - `OPENROUTER_INTEGRATION_TIER`: `stable` (default) or `hot`.
 - `OPENROUTER_TEST_MODEL_POOL_FILE`: path to a model-pool JSON file.
 - `OPENROUTER_TEST_CHAT_MODEL`: force the primary chat model.
+- `OPENROUTER_TEST_RESPONSES_MODEL`: force the primary Responses API model.
 - `OPENROUTER_TEST_REASONING_MODEL`: force the primary reasoning model.
 - `OPENROUTER_TEST_STABLE_MODELS`: comma-separated stable regression model list.
 - `OPENROUTER_TEST_HOT_MODELS`: comma-separated hot-model sweep list.

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -7,5 +7,6 @@ pub mod api_keys;
 pub mod chat;
 pub mod model_pool;
 pub mod models;
+pub mod responses;
 pub mod test_utils;
 pub mod tools;

--- a/tests/integration/responses.rs
+++ b/tests/integration/responses.rs
@@ -1,0 +1,149 @@
+use std::{env, time::Duration};
+
+use futures_util::StreamExt;
+use openrouter_rs::{
+    error::OpenRouterError,
+    types::stream::{UnifiedStreamEvent, UnifiedStreamSource},
+};
+use serde_json::json;
+
+use super::test_utils::{create_test_client, rate_limit_delay};
+
+const DEFAULT_RESPONSES_MODEL: &str = "openai/gpt-4o-mini";
+
+fn test_responses_model() -> String {
+    env::var("OPENROUTER_TEST_RESPONSES_MODEL")
+        .ok()
+        .map(|model| model.trim().to_string())
+        .filter(|model| !model.is_empty())
+        .unwrap_or_else(|| DEFAULT_RESPONSES_MODEL.to_string())
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_create_response_non_streaming() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    rate_limit_delay().await;
+
+    let model = test_responses_model();
+    let request = openrouter_rs::api::responses::ResponsesRequest::builder()
+        .model(model.clone())
+        .input(json!([{
+            "role": "user",
+            "content": "Reply with a short sentence that includes the word Rust."
+        }]))
+        .max_output_tokens(80)
+        .temperature(0.0)
+        .build()?;
+
+    let response = client.responses().create(&request).await?;
+
+    assert!(
+        response
+            .id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty()),
+        "response.id should be present"
+    );
+    assert!(
+        response
+            .object_type
+            .as_deref()
+            .is_some_and(|kind| !kind.trim().is_empty()),
+        "response.object should be present"
+    );
+    assert!(
+        response
+            .status
+            .as_deref()
+            .is_some_and(|status| !status.trim().is_empty()),
+        "response.status should be present"
+    );
+    assert!(
+        response
+            .output
+            .as_ref()
+            .is_some_and(|output| !output.is_empty()),
+        "response.output should be non-empty"
+    );
+
+    println!(
+        "Responses non-stream test passed (model={model}, id={})",
+        response.id.as_deref().unwrap_or("<missing>")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_stream_response_unified_done_semantics() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    rate_limit_delay().await;
+
+    let model = test_responses_model();
+    let request = openrouter_rs::api::responses::ResponsesRequest::builder()
+        .model(model.clone())
+        .input(json!([{
+            "role": "user",
+            "content": "Give a brief greeting."
+        }]))
+        .max_output_tokens(60)
+        .temperature(0.0)
+        .build()?;
+
+    let mut stream = client.responses().stream_unified(&request).await?;
+
+    let (saw_payload_event, saw_done) = tokio::time::timeout(Duration::from_secs(90), async move {
+        let mut saw_payload_event = false;
+        let mut saw_done = false;
+
+        while let Some(event) = stream.next().await {
+            match event {
+                UnifiedStreamEvent::Error(err) => return Err(err),
+                UnifiedStreamEvent::Done { source, .. } => {
+                    assert_eq!(
+                        source,
+                        UnifiedStreamSource::Responses,
+                        "terminal event source should be responses"
+                    );
+                    saw_done = true;
+                    break;
+                }
+                UnifiedStreamEvent::ContentDelta(delta) => {
+                    if !delta.trim().is_empty() {
+                        saw_payload_event = true;
+                    }
+                }
+                UnifiedStreamEvent::ReasoningDelta(delta) => {
+                    if !delta.trim().is_empty() {
+                        saw_payload_event = true;
+                    }
+                }
+                UnifiedStreamEvent::ReasoningDetailsDelta(details) => {
+                    if !details.is_empty() {
+                        saw_payload_event = true;
+                    }
+                }
+                UnifiedStreamEvent::ToolDelta(_) => {
+                    saw_payload_event = true;
+                }
+                UnifiedStreamEvent::Raw { .. } => {
+                    saw_payload_event = true;
+                }
+            }
+        }
+
+        Ok::<(bool, bool), OpenRouterError>((saw_payload_event, saw_done))
+    })
+    .await
+    .expect("timed out waiting for responses stream completion")?;
+
+    assert!(
+        saw_payload_event,
+        "stream should emit at least one payload event"
+    );
+    assert!(saw_done, "stream should emit terminal done event");
+
+    println!("Responses stream test passed (model={model})");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add live integration tests for official `POST /responses` non-stream + stream paths
- register new `responses` integration module and document `OPENROUTER_TEST_RESPONSES_MODEL` override
- add endpoint-level matrix doc and mark `/responses` live coverage as completed

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test unit`
- `cargo test --test integration -- --list`
- `cargo test --test integration responses:: -- --nocapture`

Closes #80
