### PR TITLE
docs: add contributor and maintenance policy docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+See `CONTRIBUTING.md` and `docs/maintenance-policy.md` for contributor workflow, release expectations, MSRV policy, and breaking-change guidance.
+
 ## Summary
 - What problem does this PR solve?
 - What is the high-level approach?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to openrouter-rs
+
+Thanks for improving `openrouter-rs` and `openrouter-cli`.
+
+This repository contains two closely related surfaces:
+
+- `openrouter-rs`: the Rust SDK
+- `openrouter-cli`: the workspace CLI companion
+
+The best contributions keep one change focused, keep docs/examples in sync with behavior, and stay aligned with the repo's CI entrypoints.
+
+## Before You Start
+
+- Search existing issues and pull requests before starting overlapping work.
+- For larger changes, especially public API changes or behavior changes, open or reference an issue first.
+- Keep pull requests tightly scoped. Splitting refactors from behavioral changes makes review much easier.
+- Never commit real API keys, management keys, or other secrets.
+
+## Local Setup
+
+Requirements:
+
+- Rust `1.85+`
+- `just`
+- `OPENROUTER_API_KEY` for live API-backed examples and tests
+- `OPENROUTER_MANAGEMENT_KEY` for management-governed live tests
+
+Useful commands:
+
+```bash
+just quality
+just quality-ci
+just test-live-contract
+OPENROUTER_MANAGEMENT_KEY=... just test-live-contract-management
+```
+
+Prefer the `just` recipes over ad hoc command sequences so local validation stays aligned with CI.
+
+## Validation Expectations
+
+For most changes:
+
+- run `just quality`
+
+Also run `just quality-ci` if you changed:
+
+- CLI behavior or CLI docs
+- migration docs or migration shims
+- CI/release workflows
+- release-facing documentation or validation flows
+
+Live integration suites are valuable, but they require credentials and may exercise billable upstream APIs. If you cannot run them locally, say so clearly in the pull request.
+
+## Change-Type Expectations
+
+If you change public API surface:
+
+- update the relevant README/docs in the same change
+- update examples if the canonical usage changed
+- update `CHANGELOG.md`
+- call out any compatibility risk explicitly in the PR
+
+If you change CLI behavior:
+
+- update [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md)
+- keep JSON/table output expectations and config resolution behavior explicit
+
+If you change migration-sensitive behavior:
+
+- update [`MIGRATION.md`](MIGRATION.md) when needed
+- run `just check-migration-docs`
+- run `just test-migration-smoke`
+
+If you change docs/examples only:
+
+- prefer small, concrete examples over aspirational or pseudo-code-heavy docs
+- keep README and example names aligned
+
+## Pull Requests
+
+- Link the relevant issue in the PR body.
+- Use the existing PR template and fill out the validation section honestly.
+- Mark breaking changes clearly.
+- Keep unrelated cleanup out of behavior-changing PRs unless the cleanup is required for the change.
+
+Reviewers will usually look for:
+
+- correctness and compatibility risk first
+- docs/examples consistency
+- tests or validation appropriate to the change
+- explicit migration notes when behavior changes are user-visible
+
+## Project Policies
+
+Contributor-facing project policies live here:
+
+- [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for release, MSRV, and breaking-change policy
+- [`SECURITY.md`](SECURITY.md) for vulnerability reporting and coordinated disclosure expectations
+- [`SUPPORT.md`](SUPPORT.md) for usage questions, bug reports, and support boundaries
+
+## Support Boundaries
+
+This repository can fix SDK/CLI bugs, docs gaps, and compatibility issues in the Rust surfaces it owns.
+
+Upstream platform issues, account issues, provider outages, billing questions, and OpenRouter service incidents may need to be handled by OpenRouter directly unless there is a clear SDK/CLI bug in this repository.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ See [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md) for the
 - Migration guidance for the `0.5.x -> 0.6.x` transition lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
 
+### 🔁 0.6 Naming/Pagination Migration
+
+Full migration guide: [`MIGRATION.md`](MIGRATION.md)
+
+- `models().count()` -> `models().get_model_count()`
+- `models().list_for_user()` -> `models().list_user_models()`
+- `management().exchange_code_for_api_key(...)` -> `management().create_api_key_from_auth_code(...)`
+- `management().list_guardrails(offset, limit)` -> `management().list_guardrails(Some(PaginationOptions::with_offset_and_limit(offset, limit)))`
+- `client.list_api_keys(offset, include_disabled)` -> `management().list_api_keys(Some(PaginationOptions::with_offset(offset)), include_disabled)`
+
+`0.6.0` removed the transitional aliases above; use the canonical method names shown here.
+
 ## Development
 
 Prefer the `just` recipes so local work stays aligned with CI:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, embeddings, and ZDR endpoints
-- management-key workflows for keys, auth codes, guardrails, activity, credits, and generation
+- management-key workflows for keys, auth codes, guardrails, and activity, plus API-key-authenticated credits and generation endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,36 @@
-# OpenRouter Rust SDK
+# openrouter-rs
 
 <div align="center">
 
-Type-safe, async Rust bindings for the OpenRouter API.
+Type-safe, async Rust SDK for the OpenRouter API.
 
 [![Crates.io](https://img.shields.io/crates/v/openrouter-rs)](https://crates.io/crates/openrouter-rs)
 [![Documentation](https://docs.rs/openrouter-rs/badge.svg)](https://docs.rs/openrouter-rs)
+[![CI](https://github.com/realmorrisliu/openrouter-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/realmorrisliu/openrouter-rs/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [docs.rs](https://docs.rs/openrouter-rs) |
 [examples](https://github.com/realmorrisliu/openrouter-rs/tree/main/examples) |
-[crate](https://crates.io/crates/openrouter-rs)
+[crate](https://crates.io/crates/openrouter-rs) |
+[openrouter-cli](https://github.com/realmorrisliu/openrouter-rs/tree/main/crates/openrouter-cli) |
+[contributing](CONTRIBUTING.md) |
+[endpoint matrix](docs/official-endpoint-test-matrix.md) |
+[changelog](CHANGELOG.md)
 
 </div>
 
-`openrouter-rs` is built around the canonical `0.7.x` domain-oriented client surface:
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-- `client.chat()` for `POST /chat/completions`
-- `client.responses()` for `POST /responses`
-- `client.messages()` for Anthropic-compatible `POST /messages`
-- `client.models()` for model discovery and embeddings
-- `client.management()` for auth-code, API-key, guardrail, activity, and account-management flows
-- `client.legacy()` for `POST /completions` when `legacy-completions` is explicitly enabled
+The current repo snapshot implements `36 / 36` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md).
 
-The crate ships typed request/response models, builder-based ergonomics, streaming support, typed tools, multimodal chat content, and complete endpoint coverage for the current repository snapshot. The implementation map and live-test status live in [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md).
+## Why `openrouter-rs`
+
+- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `models()`, `management()`, and opt-in `legacy()`
+- Typed request/response models with builder-style ergonomics
+- Streaming support for chat, responses, and messages, including a unified stream abstraction
+- Typed tools, manual JSON-schema tools, and multimodal chat content
+- Discovery, embeddings, API-key management, guardrails, activity, credits, and generation coverage
+- A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
 
@@ -40,6 +47,13 @@ Legacy text completions are opt-in:
 openrouter-rs = { version = "0.7.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
+
+Requirements:
+
+- Rust `1.85+`
+- Tokio `1.x`
+- `OPENROUTER_API_KEY` for API-backed examples and live tests
+- `OPENROUTER_MANAGEMENT_KEY` for management-governed examples and tests
 
 ## Quick Start
 
@@ -73,9 +87,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-## Design Overview
+The SDK keeps setup intentionally narrow: configure runtime values on `OpenRouterClient::builder()`, then choose the final `model` on each request builder. File/profile config resolution belongs in the companion CLI or in your application layer, not in the SDK core.
 
-The main design direction in `0.7.x` is that public documentation and examples treat the domain clients as the canonical surface. Flat `OpenRouterClient::*` helpers still exist in places, but they are not the recommended path for new code.
+## API Surface
+
+The canonical public surface in `0.7.x` is domain-oriented:
 
 | Domain | Canonical methods | Primary endpoints | Auth note |
 | --- | --- | --- | --- |
@@ -86,7 +102,7 @@ The main design direction in `0.7.x` is that public documentation and examples t
 | `management()` | `create_api_key`, `list_api_keys`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/activity`, `/credits*`, `/generation`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
-The client builder exposes the runtime options the SDK directly consumes:
+At runtime, the builder/client exposes the values the SDK directly consumes:
 
 - `base_url`
 - `api_key`
@@ -94,278 +110,57 @@ The client builder exposes the runtime options the SDK directly consumes:
 - `http_referer`
 - `x_title`
 
-At runtime you can also call `set_api_key`, `clear_api_key`, `set_management_key`, and `clear_management_key`.
+## Common Workflows
 
-## Core Workflows
+`openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:
 
-### Streaming
+- chat completions, responses, and Anthropic-compatible messages
+- unified streaming across chat, responses, and messages
+- manual tools and typed tools backed by `schemars`
+- multimodal chat content, including image, audio, video, and file parts
+- model discovery, provider discovery, embeddings, and ZDR endpoints
+- management-key workflows for keys, auth codes, guardrails, activity, credits, and generation
 
-The SDK exposes three useful streaming layers:
-
-1. Raw endpoint streams:
-   - `chat().stream(...)`
-   - `responses().stream(...)`
-   - `messages().stream(...)`
-2. Tool-aware chat aggregation:
-   - `chat().stream_tool_aware(...)`
-3. A unified event model across chat, responses, and messages:
-   - `chat().stream_unified(...)`
-   - `responses().stream_unified(...)`
-   - `messages().stream_unified(...)`
-
-```rust
-use futures_util::StreamExt;
-use openrouter_rs::types::stream::UnifiedStreamEvent;
-
-let mut stream = client.chat().stream_unified(&request).await?;
-
-while let Some(event) = stream.next().await {
-    match event {
-        UnifiedStreamEvent::ContentDelta(text) => print!("{text}"),
-        UnifiedStreamEvent::ReasoningDelta(text) => eprint!("[reasoning]{text}"),
-        UnifiedStreamEvent::Done { .. } => break,
-        UnifiedStreamEvent::Error(err) => {
-            eprintln!("stream error: {err}");
-            break;
-        }
-        _ => {}
-    }
-}
-```
-
-### Tool Calling And Typed Tools
-
-Manual tool schemas and typed tools are both first-class:
-
-- `types::Tool` for explicit JSON-schema tool definitions
-- `types::typed_tool::{TypedTool, TypedToolParams}` for Rust-typed tools backed by `schemars`
-
-```rust
-use openrouter_rs::types::typed_tool::{TypedTool, TypedToolParams};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-struct WeatherParams {
-    location: String,
-    unit: Option<String>,
-}
-
-impl TypedTool for WeatherParams {
-    fn name() -> &'static str { "get_weather" }
-    fn description() -> &'static str { "Fetch weather for a location" }
-}
-
-let request = ChatCompletionRequest::builder()
-    .model("anthropic/claude-sonnet-4")
-    .messages(vec![Message::new(Role::User, "Weather in Paris?")])
-    .typed_tool::<WeatherParams>()
-    .build()?;
-```
-
-### Multimodal Chat Content
-
-`api::chat::ContentPart` now covers text, image URLs, audio input, video input, and file payloads.
-
-```rust
-use openrouter_rs::api::chat::ContentPart;
-
-let request = ChatCompletionRequest::builder()
-    .model("anthropic/claude-sonnet-4")
-    .messages(vec![Message::with_parts(
-        Role::User,
-        vec![
-            ContentPart::text("Describe this image."),
-            ContentPart::image_url_with_detail("https://example.com/image.jpg", "high"),
-        ],
-    )])
-    .build()?;
-```
-
-### Responses, Messages, And Embeddings
-
-The current repo has dedicated typed surfaces for the non-chat APIs as well:
-
-```rust
-use openrouter_rs::{
-    api::{
-        embeddings::EmbeddingRequest,
-        messages::{AnthropicMessage, AnthropicMessagesRequest},
-        responses::ResponsesRequest,
-    },
-};
-use serde_json::json;
-
-let responses_request = ResponsesRequest::builder()
-    .model("openai/gpt-5")
-    .input(json!([{ "role": "user", "content": "Say hello." }]))
-    .build()?;
-let _responses = client.responses().create(&responses_request).await?;
-
-let messages_request = AnthropicMessagesRequest::builder()
-    .model("anthropic/claude-sonnet-4")
-    .max_tokens(256)
-    .messages(vec![AnthropicMessage::user("Say hello.")])
-    .build()?;
-let _message = client.messages().create(&messages_request).await?;
-
-let embedding_request = EmbeddingRequest::builder()
-    .model("openai/text-embedding-3-large")
-    .input("OpenRouter Rust SDK")
-    .build()?;
-let _embedding = client.models().create_embedding(&embedding_request).await?;
-```
-
-### Discovery And Management
-
-Discovery and governance endpoints are intentionally separated:
-
-```rust
-use openrouter_rs::{
-    api::guardrails::CreateGuardrailRequest,
-    types::{ModelCategory, PaginationOptions},
-};
-
-let programming_models = client
-    .models()
-    .list_by_category(ModelCategory::Programming)
-    .await?;
-
-let providers = client.models().list_providers().await?;
-let zdr_endpoints = client.models().list_zdr_endpoints().await?;
-
-let keys = client
-    .management()
-    .list_api_keys(Some(PaginationOptions::with_offset_and_limit(0, 25)), Some(false))
-    .await?;
-
-let guardrail = client
-    .management()
-    .create_guardrail(
-        &CreateGuardrailRequest::builder()
-            .name("ci-budget-cap")
-            .limit_usd(25.0)
-            .enforce_zdr(true)
-            .build()?,
-    )
-    .await?;
-```
-
-Management-key reminders:
-
-- `/activity` requires `.management_key(...)`
-- `/keys*` requires `.management_key(...)`
-- `/auth/keys*` requires `.management_key(...)`
-- `/guardrails*` requires `.management_key(...)`
-
-API-key reminders:
-
-- `/credits`
-- `/credits/coinbase`
-- `/generation`
-- `/key`
-
-Those endpoints are grouped under `management()` for discoverability, but the underlying upstream auth model is still API-key based.
-
-## Client Setup
-
-The SDK intentionally keeps setup narrow: configure runtime values on `OpenRouterClient::builder()`, then choose the final `model` on each request builder.
-
-```rust
-use openrouter_rs::OpenRouterClient;
-
-let client = OpenRouterClient::builder()
-    .api_key("your_api_key")
-    .http_referer("https://yourapp.example")
-    .x_title("My App")
-    .build()?;
-
-# Ok::<(), openrouter_rs::error::OpenRouterError>(())
-```
-
-File/profile config resolution belongs to the companion CLI or to the caller's application layer, not to the SDK core.
-
-## Legacy Completions
-
-Legacy `POST /completions` support is isolated behind the `legacy-completions` feature and the explicit legacy namespace.
-
-```rust
-use openrouter_rs::{OpenRouterClient, api::legacy::completion::CompletionRequest};
-
-let request = CompletionRequest::builder()
-    .model("deepseek/deepseek-chat-v3-0324:free")
-    .prompt("Once upon a time")
-    .build()?;
-
-let response = client.legacy().completions().create(&request).await?;
-```
-
-For new applications, prefer `chat()` or `responses()`.
-
-### 🔁 0.6 Naming/Pagination Migration
-
-Full migration guide: [MIGRATION.md](./MIGRATION.md)
-
-- `models().count()` -> `models().get_model_count()`
-- `models().list_for_user()` -> `models().list_user_models()`
-- `management().exchange_code_for_api_key(...)` -> `management().create_api_key_from_auth_code(...)`
-- `management().list_guardrails(offset, limit)` -> `management().list_guardrails(Some(PaginationOptions::with_offset_and_limit(offset, limit)))`
-- `client.list_api_keys(offset, include_disabled)` -> `management().list_api_keys(Some(PaginationOptions::with_offset(offset)), include_disabled)`
-
-`0.6.0` removes the transitional aliases above; use the canonical method names shown in the mapping list.
-
-Migration validation commands for contributors:
-
-```bash
-./scripts/check_migration_docs.sh
-cargo test --test migration_smoke --all-features
-```
+For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 
 ## Examples
 
-The repo includes runnable examples for the canonical flows:
+The repo includes runnable examples for the highest-value workflows:
 
 | Example | Focus |
 | --- | --- |
-| `examples/domain_chat_completion.rs` | Canonical `chat()` usage |
-| `examples/basic_tool_calling.rs` | Manual tool-calling loop |
-| `examples/typed_tool_calling.rs` | Typed tools with generated schema |
-| `examples/chat_with_reasoning.rs` | Reasoning controls |
-| `examples/stream_chat_completion.rs` | Raw chat streaming |
-| `examples/stream_chat_with_tools.rs` | `ToolAwareStream` |
-| `examples/create_response.rs` | `responses()` create |
-| `examples/stream_response.rs` | `responses()` streaming |
-| `examples/create_message.rs` | `messages()` create |
-| `examples/stream_messages.rs` | `messages()` streaming |
-| `examples/create_embedding.rs` | `models().create_embedding(...)` |
-| `examples/domain_management_api_keys.rs` | API-key management via `management()` |
-| `examples/exchange_code_for_api_key.rs` | PKCE/auth-code flow |
-| `examples/send_completion_request.rs` | Legacy completions (`legacy-completions` required) |
+| [`examples/domain_chat_completion.rs`](examples/domain_chat_completion.rs) | Canonical `chat()` usage |
+| [`examples/stream_chat_completion.rs`](examples/stream_chat_completion.rs) | Raw chat streaming |
+| [`examples/stream_chat_with_tools.rs`](examples/stream_chat_with_tools.rs) | Tool-aware streaming aggregation |
+| [`examples/basic_tool_calling.rs`](examples/basic_tool_calling.rs) | Manual tool-calling loop |
+| [`examples/typed_tool_calling.rs`](examples/typed_tool_calling.rs) | Typed tools with generated schema |
+| [`examples/create_response.rs`](examples/create_response.rs) | `responses()` create |
+| [`examples/stream_response.rs`](examples/stream_response.rs) | `responses()` streaming |
+| [`examples/create_message.rs`](examples/create_message.rs) | `messages()` create |
+| [`examples/stream_messages.rs`](examples/stream_messages.rs) | `messages()` streaming |
+| [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
+| [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
+| [`examples/exchange_code_for_api_key.rs`](examples/exchange_code_for_api_key.rs) | PKCE/auth-code flow |
+| [`examples/send_completion_request.rs`](examples/send_completion_request.rs) | Legacy completions (`legacy-completions` required) |
 
-Local commands:
+Typical local usage:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-v1-...
 
 cargo run --example domain_chat_completion
-cargo run --example basic_tool_calling
-cargo run --example typed_tool_calling
-cargo run --example chat_with_reasoning
 cargo run --example stream_chat_completion
-cargo run --example stream_chat_with_tools
+cargo run --example typed_tool_calling
 cargo run --example create_response
-cargo run --example stream_response
 cargo run --example create_message
-cargo run --example stream_messages
 cargo run --example create_embedding
-cargo run --features legacy-completions --example send_completion_request
 ```
 
 ## CLI Companion
 
 This workspace also contains [`crates/openrouter-cli`](crates/openrouter-cli), a companion CLI for profile resolution, discovery, management, and usage/billing workflows.
 
-Useful entrypoints:
+Examples:
 
 ```bash
 cargo run -p openrouter-cli -- --help
@@ -375,16 +170,18 @@ cargo run -p openrouter-cli -- keys list --include-disabled
 cargo run -p openrouter-cli -- usage activity --date 2026-03-01
 ```
 
-CLI auth/config precedence is deterministic:
+See [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md) for the full command surface and config/auth precedence rules.
 
-1. Flags: `--api-key`, `--management-key`, `--base-url`
-2. Environment: `OPENROUTER_API_KEY`, `OPENROUTER_MANAGEMENT_KEY`, `OPENROUTER_BASE_URL`
-3. Profile config values from `profiles.toml`
-4. Default `base_url`
+## Project Status
 
-See [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md) for the full command surface.
+- Community-maintained third-party SDK; not affiliated with OpenRouter
+- Canonical docs and examples prefer the domain clients over older flat helpers
+- Full endpoint coverage is tracked against the current OpenAPI snapshot
+- Live integration coverage and gaps are published in [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md)
+- Migration guidance for the `0.5.x -> 0.6.x` transition lives in [`MIGRATION.md`](MIGRATION.md)
+- Legacy `POST /completions` support remains available behind the `legacy-completions` feature
 
-## Testing And Quality
+## Development
 
 Prefer the `just` recipes so local work stays aligned with CI:
 
@@ -408,57 +205,34 @@ Focused commands:
 
 Environment and model-pool details live in [`tests/integration/README.md`](tests/integration/README.md). A starter env file lives at [`.env.example`](.env.example).
 
-## Repo Docs
+## Repository Docs
 
-- [MIGRATION.md](MIGRATION.md) for `0.5.x -> 0.6.0`
-- [docs/official-endpoint-test-matrix.md](docs/official-endpoint-test-matrix.md) for endpoint-by-endpoint implementation/test status
-- [tests/integration/README.md](tests/integration/README.md) for live test pools and env switches
-- [crates/openrouter-cli/README.md](crates/openrouter-cli/README.md) for CLI behavior and examples
-- [CHANGELOG.md](CHANGELOG.md) for release-by-release changes
+- [`MIGRATION.md`](MIGRATION.md) for migration guidance
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor workflow and review expectations
+- [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for release, MSRV, and breaking-change policy
+- [`SECURITY.md`](SECURITY.md) for vulnerability reporting
+- [`SUPPORT.md`](SUPPORT.md) for support boundaries and issue-reporting guidance
+- [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md) for endpoint-by-endpoint implementation and test status
+- [`tests/integration/README.md`](tests/integration/README.md) for live test pools and env switches
+- [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md) for CLI behavior and examples
+- [`CHANGELOG.md`](CHANGELOG.md) for release-by-release changes
 
 ## Contributing
 
-When you change API surface or examples:
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full contributor workflow.
+
+At a minimum, if you change public API surface, examples, or docs:
 
 - update the relevant README/docs in the same change
 - run `just quality`
 - run `just quality-ci` if you touched migration docs, CLI behavior, or CI-aligned release/test flows
 
-## Requirements
+Related policies:
 
-- Rust `1.85+`
-- Tokio `1.x`
-- An `OPENROUTER_API_KEY` for API-backed examples and live tests
-- An `OPENROUTER_MANAGEMENT_KEY` for management-governed examples/tests
-
-## 📈 Release History
-
-### Version 0.7.0 *(Latest)*
-
-- Removed the SDK-level `config` module so file/profile config resolution now lives in the companion CLI or the caller's application layer.
-- Fixed structured assistant `content` parsing and normalized `HTTP 200` error payloads into proper API errors.
-- Moved hot live integrations to a Responses-first model pool with candidate health checks.
-
-### Version 0.6.1
-
-- Fixed `ToolBuilder` field loss when setters are called in different orders.
-- Preserved combined model filters and model resolution ordering, and propagated default headers to chat streaming requests.
-- Hardened SSE frame parsing, normalized response parsing errors across endpoints, and aligned release validation around `just` plus live contract checks.
-
-### Version 0.6.0
-
-- Removed `0.5.x` compatibility aliases, made `legacy-completions` opt-in, and standardized the canonical domain-client documentation around `chat()`, `responses()`, `messages()`, `models()`, and `management()`.
-
-### Version 0.5.2
-
-- Added `/messages`, discovery/activity, guardrails, auth-code flows, unified streaming, CLI foundation, and the `0.5.x -> 0.6.0` migration bridge.
-
-See [CHANGELOG.md](CHANGELOG.md) for the full history.
+- [`docs/maintenance-policy.md`](docs/maintenance-policy.md)
+- [`SECURITY.md`](SECURITY.md)
+- [`SUPPORT.md`](SUPPORT.md)
 
 ## License
 
 MIT. See [LICENSE](LICENSE).
-
-## Disclaimer
-
-This is a third-party SDK and is not affiliated with OpenRouter.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported Versions
+
+This project currently supports the latest released minor line of `openrouter-rs` and `openrouter-cli`.
+
+| Version line | Status |
+| --- | --- |
+| Latest released minor line of `openrouter-rs` | Supported |
+| Latest released minor line of `openrouter-cli` | Supported |
+| Older release lines | Upgrade first, then report if the issue still reproduces |
+| Unreleased `main` | Best effort during active development |
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for a suspected security vulnerability.
+
+Instead:
+
+- use GitHub's private vulnerability reporting for this repository if it is available, or
+- email `morrisliu1994@outlook.com`
+
+Please include:
+
+- affected crate or CLI surface
+- affected version(s)
+- a minimal reproduction or proof of concept
+- impact and expected risk
+- any relevant request IDs, logs, or screenshots with secrets redacted
+
+## Response Expectations
+
+Security reports are handled on a best-effort basis.
+
+The normal expectation is:
+
+- acknowledge receipt within 5 business days
+- request clarification or a reproduction if needed
+- coordinate on disclosure timing when the report is valid
+- publish a fix and then disclose publicly once users have a reasonable upgrade path
+
+## Scope
+
+This policy covers:
+
+- `openrouter-rs`
+- `openrouter-cli`
+- release artifacts produced from this repository
+- repository documentation or examples that would cause insecure usage if followed as written
+
+This policy does not replace OpenRouter's own security handling for upstream platform or provider incidents unless the issue is specifically caused by this SDK/CLI repository.
+
+## Secrets
+
+- Never include real API keys, management keys, or tokens in reports.
+- Redact request IDs, logs, and payloads as needed to avoid leaking sensitive data.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,57 @@
+# Support
+
+## Where to Go
+
+Use GitHub issues in this repository for:
+
+- SDK bugs or regressions
+- CLI bugs or regressions
+- docs or example problems
+- feature requests for the Rust SDK or CLI
+- migration and compatibility questions specific to this repository
+
+OpenRouter platform, account, billing, or provider-status issues may need to be handled by OpenRouter directly unless there is a clear bug in this repository's Rust surfaces.
+
+## Before Opening an Issue
+
+Please check:
+
+- [`README.md`](README.md)
+- [`MIGRATION.md`](MIGRATION.md)
+- [`tests/integration/README.md`](tests/integration/README.md)
+- [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md)
+- existing issues and recent changelog entries
+
+## What to Include
+
+For bug reports, include as much of the following as you can:
+
+- crate or CLI version
+- Rust version
+- operating system
+- endpoint or command involved
+- model name, if relevant
+- minimal reproduction
+- expected behavior
+- actual behavior
+- relevant request IDs or logs with secrets removed
+
+For CLI issues, also include:
+
+- the exact command you ran
+- whether you used flags, env vars, or profile config
+- whether output mode was `table` or `json`
+
+## Best-Effort Support
+
+Support in this repository is best effort.
+
+Maintainers may ask you to:
+
+- upgrade to the latest release line
+- reduce the report to a minimal reproduction
+- move an upstream platform issue to the appropriate OpenRouter support channel
+
+## Security Issues
+
+For security-sensitive reports, do not file a public issue. Follow [`SECURITY.md`](SECURITY.md) instead.

--- a/docs/maintenance-policy.md
+++ b/docs/maintenance-policy.md
@@ -1,0 +1,58 @@
+# Maintenance Policy
+
+This document describes the repository's contributor-facing maintenance expectations for releases, MSRV, and breaking changes.
+
+## Release Policy
+
+The repository aims to keep `main` in a releasable state.
+
+Contributor expectations:
+
+- run `just quality` for normal changes
+- run `just quality-ci` when touching CLI behavior, migration docs, or CI/release-aligned validation flows
+- update public docs/examples in the same change when public behavior changes
+- update `CHANGELOG.md` for user-visible changes
+
+SDK releases:
+
+- use tags in the form `v<version>`
+- the tag must match the root `Cargo.toml` version
+- the release workflow verifies formatting, clippy, unit tests, and `cargo package --locked`
+- crates.io publishing occurs only when the registry token is configured
+
+CLI releases:
+
+- use tags in the form `openrouter-cli-v<version>`
+- the tag must match `crates/openrouter-cli/Cargo.toml`
+- the CLI release workflow verifies CLI tests, packages the crate, publishes to crates.io, and builds release archives
+
+When a change affects the public API surface, release-facing docs should be updated in the same pull request rather than deferred.
+
+## MSRV Policy
+
+The current MSRV is Rust `1.85`.
+
+MSRV expectations:
+
+- CI enforces the current MSRV for `cargo check` on all targets with default and all features
+- MSRV bumps must update the relevant source of truth, including `Cargo.toml`, CI, and README/docs references
+- MSRV bumps should ship in a new minor release line, not a patch release
+
+If a dependency causes an accidental MSRV regression, the preferred response is to pin, update, or otherwise restore the documented MSRV when feasible.
+
+## Breaking-Change Policy
+
+This project follows Semantic Versioning, with explicit pre-`1.0` expectations:
+
+- patch releases within the same `0.x` line should remain backward compatible except for urgent bug or security fixes
+- user-visible breaking changes require at least a new minor release line
+- when feasible, introduce deprecation bridges before removals instead of removing old APIs immediately
+
+Breaking changes should:
+
+- be called out explicitly in the PR body
+- be documented in `CHANGELOG.md`
+- update README/examples if canonical usage changed
+- update [`MIGRATION.md`](../MIGRATION.md) when a migration path is needed
+
+When a compatibility bridge exists, removals should normally be announced before they are deleted in a later release line.


### PR DESCRIPTION
## Summary
- add contributor-facing `CONTRIBUTING.md`, `SECURITY.md`, and `SUPPORT.md`
- add `docs/maintenance-policy.md` covering release, MSRV, and breaking-change policy
- refresh `README.md` and the PR template to surface the new contributor and maintenance docs

## Related Issues
- Closes #151
- Related to #158

## Changes
- [ ] API behavior changes
- [ ] Type/model changes
- [x] Docs/examples updates
- [x] CI/release changes

## Validation
- [x] `just quality`
- [ ] `just quality-ci` (not run; docs-only change)
- [ ] `cargo test --test integration -- --nocapture` (not run; docs-only change)

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Notes for Reviewers
- This change is intentionally documentation-only.
- The README is now more aligned with community-standard Rust crate structure while issue #151 adds the missing contributor/support/security policy surface.
