### PR TITLE
ci: add doctest coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run unit tests
         run: cargo test --test unit
 
+      - name: Run doctests
+        run: cargo test --doc
+
       - name: Run deterministic integration subsets
         run: |
           cargo test --test integration model_pool:: -- --nocapture


### PR DESCRIPTION
## Summary
- add cargo test --doc to the main CI lint-and-unit job
- close the last remaining gap from the OR-40 audit epic by enforcing doctest coverage in CI

## Testing
- cargo test --doc
- cargo test --test unit

Closes #113