### PR TITLE
chore(release): prepare 0.6.0 RC + default request attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed in 0.6.0
+## [0.6.0] - 2026-03-10
+
+### Removed
 - Removed management-key compatibility aliases:
   - `OpenRouterClientBuilder::provisioning_key(...)`
   - `OpenRouterClient::{set_provisioning_key, clear_provisioning_key}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-openrouter-rs = "0.5.2"
+openrouter-rs = "0.6.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -119,7 +119,7 @@ Legacy `POST /completions` support is isolated behind `legacy-completions` and e
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.5.2", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.6.0", features = ["legacy-completions"] }
 ```
 
 ```rust
@@ -408,6 +408,9 @@ let client = OpenRouterClient::builder()
     .build()?;
 ```
 
+By default, the SDK sends `X-Title: openrouter-rs` so requests are attributed in OpenRouter activity logs.
+Set `.x_title(...)` to override this value for your app.
+
 ### Streaming with Reasoning
 
 ```rust
@@ -578,14 +581,14 @@ This is a **third-party SDK** not officially affiliated with OpenRouter. Use at 
 
 ## 📈 Release History
 
-### Version 0.6.0 *(Upcoming)*
+### Version 0.6.0 *(Latest)*
 
 - ❗ **Breaking**: Removed all 0.5.x compatibility aliases; canonical APIs only (`management_key`, domain clients, `PaginationOptions`)
 - 🧭 **Breaking**: Legacy completions now only via explicit surface (`api::legacy::completion` + `client.legacy().completions().create(...)`)
 - ⚙️ **Changed**: `legacy-completions` feature is opt-in (not part of default features)
 - 📚 **Migration**: Finalized migration guide and smoke-test coverage for removed/renamed APIs
 
-### Version 0.5.2 *(Latest stable)*
+### Version 0.5.2
 
 - 🧭 **Added**: Domain-oriented SDK surface and major OpenRouter coverage expansion (`messages`, discovery/activity, guardrails, auth code flow)
 - 🛠️ **Added**: `openrouter-cli v0.1` foundation with discovery, management, and usage/billing command groups

--- a/docs/official-endpoint-test-matrix.md
+++ b/docs/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-03-02  
+Snapshot date: 2026-03-10  
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)
 
 ## Coverage Summary
@@ -48,7 +48,7 @@ Legend:
 | `GET /guardrails/assignments/keys` | `client.management().list_key_assignments(...)` | Yes | Path | No | P1 |
 | `GET /guardrails/assignments/members` | `client.management().list_member_assignments(...)` | Yes | Path | No | P1 |
 | `GET /key` | `client.get_current_api_key_info()` / `client.management().get_current_api_key_info()` | Yes | Contract | Yes | Keep |
-| `GET /keys` | `client.list_api_keys(...)` / `client.management().list_api_keys(...)` | Yes | Path | Yes | Keep |
+| `GET /keys` | `client.management().list_api_keys(...)` | Yes | Path | Yes | Keep |
 | `POST /keys` | `client.create_api_key(...)` / `client.management().create_api_key(...)` | Yes | Path | Yes | Keep |
 | `GET /keys/{hash}` | `client.get_api_key(...)` / `client.management().get_api_key(...)` | Yes | Path | Yes | Keep |
 | `PATCH /keys/{hash}` | `client.update_api_key(...)` / `client.management().update_api_key(...)` | Yes | Path | Yes | Keep |

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,7 +34,10 @@ pub struct OpenRouterClient {
     management_key: Option<String>,
     #[builder(setter(into, strip_option), default)]
     http_referer: Option<String>,
-    #[builder(setter(into, strip_option), default)]
+    #[builder(
+        setter(into, strip_option),
+        default = "Some(String::from(\"openrouter-rs\"))"
+    )]
     x_title: Option<String>,
     #[builder(setter(into, strip_option), default)]
     config: Option<OpenRouterConfig>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.5.2"
+//! openrouter-rs = "0.6.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!

--- a/tests/unit/default_headers.rs
+++ b/tests/unit/default_headers.rs
@@ -1,0 +1,172 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::{OpenRouterClient, api::chat, types::Role};
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should include header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+
+        tx.send(CapturedRequest {
+            request_line,
+            request_text: header_text,
+        })
+        .expect("captured request should send");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+fn chat_response_json() -> &'static str {
+    r#"{
+        "id": "gen-123",
+        "choices": [{
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "ok"
+            }
+        }],
+        "created": 1700000000,
+        "model": "openai/gpt-4.1-mini",
+        "object": "chat.completion"
+    }"#
+}
+
+fn build_chat_request() -> chat::ChatCompletionRequest {
+    chat::ChatCompletionRequest::builder()
+        .model("openai/gpt-4.1-mini")
+        .messages(vec![chat::Message::new(Role::User, "hello")])
+        .build()
+        .expect("chat request should build")
+}
+
+#[tokio::test]
+async fn test_default_x_title_header_is_sent() {
+    let (base_url, rx, server) = spawn_json_server(chat_response_json());
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .build()
+        .expect("client should build");
+
+    let request = build_chat_request();
+    let _response = client
+        .chat()
+        .create(&request)
+        .await
+        .expect("chat request should succeed");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/chat/completions HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("x-title: openrouter-rs")
+            || request_lower.contains("x-title:openrouter-rs"),
+        "default x-title header should be present, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_explicit_x_title_overrides_default() {
+    let (base_url, rx, server) = spawn_json_server(chat_response_json());
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .x_title("openrouter-rs-tests")
+        .build()
+        .expect("client should build");
+
+    let request = build_chat_request();
+    let _response = client
+        .chat()
+        .create(&request)
+        .await
+        .expect("chat request should succeed");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/chat/completions HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("x-title: openrouter-rs-tests")
+            || request_lower.contains("x-title:openrouter-rs-tests"),
+        "explicit x-title header should be present, request:\n{}",
+        captured.request_text
+    );
+    assert!(
+        !request_lower.contains("x-title: openrouter-rs\r\n")
+            && !request_lower.contains("x-title:openrouter-rs\r\n"),
+        "default x-title should be replaced when custom title is set, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -13,6 +13,7 @@ pub mod client_management_key;
 pub mod completion;
 pub mod config;
 pub mod credits;
+pub mod default_headers;
 pub mod discovery;
 pub mod embeddings;
 pub mod error_model;


### PR DESCRIPTION
## Summary
- prepare `0.6.0` release metadata/docs alignment:
  - bump crate version to `0.6.0` in `Cargo.toml`
  - sync docs snippets to `0.6.0` (`README.md`, `src/lib.rs`)
  - finalize `CHANGELOG.md` with `## [0.6.0] - 2026-03-10`
  - update README release history so `0.6.0` is latest
- update official endpoint test matrix snapshot and remove stale `client.list_api_keys(...)` mention
- set default request attribution header to avoid `activity.app = unknown`:
  - default `X-Title` is now `openrouter-rs`
  - explicit `.x_title(...)` still overrides
- add unit regression coverage for default/override `X-Title` behavior

## Verification (local)
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test unit
- cargo test --test migration_smoke --all-features
- cargo check --examples
- cargo check --examples --features legacy-completions
- ./scripts/check_migration_docs.sh
- bash /Users/morris/.codex/skills/local/openrouter-rs-release/scripts/verify_release_sync.sh 0.6.0

## Verification (live workflows)
- Integration Tests (stable tier, includes management-smoke):
  - https://github.com/realmorrisliu/openrouter-rs/actions/runs/22890404045
- CLI Integration Tests (include write):
  - https://github.com/realmorrisliu/openrouter-rs/actions/runs/22890404064

Note: a prior hot-tier integration dispatch failed due transient hot-model sweep responses; release gate for this commit was validated on stable tier.

Closes #98
