### PR TITLE
test: add live Messages API integration coverage (OR-28)

### DIFF
--- a/docs/official-endpoint-test-matrix.md
+++ b/docs/official-endpoint-test-matrix.md
@@ -7,8 +7,8 @@ Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted fro
 
 - Official OpenAPI endpoints: `36` method+path entries.
 - SDK implementation coverage (`src/api` + domain client): `36 / 36` (`100%`).
-- Live integration coverage (`tests/integration`): `4 / 36` endpoints currently exercised.
-  - Covered live now: `POST /chat/completions`, `POST /responses`, `GET /models`, `GET /key`
+- Live integration coverage (`tests/integration`): `5 / 36` endpoints currently exercised.
+  - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `GET /models`, `GET /key`
 
 Legend:
 
@@ -58,7 +58,7 @@ Legend:
 | `GET /models/count` | `client.count_models()` / `client.models().get_model_count()` | Yes | Contract | No | P1 |
 | `GET /models/user` | `client.list_models_for_user()` / `client.models().list_user_models()` | Yes | Path | No | P1 |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | No | P1 |
-| `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | No | P0 |
+| `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
 
 ## Supplemental (Legacy)
@@ -71,10 +71,9 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 
 ## Incremental Test Plan
 
-1. P0: add live integration tests for `/messages` (non-stream + stream).
-2. P1: add live integration tests for `/embeddings`, `/embeddings/models`, `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`.
-3. P1: add management-key live suite for guardrails and keys in a dedicated workflow gate (manual + weekly, no PR auto-trigger).
-4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
+1. P1: add live integration tests for `/embeddings`, `/embeddings/models`, `/providers`, `/models/user`, `/models/count`, `/endpoints/zdr`.
+2. P1: add management-key live suite for guardrails and keys in a dedicated workflow gate (manual + weekly, no PR auto-trigger).
+3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
 
 ## Reproduce Snapshot
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,6 +15,7 @@ The integration suite loads model selection in this order:
 - `OPENROUTER_INTEGRATION_TIER`: `stable` (default) or `hot`.
 - `OPENROUTER_TEST_MODEL_POOL_FILE`: path to a model-pool JSON file.
 - `OPENROUTER_TEST_CHAT_MODEL`: force the primary chat model.
+- `OPENROUTER_TEST_MESSAGES_MODEL`: force the primary Messages API model.
 - `OPENROUTER_TEST_RESPONSES_MODEL`: force the primary Responses API model.
 - `OPENROUTER_TEST_REASONING_MODEL`: force the primary reasoning model.
 - `OPENROUTER_TEST_STABLE_MODELS`: comma-separated stable regression model list.

--- a/tests/integration/messages.rs
+++ b/tests/integration/messages.rs
@@ -1,0 +1,148 @@
+use std::{env, time::Duration};
+
+use futures_util::StreamExt;
+use openrouter_rs::{
+    api::messages::{AnthropicMessage, AnthropicMessagesRequest},
+    error::OpenRouterError,
+    types::stream::{UnifiedStreamEvent, UnifiedStreamSource},
+};
+
+use super::{
+    model_pool::test_chat_model,
+    test_utils::{create_test_client, rate_limit_delay},
+};
+
+fn test_messages_model() -> String {
+    env::var("OPENROUTER_TEST_MESSAGES_MODEL")
+        .ok()
+        .map(|model| model.trim().to_string())
+        .filter(|model| !model.is_empty())
+        .unwrap_or_else(test_chat_model)
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_create_message_non_streaming() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    rate_limit_delay().await;
+
+    let model = test_messages_model();
+    let request = AnthropicMessagesRequest::builder()
+        .model(model.clone())
+        .max_tokens(120)
+        .messages(vec![AnthropicMessage::user(
+            "Please reply with a short greeting that includes the word Rust.",
+        )])
+        .build()?;
+
+    let response = client.messages().create(&request).await?;
+
+    assert!(
+        response
+            .id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty()),
+        "response.id should be present"
+    );
+    assert!(
+        response
+            .object_type
+            .as_deref()
+            .is_some_and(|kind| !kind.trim().is_empty()),
+        "response.type should be present"
+    );
+    assert!(
+        response
+            .role
+            .as_deref()
+            .is_some_and(|role| !role.trim().is_empty()),
+        "response.role should be present"
+    );
+    assert!(
+        !response.content.is_empty(),
+        "response.content should be non-empty"
+    );
+
+    println!(
+        "Messages non-stream test passed (model={model}, id={})",
+        response.id.as_deref().unwrap_or("<missing>")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_stream_messages_unified_done_semantics() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    rate_limit_delay().await;
+
+    let model = test_messages_model();
+    let request = AnthropicMessagesRequest::builder()
+        .model(model.clone())
+        .max_tokens(120)
+        .messages(vec![AnthropicMessage::user(
+            "Give a brief greeting in English.",
+        )])
+        .build()?;
+
+    let mut stream = client.messages().stream_unified(&request).await?;
+
+    let (saw_payload_event, saw_done) = tokio::time::timeout(Duration::from_secs(90), async move {
+        let mut saw_payload_event = false;
+        let mut saw_done = false;
+
+        while let Some(event) = stream.next().await {
+            match event {
+                UnifiedStreamEvent::Error(err) => return Err(err),
+                UnifiedStreamEvent::Done { source, .. } => {
+                    assert_eq!(
+                        source,
+                        UnifiedStreamSource::Messages,
+                        "terminal event source should be messages"
+                    );
+                    saw_done = true;
+                    break;
+                }
+                UnifiedStreamEvent::ContentDelta(delta) => {
+                    if !delta.trim().is_empty() {
+                        saw_payload_event = true;
+                    }
+                }
+                UnifiedStreamEvent::ReasoningDelta(delta) => {
+                    if !delta.trim().is_empty() {
+                        saw_payload_event = true;
+                    }
+                }
+                UnifiedStreamEvent::ReasoningDetailsDelta(details) => {
+                    if !details.is_empty() {
+                        saw_payload_event = true;
+                    }
+                }
+                UnifiedStreamEvent::ToolDelta(_) => {
+                    saw_payload_event = true;
+                }
+                UnifiedStreamEvent::Raw { source, .. } => {
+                    assert_eq!(
+                        source,
+                        UnifiedStreamSource::Messages,
+                        "raw event source should be messages"
+                    );
+                    saw_payload_event = true;
+                }
+            }
+        }
+
+        Ok::<(bool, bool), OpenRouterError>((saw_payload_event, saw_done))
+    })
+    .await
+    .expect("timed out waiting for messages stream completion")?;
+
+    assert!(
+        saw_payload_event,
+        "stream should emit at least one payload event"
+    );
+    assert!(saw_done, "stream should emit terminal done event");
+
+    println!("Messages stream test passed (model={model})");
+    Ok(())
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -5,6 +5,7 @@ fn dummy_test() {
 
 pub mod api_keys;
 pub mod chat;
+pub mod messages;
 pub mod model_pool;
 pub mod models;
 pub mod responses;


### PR DESCRIPTION
## Summary
- add live integration tests for official `POST /messages` non-stream + stream paths
- register `messages` integration module and document `OPENROUTER_TEST_MESSAGES_MODEL` override
- update endpoint-level matrix and mark `/messages` live coverage as completed

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test unit`
- `cargo test --test integration -- --list`
- `cargo test --test integration messages:: -- --nocapture`

Closes #81
