### PR TITLE
test: add live embeddings integration coverage

### DIFF
--- a/docs/official-endpoint-test-matrix.md
+++ b/docs/official-endpoint-test-matrix.md
@@ -7,8 +7,8 @@ Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted fro
 
 - Official OpenAPI endpoints: `36` method+path entries.
 - SDK implementation coverage (`src/api` + domain client): `36 / 36` (`100%`).
-- Live integration coverage (`tests/integration`): `10 / 36` endpoints currently exercised.
-  - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`
+- Live integration coverage (`tests/integration`): `12 / 36` endpoints currently exercised.
+  - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`
 
 Legend:
 
@@ -30,8 +30,8 @@ Legend:
 | `POST /chat/completions` | `client.chat().create(...)` / `client.chat().stream(...)` | Yes | Contract | Yes | Keep |
 | `GET /credits` | `client.get_credits()` / `client.management().get_credits()` | Yes | None | No | P2 |
 | `POST /credits/coinbase` | `client.create_coinbase_charge(...)` / `client.management().create_coinbase_charge(...)` | Yes | None | No | P2 |
-| `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | No | P1 |
-| `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | None | No | P1 |
+| `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | Yes | Keep |
+| `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | None | Yes | Keep |
 | `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | Yes | Keep |
 | `GET /generation` | `client.get_generation(...)` / `client.management().get_generation(...)` | Yes | None | No | P2 |
 | `GET /guardrails` | `client.management().list_guardrails(...)` | Yes | Path | No | P1 |
@@ -71,9 +71,8 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 
 ## Incremental Test Plan
 
-1. P1: add live integration tests for `/embeddings` and `/embeddings/models`.
-2. P1: add management-key live suite for guardrails and keys in a dedicated workflow gate (manual + weekly, no PR auto-trigger).
-3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
+1. P1: add management-key live suite for guardrails and keys in a dedicated workflow gate (manual + weekly, no PR auto-trigger).
+2. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
 
 ## Reproduce Snapshot
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,6 +15,7 @@ The integration suite loads model selection in this order:
 - `OPENROUTER_INTEGRATION_TIER`: `stable` (default) or `hot`.
 - `OPENROUTER_TEST_MODEL_POOL_FILE`: path to a model-pool JSON file.
 - `OPENROUTER_TEST_CHAT_MODEL`: force the primary chat model.
+- `OPENROUTER_TEST_EMBEDDINGS_MODEL`: force the primary embeddings model.
 - `OPENROUTER_TEST_MESSAGES_MODEL`: force the primary Messages API model.
 - `OPENROUTER_TEST_RESPONSES_MODEL`: force the primary Responses API model.
 - `OPENROUTER_TEST_REASONING_MODEL`: force the primary reasoning model.

--- a/tests/integration/embeddings.rs
+++ b/tests/integration/embeddings.rs
@@ -1,0 +1,128 @@
+use std::{collections::HashSet, env};
+
+use openrouter_rs::{
+    api::embeddings::{EmbeddingRequest, EmbeddingVector},
+    error::OpenRouterError,
+};
+
+use super::test_utils::{create_test_client, rate_limit_delay};
+
+const MAX_EMBEDDING_MODEL_PROBES: usize = 12;
+
+fn configured_embeddings_model() -> Option<String> {
+    env::var("OPENROUTER_TEST_EMBEDDINGS_MODEL")
+        .ok()
+        .map(|model| model.trim().to_string())
+        .filter(|model| !model.is_empty())
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_list_embedding_models_live() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    rate_limit_delay().await;
+
+    let models = client.models().list_embedding_models().await?;
+    assert!(
+        !models.is_empty(),
+        "embedding model list should not be empty"
+    );
+    assert!(
+        models
+            .iter()
+            .any(|model| !model.id.trim().is_empty() && !model.name.trim().is_empty()),
+        "at least one embedding model should include id and name"
+    );
+
+    println!("Embeddings models test passed: {} models", models.len());
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_create_embedding_live() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    rate_limit_delay().await;
+
+    let models = client.models().list_embedding_models().await?;
+    assert!(
+        !models.is_empty(),
+        "embedding model list should not be empty"
+    );
+
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    if let Some(model) = configured_embeddings_model() {
+        seen.insert(model.clone());
+        candidates.push(model);
+    }
+
+    for model in &models {
+        let id = model.id.trim();
+        if id.is_empty() {
+            continue;
+        }
+
+        if seen.insert(id.to_string()) {
+            candidates.push(id.to_string());
+        }
+
+        if candidates.len() >= MAX_EMBEDDING_MODEL_PROBES {
+            break;
+        }
+    }
+
+    let mut last_failure = None;
+    let mut attempted = 0usize;
+
+    for model in candidates {
+        attempted += 1;
+        rate_limit_delay().await;
+
+        let request = EmbeddingRequest::new(
+            model.clone(),
+            "Return a deterministic embedding for this short integration sentence.",
+        );
+
+        match client.models().create_embedding(&request).await {
+            Ok(response) => {
+                assert!(
+                    !response.object.trim().is_empty(),
+                    "response.object should exist"
+                );
+                assert!(
+                    !response.model.trim().is_empty(),
+                    "response.model should exist"
+                );
+                assert!(
+                    !response.data.is_empty(),
+                    "response.data should not be empty"
+                );
+
+                assert!(
+                    response.data.iter().any(|item| match &item.embedding {
+                        EmbeddingVector::Float(values) => !values.is_empty(),
+                        EmbeddingVector::Base64(value) => !value.trim().is_empty(),
+                    }),
+                    "at least one embedding item should contain non-empty vector payload"
+                );
+
+                println!(
+                    "Embeddings create test passed (model={}, vectors={})",
+                    response.model,
+                    response.data.len()
+                );
+                return Ok(());
+            }
+            Err(error) => {
+                last_failure = Some(format!("{model} => {error}"));
+            }
+        }
+    }
+
+    panic!(
+        "failed to create embedding after trying {attempted}/{MAX_EMBEDDING_MODEL_PROBES} candidate models; last failure: {}",
+        last_failure.unwrap_or_else(|| "no candidate models were available".to_string())
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -6,6 +6,7 @@ fn dummy_test() {
 pub mod api_keys;
 pub mod chat;
 pub mod discovery;
+pub mod embeddings;
 pub mod messages;
 pub mod model_pool;
 pub mod models;


### PR DESCRIPTION
## Summary
- add live integration tests for `GET /embeddings/models` and `POST /embeddings`
- add optional `OPENROUTER_TEST_EMBEDDINGS_MODEL` override for deterministic model pinning
- register embeddings integration module and refresh official endpoint coverage matrix (live: 12/36)

## Validation
- `cargo fmt --all`
- `cargo test --test unit embeddings -- --nocapture`
- `cargo test --test integration embeddings:: -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`

Live integration output:
- `embeddings::test_list_embedding_models_live` passed (`22` models)
- `embeddings::test_create_embedding_live` passed (`model=private/openrouter/nvidia/llama-nemotron-embed-vl-1b-v2`, `vectors=1`)

Closes #83
