### PR TITLE
docs: [P0][OR-40A] Restore doctest coverage and align public docs with current API

### DIFF
--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -680,6 +680,8 @@ impl ChatCompletionRequestBuilder {
     /// # Examples
     ///
     /// ```rust
+    /// use openrouter_rs::api::chat::{ChatCompletionRequest, Message};
+    /// use openrouter_rs::types::Role;
     /// use openrouter_rs::types::typed_tool::TypedTool;
     /// use serde::{Deserialize, Serialize};
     /// use schemars::JsonSchema;
@@ -696,6 +698,7 @@ impl ChatCompletionRequestBuilder {
     ///
     /// let request = ChatCompletionRequest::builder()
     ///     .model("anthropic/claude-sonnet-4")
+    ///     .messages(vec![Message::new(Role::User, "What is the weather in Paris?")])
     ///     .typed_tool::<WeatherParams>()
     ///     .build()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -713,6 +716,8 @@ impl ChatCompletionRequestBuilder {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::api::chat::{ChatCompletionRequest, Message};
+    /// # use openrouter_rs::types::Role;
     /// # use openrouter_rs::types::typed_tool::TypedTool;
     /// # use serde::{Deserialize, Serialize};
     /// # use schemars::JsonSchema;
@@ -731,6 +736,7 @@ impl ChatCompletionRequestBuilder {
     ///
     /// let request = ChatCompletionRequest::builder()
     ///     .model("anthropic/claude-sonnet-4")
+    ///     .messages(vec![Message::new(Role::User, "Need weather and calculator help")])
     ///     .typed_tools_batch(&[
     ///         WeatherParams::create_tool(),
     ///         CalculatorParams::create_tool(),
@@ -753,6 +759,8 @@ impl ChatCompletionRequestBuilder {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::api::chat::{ChatCompletionRequest, Message};
+    /// # use openrouter_rs::types::Role;
     /// # use openrouter_rs::types::typed_tool::TypedTool;
     /// # use serde::{Deserialize, Serialize};
     /// # use schemars::JsonSchema;
@@ -765,6 +773,7 @@ impl ChatCompletionRequestBuilder {
     ///
     /// let request = ChatCompletionRequest::builder()
     ///     .model("anthropic/claude-sonnet-4")
+    ///     .messages(vec![Message::new(Role::User, "What is the weather in Paris?")])
     ///     .force_typed_tool::<WeatherParams>()
     ///     .build()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,12 +37,18 @@
 //! - Filter by supported parameters
 //! - Get detailed model specifications
 //!
-//! ```rust
-//! use openrouter_rs::types::ModelCategory;
+//! ```no_run
+//! use openrouter_rs::{OpenRouterClient, types::ModelCategory};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = OpenRouterClient::builder()
+//!     .api_key("your_key")
+//!     .build()?;
 //!
 //! // Get all models in the programming category
 //! let models = client.models().list_by_category(ModelCategory::Programming).await?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # }
 //! ```
 //!
 //! ### API Key Management ([`api_keys`])
@@ -78,7 +84,7 @@
 //! ## 🚀 Quick Examples
 //!
 //! ### Basic Chat
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::{OpenRouterClient, api::chat::*};
 //! use openrouter_rs::types::Role;
 //!
@@ -98,7 +104,7 @@
 //! ```
 //!
 //! ### Model Discovery
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::OpenRouterClient;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -116,16 +122,27 @@
 //!
 //! All API methods return `Result` types that should be handled appropriately:
 //!
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::error::OpenRouterError;
+//! use openrouter_rs::{OpenRouterClient, api::chat::{ChatCompletionRequest, Message}, types::Role};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = OpenRouterClient::builder()
+//!     .api_key("your_key")
+//!     .build()?;
+//! let request = ChatCompletionRequest::builder()
+//!     .model("google/gemini-2.5-flash")
+//!     .messages(vec![Message::new(Role::User, "Hello!")])
+//!     .build()?;
+//!
 //! match client.chat().create(&request).await {
 //!     Ok(response) => println!("Success: {:?}", response),
-//!     Err(OpenRouterError::RateLimitExceeded) => {
+//!     Err(OpenRouterError::Api(api_error)) if api_error.is_retryable() => {
 //!         println!("Rate limit hit, retrying later...");
 //!     }
-//!     Err(OpenRouterError::InvalidApiKey) => {
+//!     Err(OpenRouterError::Api(api_error))
+//!         if api_error.status == surf::StatusCode::Unauthorized =>
+//!     {
 //!         println!("Check your API key configuration");
 //!     }
 //!     Err(e) => println!("Other error: {}", e),

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,8 +61,10 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let mut client = OpenRouterClient::builder().build();
+    /// # use openrouter_rs::OpenRouterClient;
+    /// let mut client = OpenRouterClient::builder().build()?;
     /// client.set_api_key("your_api_key");
+    /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
     /// ```
     pub fn set_api_key(&mut self, api_key: impl Into<String>) {
         self.api_key = Some(api_key.into());
@@ -73,8 +75,10 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let mut client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// # use openrouter_rs::OpenRouterClient;
+    /// let mut client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// client.clear_api_key();
+    /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
     /// ```
     pub fn clear_api_key(&mut self) {
         self.api_key = None;
@@ -89,8 +93,10 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let mut client = OpenRouterClient::builder().build();
+    /// # use openrouter_rs::OpenRouterClient;
+    /// let mut client = OpenRouterClient::builder().build()?;
     /// client.set_management_key("your_management_key");
+    /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
     /// ```
     pub fn set_management_key(&mut self, management_key: impl Into<String>) {
         self.management_key = Some(management_key.into());
@@ -101,9 +107,11 @@ impl OpenRouterClient {
     /// # Example
     ///
     /// ```
-    /// let mut client = OpenRouterClient::builder().build();
+    /// # use openrouter_rs::OpenRouterClient;
+    /// let mut client = OpenRouterClient::builder().build()?;
     /// client.set_management_key("your_management_key");
     /// client.clear_management_key();
+    /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
     /// ```
     pub fn clear_management_key(&mut self) {
         self.management_key = None;
@@ -156,10 +164,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build()?;
     /// let api_key = client.create_api_key("New API Key", Some(100.0)).await?;
     /// println!("{:?}", api_key);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn create_api_key(
         &self,
@@ -181,10 +193,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let api_key_details = client.get_current_api_key_info().await?;
     /// println!("{:?}", api_key_details);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn get_current_api_key_info(
         &self,
@@ -208,10 +224,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build()?;
     /// let success = client.delete_api_key("api_key_hash").await?;
     /// println!("Deletion successful: {}", success);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn delete_api_key(&self, hash: &str) -> Result<bool, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
@@ -236,10 +256,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build()?;
     /// let updated_api_key = client.update_api_key("api_key_hash", Some("Updated Name".to_string()), Some(false), Some(200.0)).await?;
     /// println!("{:?}", updated_api_key);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn update_api_key(
         &self,
@@ -281,10 +305,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().management_key("your_management_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().management_key("your_management_key").build()?;
     /// let api_key = client.get_api_key("api_key_hash").await?;
     /// println!("{:?}", api_key);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn get_api_key(&self, hash: &str) -> Result<api_keys::ApiKey, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
@@ -544,10 +572,18 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
-    /// let auth_response = client.exchange_code_for_api_key("auth_code", Some("code_verifier"), Some(auth::CodeChallengeMethod::S256)).await?;
+    /// ```no_run
+    /// # use openrouter_rs::{OpenRouterClient, api::auth};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
+    /// let auth_response = client.exchange_code_for_api_key(
+    ///     "auth_code",
+    ///     Some("code_verifier"),
+    ///     Some(auth::CodeChallengeMethod::S256),
+    /// ).await?;
     /// println!("{:?}", auth_response);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn exchange_code_for_api_key(
         &self,
@@ -571,16 +607,20 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::{OpenRouterClient, api::chat::{self, Message}, types::Role};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let request = chat::ChatCompletionRequest::builder()
     ///     .model("deepseek/deepseek-chat-v3-0324:free")
-    ///     .messages(vec![chat::Message::new(chat::Role::User, "What is the meaning of life?")])
+    ///     .messages(vec![Message::new(Role::User, "What is the meaning of life?")])
     ///     .max_tokens(100)
     ///     .temperature(0.7)
     ///     .build()?;
     /// let response = client.send_chat_completion(&request).await?;
     /// println!("{:?}", response);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn send_chat_completion(
         &self,
@@ -612,11 +652,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use futures_util::StreamExt;
+    /// # use openrouter_rs::{OpenRouterClient, api::chat::{self, Message}, types::Role};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let request = chat::ChatCompletionRequest::builder()
     ///     .model("deepseek/deepseek-chat-v3-0324:free")
-    ///     .messages(vec![chat::Message::new(chat::Role::User, "Tell me a joke.")])
+    ///     .messages(vec![Message::new(Role::User, "Tell me a joke.")])
     ///     .max_tokens(50)
     ///     .temperature(0.5)
     ///     .build()?;
@@ -627,6 +670,8 @@ impl OpenRouterClient {
     ///         Err(e) => eprintln!("Error: {:?}", e),
     ///     }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn stream_chat_completion(
         &self,
@@ -862,8 +907,10 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::{OpenRouterClient, api::credits};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let request = credits::CoinbaseChargeRequest::builder()
     ///     .amount(100.0)
     ///     .sender("sender_address")
@@ -871,6 +918,8 @@ impl OpenRouterClient {
     ///     .build()?;
     /// let response = client.create_coinbase_charge(&request).await?;
     /// println!("{:?}", response);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn create_coinbase_charge(
         &self,
@@ -891,10 +940,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let credits_data = client.get_credits().await?;
     /// println!("{:?}", credits_data);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn get_credits(&self) -> Result<credits::CreditsData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
@@ -916,13 +969,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
-    /// let request = generation::GenerationRequest::builder()
-    ///     .id("generation_id")
-    ///     .build()?;
-    /// let generation_data = client.get_generation(&request).await?;
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
+    /// let generation_data = client.get_generation("generation_id").await?;
     /// println!("{:?}", generation_data);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn get_generation(
         &self,
@@ -943,10 +997,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let models = client.list_models().await?;
     /// println!("{:?}", models);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn list_models(&self) -> Result<Vec<models::Model>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
@@ -968,10 +1026,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
-    /// let models = client.list_models_by_category(ModelCategory::TextCompletion).await?;
+    /// ```no_run
+    /// # use openrouter_rs::{OpenRouterClient, types::ModelCategory};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
+    /// let models = client.list_models_by_category(ModelCategory::Programming).await?;
     /// println!("{:?}", models);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn list_models_by_category(
         &self,
@@ -996,10 +1058,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::{OpenRouterClient, types::SupportedParameters};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let models = client.list_models_by_parameters(SupportedParameters::Tools).await?;
     /// println!("{:?}", models);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn list_models_by_parameters(
         &self,
@@ -1025,10 +1091,14 @@ impl OpenRouterClient {
     ///
     /// # Example
     ///
-    /// ```
-    /// let client = OpenRouterClient::builder().api_key("your_api_key").build();
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
     /// let endpoint_data = client.list_model_endpoints("author_name", "model_slug").await?;
     /// println!("{:?}", endpoint_data);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn list_model_endpoints(
         &self,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -42,6 +42,9 @@ impl ModelConfig {
     ///
     /// # Example
     /// ```rust
+    /// use openrouter_rs::config::ModelConfig;
+    /// use std::collections::HashMap;
+    ///
     /// let mut config = ModelConfig {
     ///     enable: vec!["preset:programming".into()],
     ///     presets: {
@@ -83,6 +86,8 @@ impl ModelConfig {
     ///
     /// # Example
     /// ```rust
+    /// use openrouter_rs::config::ModelConfig;
+    ///
     /// let config = ModelConfig {
     ///     resolved_models: vec!["anthropic/claude-sonnet-4".into()],
     ///     ..Default::default()

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@
 //!
 //! ### Basic Error Handling
 //!
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::{OpenRouterClient, error::OpenRouterError};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -56,10 +56,19 @@
 //!
 //! ### Rate Limiting Handling
 //!
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::error::OpenRouterError;
+//! use openrouter_rs::{OpenRouterClient, api::chat::{ChatCompletionRequest, Message}, types::Role};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = OpenRouterClient::builder()
+//!     .api_key("your_api_key")
+//!     .build()?;
+//! let request = ChatCompletionRequest::builder()
+//!     .model("google/gemini-2.5-flash")
+//!     .messages(vec![Message::new(Role::User, "Hello!")])
+//!     .build()?;
+//!
 //! match client.chat().create(&request).await {
 //!     Err(OpenRouterError::Api(api_error)) if api_error.is_retryable() => {
 //!         println!("Rate limited, retrying after delay...");
@@ -80,10 +89,6 @@
 //!
 //! match load_config("./config.toml") {
 //!     Ok(config) => println!("Config loaded successfully"),
-//!     Err(OpenRouterError::ConfigNotFound(path)) => {
-//!         println!("Config file not found at: {}", path.display());
-//!         // Use default configuration
-//!     }
 //!     Err(OpenRouterError::ConfigError(msg)) => {
 //!         eprintln!("Invalid configuration: {}", msg);
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ### Basic Chat Completion
 //!
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::{
 //!     OpenRouterClient,
 //!     api::chat::{ChatCompletionRequest, Message},
@@ -63,9 +63,9 @@
 //!
 //! ### Streaming Responses
 //!
-//! ```rust
+//! ```no_run
 //! use futures_util::StreamExt;
-//! use openrouter_rs::{OpenRouterClient, api::chat::*};
+//! use openrouter_rs::{OpenRouterClient, api::chat::*, types::Role};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = OpenRouterClient::builder()
@@ -92,7 +92,7 @@
 //!
 //! ### Reasoning Tokens (Chain-of-Thought)
 //!
-//! ```rust
+//! ```no_run
 //! use openrouter_rs::{OpenRouterClient, api::chat::*, types::{Role, Effort}};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -107,6 +107,7 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
+    /// use openrouter_rs::types::{ToolCall, completion::FunctionCall};
     /// use openrouter_rs::types::typed_tool::TypedTool;
     /// use serde::{Deserialize, Serialize};
     /// use schemars::JsonSchema;
@@ -121,8 +122,18 @@ impl ToolCall {
     ///     fn description() -> &'static str { "Get weather" }
     /// }
     ///
-    /// // Parse tool call parameters
+    /// let tool_call = ToolCall {
+    ///     id: "call_123".to_string(),
+    ///     type_: "function".to_string(),
+    ///     function: FunctionCall {
+    ///         name: "get_weather".to_string(),
+    ///         arguments: r#"{"location":"Paris"}"#.to_string(),
+    ///     },
+    ///     index: None,
+    /// };
+    ///
     /// let params: WeatherParams = tool_call.parse_params()?;
+    /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
     /// ```
     pub fn parse_params<T>(&self) -> Result<T, crate::error::OpenRouterError>
     where
@@ -137,10 +148,30 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// # use openrouter_rs::types::typed_tool::TypedTool;
+    /// # use serde::{Deserialize, Serialize};
+    /// # use schemars::JsonSchema;
+    /// # #[derive(Serialize, Deserialize, JsonSchema)]
+    /// # struct WeatherParams { location: String }
+    /// # impl TypedTool for WeatherParams {
+    /// #     fn name() -> &'static str { "get_weather" }
+    /// #     fn description() -> &'static str { "Get weather" }
+    /// # }
+    /// # let tool_call = ToolCall {
+    /// #     id: "call_123".to_string(),
+    /// #     type_: "function".to_string(),
+    /// #     function: FunctionCall {
+    /// #         name: "get_weather".to_string(),
+    /// #         arguments: r#"{"location":"Paris"}"#.to_string(),
+    /// #     },
+    /// #     index: None,
+    /// # };
     /// if tool_call.is_tool::<WeatherParams>() {
     ///     let params = tool_call.parse_params::<WeatherParams>()?;
     ///     // Handle weather tool
     /// }
+    /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
     /// ```
     pub fn is_tool<T>(&self) -> bool
     where
@@ -154,6 +185,16 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// # let tool_call = ToolCall {
+    /// #     id: "call_123".to_string(),
+    /// #     type_: "function".to_string(),
+    /// #     function: FunctionCall {
+    /// #         name: "get_weather".to_string(),
+    /// #         arguments: "{}".to_string(),
+    /// #     },
+    /// #     index: None,
+    /// # };
     /// match tool_call.name() {
     ///     "get_weather" => { /* handle weather */ }
     ///     "calculator" => { /* handle calculator */ }
@@ -169,6 +210,16 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// # let tool_call = ToolCall {
+    /// #     id: "call_123".to_string(),
+    /// #     type_: "function".to_string(),
+    /// #     function: FunctionCall {
+    /// #         name: "get_weather".to_string(),
+    /// #         arguments: r#"{"location":"Paris"}"#.to_string(),
+    /// #     },
+    /// #     index: None,
+    /// # };
     /// println!("Raw arguments: {}", tool_call.arguments_json());
     /// ```
     pub fn arguments_json(&self) -> &str {
@@ -180,6 +231,16 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// # let tool_call = ToolCall {
+    /// #     id: "call_123".to_string(),
+    /// #     type_: "function".to_string(),
+    /// #     function: FunctionCall {
+    /// #         name: "get_weather".to_string(),
+    /// #         arguments: "{}".to_string(),
+    /// #     },
+    /// #     index: None,
+    /// # };
     /// println!("Tool call ID: {}", tool_call.id());
     /// ```
     pub fn id(&self) -> &str {
@@ -191,6 +252,16 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
+    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// # let tool_call = ToolCall {
+    /// #     id: "call_123".to_string(),
+    /// #     type_: "function".to_string(),
+    /// #     function: FunctionCall {
+    /// #         name: "get_weather".to_string(),
+    /// #         arguments: "{}".to_string(),
+    /// #     },
+    /// #     index: None,
+    /// # };
     /// assert_eq!(tool_call.tool_type(), "function");
     /// ```
     pub fn tool_type(&self) -> &str {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -69,24 +69,23 @@
 //! ```rust
 //! use openrouter_rs::types::{ReasoningConfig, Effort};
 //!
-//! let reasoning = ReasoningConfig::builder()
-//!     .enabled(true)
+//! let reasoning = ReasoningConfig::enabled()
 //!     .effort(Effort::High)
 //!     .max_tokens(1000)
-//!     .build()?;
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//!     .exclude(false);
 //! ```
 //!
 //! ### ProviderPreferences
 //! Specify preferences for model provider selection:
 //!
 //! ```rust
-//! use openrouter_rs::types::ProviderPreferences;
+//! use openrouter_rs::types::{DataCollectionPolicy, ProviderPreferences};
 //!
 //! let prefs = ProviderPreferences {
-//!     allow_fallbacks: true,
-//!     require_parameters: Some(vec!["tools".to_string()]),
-//!     data_collection: Some("deny".to_string()),
+//!     allow_fallbacks: Some(true),
+//!     require_parameters: Some(true),
+//!     data_collection: Some(DataCollectionPolicy::Deny),
+//!     ..Default::default()
 //! };
 //! ```
 //!
@@ -99,8 +98,8 @@
 //!
 //! // Filter models by use case
 //! let programming_models = ModelCategory::Programming;
-//! let reasoning_models = ModelCategory::Reasoning;
-//! let image_models = ModelCategory::Image;
+//! let roleplay_models = ModelCategory::Roleplay;
+//! let science_models = ModelCategory::Science;
 //! ```
 //!
 //! ## 🏗️ Builder Patterns
@@ -110,13 +109,10 @@
 //! ```rust
 //! use openrouter_rs::types::{ReasoningConfig, Effort};
 //!
-//! let config = ReasoningConfig::builder()
-//!     .enabled(true)
+//! let config = ReasoningConfig::enabled()
 //!     .effort(Effort::High)
 //!     .max_tokens(2000)
-//!     .exclude(false)
-//!     .build()?;
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//!     .exclude(false);
 //! ```
 //!
 //! ## 🔄 Serialization Support
@@ -218,12 +214,13 @@ impl Display for Role {
 ///
 /// ```rust
 /// use openrouter_rs::types::Effort;
-/// use openrouter_rs::api::chat::ChatCompletionRequest;
+/// use openrouter_rs::api::chat::{ChatCompletionRequest, Message};
+/// use openrouter_rs::types::Role;
 ///
 /// let request = ChatCompletionRequest::builder()
 ///     .model("deepseek/deepseek-r1")
-///     .reasoning_effort(Effort::High)  // Maximum reasoning depth
-///     // ... other fields
+///     .messages(vec![Message::new(Role::User, "Solve 2x + 5 = 13")])
+///     .reasoning_effort(Effort::High)
 ///     .build()?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -37,10 +37,10 @@
 //! use openrouter_rs::types::tool::ToolChoice;
 //!
 //! // Model chooses whether to use tools
-//! let auto_choice = ToolChoice::Auto;
+//! let auto_choice = ToolChoice::auto();
 //!
 //! // Force model to use tools
-//! let required_choice = ToolChoice::Required;
+//! let required_choice = ToolChoice::required();
 //!
 //! // Force specific tool
 //! let specific_choice = ToolChoice::force_tool("get_weather");
@@ -217,13 +217,13 @@ impl FunctionDefinitionBuilder {
 /// use openrouter_rs::types::tool::ToolChoice;
 ///
 /// // Let model decide
-/// let auto = ToolChoice::Auto;
+/// let auto = ToolChoice::auto();
 ///
 /// // Prevent tool use
-/// let none = ToolChoice::None;
+/// let none = ToolChoice::none();
 ///
 /// // Require tool use
-/// let required = ToolChoice::Required;
+/// let required = ToolChoice::required();
 ///
 /// // Force specific tool
 /// let specific = ToolChoice::force_tool("get_weather");


### PR DESCRIPTION
## Summary
- repair rustdoc examples across the public SDK surface so they compile against the current API
- mark live async snippets as no-run where they require network access
- fix stale enum, builder, and helper examples in types and tool docs

## Testing
- cargo test --doc
- cargo test --test unit

Closes #119