### PR TITLE
chore(cli): prepare crates.io publish readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run CLI foundation tests
         run: cargo test -p openrouter-cli
 
+      - name: Validate CLI package contents
+        run: cargo package -p openrouter-cli --locked
+
   msrv-check:
     name: MSRV Check (1.85.0)
     runs-on: ubuntu-latest

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -6,11 +6,16 @@ rust-version = "1.85"
 description = "CLI for OpenRouter account and SDK workflows"
 license = "MIT"
 repository = "https://github.com/realmorrisliu/openrouter-rs"
+homepage = "https://github.com/realmorrisliu/openrouter-rs"
+documentation = "https://github.com/realmorrisliu/openrouter-rs/tree/main/crates/openrouter-cli"
+readme = "README.md"
+keywords = ["openrouter", "cli", "ai"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { path = "../.." }
+openrouter-rs = { version = "0.6.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -9,6 +9,20 @@
 - OR-21: management commands for API keys and guardrails
 - OR-22: usage and billing commands with stable output contracts
 
+## Installation
+
+Install from crates.io:
+
+```bash
+cargo install openrouter-cli
+```
+
+Install from local source:
+
+```bash
+cargo install --path crates/openrouter-cli
+```
+
 ## Config And Profile Convention
 
 By default, config is loaded from:


### PR DESCRIPTION
## Summary
- add publish metadata to crates/openrouter-cli/Cargo.toml (homepage, documentation, readme, keywords, categories)
- make openrouter-rs dependency publish-safe by adding version alongside path
- add Installation section to crates/openrouter-cli/README.md
- add CI gate: cargo package -p openrouter-cli --locked

## Validation
- cargo test -p openrouter-cli
- cargo package -p openrouter-cli --locked --allow-dirty
- cargo install --path crates/openrouter-cli --root /tmp/openrouter-cli-install-check

Closes #108
Refs #99