### PR TITLE
ci: add nightly OpenAPI drift detection

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.x"
 
       - name: Fetch latest upstream OpenAPI spec
-        run: curl -L "https://openrouter.ai/openapi.json" -o /tmp/openapi-latest.json
+        run: curl --fail --show-error -L "https://openrouter.ai/openapi.json" -o /tmp/openapi-latest.json
 
       - name: Compare upstream spec against tracked baseline
         id: compare

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,0 +1,106 @@
+name: OpenAPI Drift
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: openapi-drift-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  detect-drift:
+    name: Detect OpenAPI Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Fetch latest upstream OpenAPI spec
+        run: curl -L "https://openrouter.ai/openapi.json" -o /tmp/openapi-latest.json
+
+      - name: Compare upstream spec against tracked baseline
+        id: compare
+        run: |
+          python3 scripts/openapi_drift.py compare \
+            --baseline specs/openrouter/openapi-baseline.json \
+            --candidate /tmp/openapi-latest.json \
+            --source-url https://openrouter.ai/openapi.json \
+            --baseline-label "tracked baseline" \
+            --candidate-label "latest upstream" \
+            --report-md /tmp/openapi-drift-report.md \
+            --report-json /tmp/openapi-drift-report.json \
+            --candidate-operations /tmp/openapi-latest.operations.json \
+            --github-output "$GITHUB_OUTPUT" \
+            --step-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload drift report artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-drift-report
+          path: |
+            /tmp/openapi-drift-report.md
+            /tmp/openapi-drift-report.json
+            /tmp/openapi-latest.operations.json
+
+      - name: Open or refresh follow-up issue
+        if: github.event_name == 'schedule' && steps.compare.outputs.has_drift == 'true'
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: /tmp/openapi-drift-report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'chore: review latest OpenRouter OpenAPI drift';
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const maxBodyLength = 60000;
+            const body = [
+              'Detected upstream OpenAPI drift against the tracked baseline.',
+              '',
+              `Workflow run: ${runUrl}`,
+              '',
+              'This issue is maintained automatically by `.github/workflows/openapi-drift.yml`.',
+              '',
+              report.length > maxBodyLength
+                ? `${report.slice(0, maxBodyLength)}\n\n... report truncated; see workflow artifact for the full diff ...`
+                : report,
+            ].join('\n');
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = issues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ['ci', 'migration'],
+            });

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -79,14 +79,19 @@ jobs:
                 : report,
             ].join('\n');
 
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              per_page: 100,
-            });
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              },
+            );
 
-            const existing = issues.find((issue) => issue.title === title);
+            const existing = issues.find(
+              (issue) => !issue.pull_request && issue.title === title,
+            );
             if (existing) {
               await github.rest.issues.update({
                 owner,

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .env.*
 !.env.example
 !.env.template
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Environment and model-pool details live in [`tests/integration/README.md`](tests
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor workflow and review expectations
 - [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for release, MSRV, and breaking-change policy
 - [`docs/community/awesome-openrouter/README.md`](docs/community/awesome-openrouter/README.md) for the Awesome OpenRouter submission kit and directory-safe assets
+- [`docs/openapi-drift-reporting.md`](docs/openapi-drift-reporting.md) for nightly upstream-spec drift detection and baseline refresh workflow
 - [`SECURITY.md`](SECURITY.md) for vulnerability reporting
 - [`SUPPORT.md`](SUPPORT.md) for support boundaries and issue-reporting guidance
 - [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md) for endpoint-by-endpoint implementation and test status

--- a/docs/official-endpoint-test-matrix.md
+++ b/docs/official-endpoint-test-matrix.md
@@ -1,7 +1,9 @@
 # Official Endpoint Test Matrix
 
 Snapshot date: 2026-03-10  
-Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)
+Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
+Tracked baseline: `specs/openrouter/openapi-baseline.json`  
+Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
@@ -82,3 +84,5 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 curl -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.json
 jq -r '.paths | to_entries[] | .key as $p | (.value | keys[] | select(. != "parameters")) as $m | "\($m|ascii_upcase) \($p)"' /tmp/openrouter-openapi.json | sort
 ```
+
+For the repo-level drift report and baseline refresh flow, see [`docs/openapi-drift-reporting.md`](openapi-drift-reporting.md).

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -20,8 +20,13 @@ This keeps `openrouter-rs` aligned with upstream changes without blocking releas
 - Nightly workflow: `.github/workflows/openapi-drift.yml`
 
 The comparison is operation-level (`METHOD /path`). It first resolves local `#/components/...`
-references, including referenced Path Item objects, then folds in inherited Path Item fields
-(`parameters` and `servers`) before hashing, and intentionally ignores docs-only fields:
+references, including referenced Path Item objects, then folds in effective defaults before hashing:
+
+- Path Item inheritance: `parameters`, `servers`
+- OpenAPI root defaults: `servers`, `security`
+- Referenced security scheme definitions for the effective `security` requirements
+
+It intentionally ignores docs-only fields:
 
 - `summary`
 - `description`

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -25,6 +25,7 @@ references, including referenced Path Item objects, then folds in effective defa
 - Path Item inheritance: `parameters`, `servers`
 - OpenAPI root defaults: `servers`, `security`
 - Referenced security scheme definitions for the effective `security` requirements
+- Order-insensitive canonicalization for `parameters` and `security` requirement lists
 
 It intentionally ignores docs-only fields:
 

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -26,6 +26,7 @@ references, including referenced Path Item objects, then folds in effective defa
 - OpenAPI root defaults: `servers`, `security`
 - Referenced security scheme definitions for the effective `security` requirements
 - Order-insensitive canonicalization for `parameters` and `security` requirement lists
+- Order-insensitive canonicalization for known unordered JSON Schema collections such as `required`, `enum`, `type`, `allOf`, `anyOf`, and `oneOf`
 
 It intentionally ignores docs-only fields:
 

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -1,0 +1,81 @@
+# OpenAPI Drift Reporting
+
+`openrouter-rs` tracks a checked-in OpenRouter OpenAPI baseline and compares it against the latest upstream spec on a nightly schedule.
+
+## Why This Exists
+
+The endpoint matrix is useful, but it is static until someone remembers to refresh it. The drift workflow closes that gap:
+
+- it fetches the latest upstream `openapi.json`
+- it compares the latest upstream operations against the tracked baseline
+- it emits a human-readable report and a machine-readable JSON summary
+- it can open or refresh a follow-up GitHub issue when drift is detected
+
+This keeps `openrouter-rs` aligned with upstream changes without blocking releases on every spec delta.
+
+## Tracked Baseline
+
+- Tracked baseline snapshot: `specs/openrouter/openapi-baseline.json`
+- Normalized operation snapshot: `specs/openrouter/openapi-baseline.operations.json`
+- Nightly workflow: `.github/workflows/openapi-drift.yml`
+
+The comparison is operation-level (`METHOD /path`). It resolves local `#/components/...`
+references before hashing and intentionally ignores docs-only fields:
+
+- `summary`
+- `description`
+- `title`
+- `example`
+- `examples`
+- `externalDocs`
+
+That keeps the report focused on compatibility-relevant API changes rather than upstream prose edits.
+
+The initial tracked baseline is intentionally seeded from the accepted endpoint matrix rather
+than silently fast-forwarded to whatever the latest upstream spec happens to contain. Baseline
+refresh is an explicit review step, not an automatic side effect of detection.
+
+## Local Commands
+
+Compare the tracked baseline against the latest upstream spec:
+
+```bash
+just openapi-drift-check
+```
+
+This writes a report to:
+
+- `/tmp/openrouter-openapi-drift-report.md`
+- `/tmp/openrouter-openapi-drift-report.json`
+- `/tmp/openrouter-openapi-latest.operations.json`
+
+Refresh the tracked baseline after reviewing and accepting upstream changes:
+
+```bash
+just openapi-refresh-baseline
+```
+
+That updates:
+
+- `specs/openrouter/openapi-baseline.json`
+- `specs/openrouter/openapi-baseline.operations.json`
+
+## Follow-Up Flow
+
+When the nightly workflow reports drift:
+
+1. Review the generated report and candidate operations snapshot artifact.
+2. Update `docs/official-endpoint-test-matrix.md` if the upstream operation surface changed.
+3. Decide whether the SDK, tests, docs, or migration notes need follow-up work.
+4. If the change is accepted as the new baseline, run `just openapi-refresh-baseline` and commit the refreshed artifacts.
+
+## Relationship To The Endpoint Matrix
+
+The drift workflow does not replace [`docs/official-endpoint-test-matrix.md`](official-endpoint-test-matrix.md).
+
+Their roles are different:
+
+- Drift reporting answers: "Did the upstream OpenAPI change?"
+- The endpoint matrix answers: "Do we implement and test that surface today?"
+
+When the drift report changes, the matrix is the next review surface.

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -19,9 +19,9 @@ This keeps `openrouter-rs` aligned with upstream changes without blocking releas
 - Normalized operation snapshot: `specs/openrouter/openapi-baseline.operations.json`
 - Nightly workflow: `.github/workflows/openapi-drift.yml`
 
-The comparison is operation-level (`METHOD /path`). It first folds in inherited Path Item fields
-(`parameters` and `servers`), then resolves local `#/components/...` references before hashing,
-and intentionally ignores docs-only fields:
+The comparison is operation-level (`METHOD /path`). It first resolves local `#/components/...`
+references, including referenced Path Item objects, then folds in inherited Path Item fields
+(`parameters` and `servers`) before hashing, and intentionally ignores docs-only fields:
 
 - `summary`
 - `description`

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -19,8 +19,9 @@ This keeps `openrouter-rs` aligned with upstream changes without blocking releas
 - Normalized operation snapshot: `specs/openrouter/openapi-baseline.operations.json`
 - Nightly workflow: `.github/workflows/openapi-drift.yml`
 
-The comparison is operation-level (`METHOD /path`). It resolves local `#/components/...`
-references before hashing and intentionally ignores docs-only fields:
+The comparison is operation-level (`METHOD /path`). It first folds in inherited Path Item fields
+(`parameters` and `servers`), then resolves local `#/components/...` references before hashing,
+and intentionally ignores docs-only fields:
 
 - `summary`
 - `description`

--- a/justfile
+++ b/justfile
@@ -54,6 +54,26 @@ check-migration-docs:
 test-migration-smoke:
     cargo test --test migration_smoke --all-features
 
+openapi-refresh-baseline:
+    curl -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
+    python3 scripts/openapi_drift.py refresh-baseline \
+        --source-file /tmp/openrouter-openapi.latest.json \
+        --baseline-json specs/openrouter/openapi-baseline.json \
+        --operations-json specs/openrouter/openapi-baseline.operations.json
+
+openapi-drift-check:
+    curl -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
+    python3 scripts/openapi_drift.py compare \
+        --baseline specs/openrouter/openapi-baseline.json \
+        --candidate /tmp/openrouter-openapi.latest.json \
+        --source-url https://openrouter.ai/openapi.json \
+        --baseline-label "tracked baseline" \
+        --candidate-label "latest upstream" \
+        --report-md /tmp/openrouter-openapi-drift-report.md \
+        --report-json /tmp/openrouter-openapi-drift-report.json \
+        --candidate-operations /tmp/openrouter-openapi-latest.operations.json \
+        --fail-on-drift
+
 quality: fmt-check check clippy test-unit test-lib test-doc
 
 quality-ci: quality test-integration-subsets test-cli check-migration-docs test-migration-smoke

--- a/justfile
+++ b/justfile
@@ -55,14 +55,14 @@ test-migration-smoke:
     cargo test --test migration_smoke --all-features
 
 openapi-refresh-baseline:
-    curl -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
+    curl --fail --show-error -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
     python3 scripts/openapi_drift.py refresh-baseline \
         --source-file /tmp/openrouter-openapi.latest.json \
         --baseline-json specs/openrouter/openapi-baseline.json \
         --operations-json specs/openrouter/openapi-baseline.operations.json
 
 openapi-drift-check:
-    curl -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
+    curl --fail --show-error -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
     python3 scripts/openapi_drift.py compare \
         --baseline specs/openrouter/openapi-baseline.json \
         --candidate /tmp/openrouter-openapi.latest.json \

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -217,6 +217,44 @@ def normalize_security_order(security: Any) -> Any:
     return sorted(normalized_requirements, key=canonical_json)
 
 
+def canonicalize_unordered_schema_collections(value: Any, key: str | None = None) -> Any:
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for child_key, child_value in value.items():
+            normalized[child_key] = canonicalize_unordered_schema_collections(
+                child_value,
+                child_key,
+            )
+
+        dependent_required = normalized.get("dependentRequired")
+        if isinstance(dependent_required, dict):
+            normalized["dependentRequired"] = {
+                dependency_key: canonicalize_unordered_schema_collections(
+                    dependency_value,
+                    "required",
+                )
+                for dependency_key, dependency_value in dependent_required.items()
+            }
+
+        return normalized
+
+    if isinstance(value, list):
+        normalized_items = [
+            canonicalize_unordered_schema_collections(item)
+            for item in value
+        ]
+
+        if key in {"required", "enum", "type"}:
+            return sorted(normalized_items, key=canonical_json)
+
+        if key in {"allOf", "anyOf", "oneOf"}:
+            return sorted(normalized_items, key=canonical_json)
+
+        return normalized_items
+
+    return value
+
+
 def collect_effective_security_schemes(
     effective_security: Any,
     spec: dict[str, Any],
@@ -292,7 +330,8 @@ def normalize_path_item(path_item: dict[str, Any], spec: dict[str, Any]) -> dict
 
 def normalize_operation(raw_operation: dict[str, Any], path_item: dict[str, Any], spec: dict[str, Any]) -> Any:
     inherited_operation = inherit_effective_operation_fields(raw_operation, path_item, spec)
-    return strip_doc_only_fields(inherited_operation)
+    normalized_operation = strip_doc_only_fields(inherited_operation)
+    return canonicalize_unordered_schema_collections(normalized_operation)
 
 
 def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import difflib
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+UPSTREAM_OPENAPI_URL = "https://openrouter.ai/openapi.json"
+HTTP_METHODS = ("get", "post", "put", "patch", "delete", "options", "head", "trace")
+DOC_ONLY_FIELDS = {"description", "example", "examples", "externalDocs", "summary", "title"}
+BASELINE_TOP_LEVEL_FIELDS = (
+    "components",
+    "info",
+    "jsonSchemaDialect",
+    "openapi",
+    "paths",
+    "servers",
+    "tags",
+)
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    ensure_parent(path)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def write_text(path: Path, payload: str) -> None:
+    ensure_parent(path)
+    path.write_text(payload, encoding="utf-8")
+
+
+def fetch_spec(url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(url) as response:
+        return json.load(response)
+
+
+def strip_doc_only_fields(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: strip_doc_only_fields(item)
+            for key, item in value.items()
+            if key not in DOC_ONLY_FIELDS
+        }
+
+    if isinstance(value, list):
+        return [strip_doc_only_fields(item) for item in value]
+
+    return value
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def short_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()[:16]
+
+
+def decode_json_pointer_token(token: str) -> str:
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def resolve_json_pointer(document: dict[str, Any], pointer: str) -> Any:
+    if not pointer.startswith("#/"):
+        raise ValueError(f"Only local JSON pointers are supported, got: {pointer}")
+
+    current: Any = document
+    for token in pointer[2:].split("/"):
+        current = current[decode_json_pointer_token(token)]
+    return current
+
+
+def resolve_local_refs(value: Any, document: dict[str, Any], active_refs: frozenset[str] = frozenset()) -> Any:
+    if isinstance(value, dict):
+        ref = value.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            if ref in active_refs:
+                return {"$ref": ref}
+
+            resolved = resolve_local_refs(
+                resolve_json_pointer(document, ref),
+                document,
+                active_refs | {ref},
+            )
+            siblings = {
+                key: resolve_local_refs(item, document, active_refs)
+                for key, item in value.items()
+                if key != "$ref"
+            }
+
+            if siblings and isinstance(resolved, dict):
+                merged = dict(resolved)
+                merged.update(siblings)
+                return merged
+
+            if siblings:
+                return {"allOf": [resolved], **siblings}
+
+            return resolved
+
+        return {
+            key: resolve_local_refs(item, document, active_refs)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [resolve_local_refs(item, document, active_refs) for item in value]
+
+    return value
+
+
+def normalize_operation(raw_operation: dict[str, Any], spec: dict[str, Any]) -> Any:
+    return strip_doc_only_fields(resolve_local_refs(raw_operation, spec))
+
+
+def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    operations: dict[str, dict[str, Any]] = {}
+
+    for path, path_item in sorted(spec.get("paths", {}).items()):
+        for method in HTTP_METHODS:
+            if method not in path_item:
+                continue
+
+            raw_operation = path_item[method]
+            normalized = normalize_operation(raw_operation, spec)
+            operation_key = f"{method.upper()} {path}"
+            operations[operation_key] = {
+                "id": operation_key,
+                "method": method.upper(),
+                "path": path,
+                "operation_id": raw_operation.get("operationId"),
+                "tags": raw_operation.get("tags", []),
+                "deprecated": raw_operation.get("deprecated", False),
+                "fingerprint": short_hash(normalized),
+                "normalized": normalized,
+            }
+
+    return operations
+
+
+def reduce_spec_for_baseline(spec: dict[str, Any]) -> dict[str, Any]:
+    reduced = {field: spec[field] for field in BASELINE_TOP_LEVEL_FIELDS if field in spec}
+    reduced["paths"] = spec.get("paths", {})
+    return reduced
+
+
+def build_snapshot(spec: dict[str, Any], source_url: str) -> dict[str, Any]:
+    operations = collect_operations(spec)
+    return {
+        "captured_at": utc_now_iso(),
+        "info": spec.get("info", {}),
+        "operation_count": len(operations),
+        "operations": [
+            {
+                "deprecated": operation["deprecated"],
+                "fingerprint": operation["fingerprint"],
+                "id": operation["id"],
+                "method": operation["method"],
+                "operation_id": operation["operation_id"],
+                "path": operation["path"],
+                "tags": operation["tags"],
+            }
+            for _, operation in sorted(operations.items())
+        ],
+        "source_url": source_url,
+    }
+
+
+def diff_preview(before: Any, after: Any, max_lines: int) -> list[str]:
+    diff_lines = list(
+        difflib.unified_diff(
+            json.dumps(before, indent=2, sort_keys=True).splitlines(),
+            json.dumps(after, indent=2, sort_keys=True).splitlines(),
+            fromfile="baseline",
+            tofile="candidate",
+            lineterm="",
+        )
+    )
+
+    if len(diff_lines) <= max_lines:
+        return diff_lines
+
+    truncated = diff_lines[:max_lines]
+    truncated.append(f"... truncated {len(diff_lines) - max_lines} additional diff line(s) ...")
+    return truncated
+
+
+def build_report(
+    baseline_spec: dict[str, Any],
+    candidate_spec: dict[str, Any],
+    baseline_label: str,
+    candidate_label: str,
+    source_url: str,
+    max_diff_lines: int,
+) -> dict[str, Any]:
+    baseline_operations = collect_operations(baseline_spec)
+    candidate_operations = collect_operations(candidate_spec)
+
+    baseline_keys = set(baseline_operations)
+    candidate_keys = set(candidate_operations)
+
+    added = sorted(candidate_keys - baseline_keys)
+    removed = sorted(baseline_keys - candidate_keys)
+    changed = []
+
+    for operation_key in sorted(baseline_keys & candidate_keys):
+        baseline_operation = baseline_operations[operation_key]
+        candidate_operation = candidate_operations[operation_key]
+        if baseline_operation["fingerprint"] == candidate_operation["fingerprint"]:
+            continue
+
+        changed.append(
+            {
+                "id": operation_key,
+                "baseline_fingerprint": baseline_operation["fingerprint"],
+                "candidate_fingerprint": candidate_operation["fingerprint"],
+                "diff_preview": diff_preview(
+                    baseline_operation["normalized"],
+                    candidate_operation["normalized"],
+                    max_diff_lines=max_diff_lines,
+                ),
+            }
+        )
+
+    return {
+        "baseline": {
+            "info": baseline_spec.get("info", {}),
+            "label": baseline_label,
+            "operation_count": len(baseline_operations),
+        },
+        "candidate": {
+            "info": candidate_spec.get("info", {}),
+            "label": candidate_label,
+            "operation_count": len(candidate_operations),
+        },
+        "compared_at": utc_now_iso(),
+        "source_url": source_url,
+        "has_drift": bool(added or removed or changed),
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+        },
+        "added": [
+            {
+                "fingerprint": candidate_operations[operation_key]["fingerprint"],
+                "id": operation_key,
+                "operation_id": candidate_operations[operation_key]["operation_id"],
+                "tags": candidate_operations[operation_key]["tags"],
+            }
+            for operation_key in added
+        ],
+        "removed": [
+            {
+                "fingerprint": baseline_operations[operation_key]["fingerprint"],
+                "id": operation_key,
+                "operation_id": baseline_operations[operation_key]["operation_id"],
+                "tags": baseline_operations[operation_key]["tags"],
+            }
+            for operation_key in removed
+        ],
+        "changed": changed,
+    }
+
+
+def markdown_list(title: str, items: list[str]) -> list[str]:
+    if not items:
+        return [f"## {title}", "", "- None", ""]
+
+    return [f"## {title}", "", *[f"- `{item}`" for item in items], ""]
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# OpenRouter OpenAPI Drift Report",
+        "",
+        f"Compared at: `{report['compared_at']}`",
+        f"Upstream source: `{report['source_url']}`",
+        "",
+        "## Summary",
+        "",
+        f"- Baseline: `{report['baseline']['label']}` with `{report['baseline']['operation_count']}` method+path entries",
+        f"- Candidate: `{report['candidate']['label']}` with `{report['candidate']['operation_count']}` method+path entries",
+        f"- Added operations: `{report['summary']['added']}`",
+        f"- Removed operations: `{report['summary']['removed']}`",
+        f"- Changed operations: `{report['summary']['changed']}`",
+        "",
+    ]
+
+    if not report["has_drift"]:
+        lines.extend(
+            [
+                "No operation-level drift detected after resolving local component refs and removing",
+                "docs-only OpenAPI fields",
+                "(`summary`, `description`, `title`, `example`, `examples`, `externalDocs`).",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "Operation-level drift detected after resolving local component refs and removing",
+                "docs-only OpenAPI fields",
+                "(`summary`, `description`, `title`, `example`, `examples`, `externalDocs`).",
+                "",
+            ]
+        )
+
+    lines.extend(markdown_list("Added Operations", [entry["id"] for entry in report["added"]]))
+    lines.extend(markdown_list("Removed Operations", [entry["id"] for entry in report["removed"]]))
+
+    lines.append("## Changed Operations")
+    lines.append("")
+    if not report["changed"]:
+        lines.append("- None")
+        lines.append("")
+    else:
+        for entry in report["changed"]:
+            lines.append(
+                f"- `{entry['id']}` "
+                f"(`{entry['baseline_fingerprint']}` -> `{entry['candidate_fingerprint']}`)"
+            )
+            lines.append("")
+            lines.append("```diff")
+            lines.extend(entry["diff_preview"] or ["# normalized operation diff was empty"])
+            lines.append("```")
+            lines.append("")
+
+    lines.extend(
+        [
+            "## Follow-up",
+            "",
+            "- Review the upstream spec change against `docs/official-endpoint-test-matrix.md`.",
+            "- If the upstream change is accepted, refresh the tracked baseline with `just openapi-refresh-baseline`.",
+            "- Update docs, tests, or endpoint coverage notes before closing the follow-up issue.",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def write_github_output(path: Path, *, has_drift: bool, report_md: Path, report_json: Path) -> None:
+    ensure_parent(path)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"has_drift={'true' if has_drift else 'false'}\n")
+        handle.write(f"report_markdown={report_md}\n")
+        handle.write(f"report_json={report_json}\n")
+
+
+def command_refresh_baseline(args: argparse.Namespace) -> int:
+    source_url = args.source_url or UPSTREAM_OPENAPI_URL
+    spec = read_json(args.source_file) if args.source_file else fetch_spec(source_url)
+    reduced_spec = reduce_spec_for_baseline(spec)
+    snapshot = build_snapshot(reduced_spec, source_url)
+    write_json(args.baseline_json, reduced_spec)
+    write_json(args.operations_json, snapshot)
+    print(
+        f"Refreshed baseline from {source_url} with "
+        f"{snapshot['operation_count']} method+path entries."
+    )
+    print(f"- raw baseline: {args.baseline_json}")
+    print(f"- normalized snapshot: {args.operations_json}")
+    return 0
+
+
+def command_compare(args: argparse.Namespace) -> int:
+    baseline_spec = read_json(args.baseline)
+    candidate_spec = fetch_spec(args.candidate_url) if args.candidate_url else read_json(args.candidate)
+    report = build_report(
+        baseline_spec=baseline_spec,
+        candidate_spec=candidate_spec,
+        baseline_label=args.baseline_label,
+        candidate_label=args.candidate_label,
+        source_url=args.source_url,
+        max_diff_lines=args.max_diff_lines,
+    )
+
+    report_markdown = render_markdown_report(report)
+    write_json(args.report_json, report)
+    write_text(args.report_md, report_markdown)
+
+    if args.candidate_operations:
+        write_json(args.candidate_operations, build_snapshot(candidate_spec, args.source_url))
+
+    if args.github_output:
+        write_github_output(
+            args.github_output,
+            has_drift=report["has_drift"],
+            report_md=args.report_md,
+            report_json=args.report_json,
+        )
+
+    if args.step_summary:
+        write_text(args.step_summary, report_markdown)
+
+    print(
+        f"Compared baseline `{args.baseline_label}` to candidate `{args.candidate_label}`: "
+        f"added={report['summary']['added']}, "
+        f"removed={report['summary']['removed']}, "
+        f"changed={report['summary']['changed']}"
+    )
+    print(f"- markdown report: {args.report_md}")
+    print(f"- json report: {args.report_json}")
+
+    if report["has_drift"] and args.fail_on_drift:
+        return 2
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="OpenRouter OpenAPI drift tooling")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    refresh = subparsers.add_parser(
+        "refresh-baseline",
+        help="Fetch the latest upstream spec and refresh the tracked baseline artifacts.",
+    )
+    refresh_source = refresh.add_mutually_exclusive_group()
+    refresh_source.add_argument(
+        "--source-url",
+        default=UPSTREAM_OPENAPI_URL,
+        help="OpenAPI URL used to refresh the tracked baseline.",
+    )
+    refresh_source.add_argument(
+        "--source-file",
+        type=Path,
+        help="Local OpenAPI JSON file used to refresh the tracked baseline.",
+    )
+    refresh.add_argument(
+        "--baseline-json",
+        type=Path,
+        required=True,
+        help="Path where the raw tracked baseline JSON should be written.",
+    )
+    refresh.add_argument(
+        "--operations-json",
+        type=Path,
+        required=True,
+        help="Path where the normalized operations snapshot should be written.",
+    )
+    refresh.set_defaults(func=command_refresh_baseline)
+
+    compare = subparsers.add_parser(
+        "compare",
+        help="Compare the tracked baseline against a candidate OpenAPI spec and emit reports.",
+    )
+    compare.add_argument(
+        "--baseline",
+        type=Path,
+        required=True,
+        help="Tracked baseline OpenAPI JSON file.",
+    )
+    compare_source = compare.add_mutually_exclusive_group(required=True)
+    compare_source.add_argument(
+        "--candidate",
+        type=Path,
+        help="Candidate OpenAPI JSON file to compare against the tracked baseline.",
+    )
+    compare_source.add_argument(
+        "--candidate-url",
+        help="Candidate OpenAPI URL to compare against the tracked baseline.",
+    )
+    compare.add_argument(
+        "--source-url",
+        default=UPSTREAM_OPENAPI_URL,
+        help="Source URL associated with the compared candidate spec.",
+    )
+    compare.add_argument(
+        "--baseline-label",
+        default="tracked baseline",
+        help="Human-readable label for the tracked baseline in reports.",
+    )
+    compare.add_argument(
+        "--candidate-label",
+        default="latest upstream",
+        help="Human-readable label for the candidate spec in reports.",
+    )
+    compare.add_argument(
+        "--report-md",
+        type=Path,
+        required=True,
+        help="Markdown report output path.",
+    )
+    compare.add_argument(
+        "--report-json",
+        type=Path,
+        required=True,
+        help="JSON report output path.",
+    )
+    compare.add_argument(
+        "--candidate-operations",
+        type=Path,
+        help="Optional output path for the candidate normalized operations snapshot.",
+    )
+    compare.add_argument(
+        "--github-output",
+        type=Path,
+        help="Optional GitHub Actions output file path.",
+    )
+    compare.add_argument(
+        "--step-summary",
+        type=Path,
+        help="Optional GitHub Actions step summary output path.",
+    )
+    compare.add_argument(
+        "--max-diff-lines",
+        type=int,
+        default=60,
+        help="Maximum diff lines to include for each changed operation in the markdown report.",
+    )
+    compare.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Exit with code 2 when drift is detected.",
+    )
+    compare.set_defaults(func=command_compare)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -131,8 +131,56 @@ def resolve_local_refs(value: Any, document: dict[str, Any], active_refs: frozen
     return value
 
 
-def normalize_operation(raw_operation: dict[str, Any], spec: dict[str, Any]) -> Any:
-    return strip_doc_only_fields(resolve_local_refs(raw_operation, spec))
+def merge_parameter_lists(
+    inherited_parameters: list[Any],
+    operation_parameters: list[Any],
+) -> list[Any]:
+    merged: list[Any] = []
+    parameter_index: dict[tuple[str, str], int] = {}
+
+    for parameter in inherited_parameters + operation_parameters:
+        if not isinstance(parameter, dict):
+            merged.append(parameter)
+            continue
+
+        name = parameter.get("name")
+        location = parameter.get("in")
+        if not isinstance(name, str) or not isinstance(location, str):
+            merged.append(parameter)
+            continue
+
+        parameter_key = (name, location)
+        existing_index = parameter_index.get(parameter_key)
+        if existing_index is None:
+            parameter_index[parameter_key] = len(merged)
+            merged.append(parameter)
+            continue
+
+        merged[existing_index] = parameter
+
+    return merged
+
+
+def inherit_path_item_fields(raw_operation: dict[str, Any], path_item: dict[str, Any]) -> dict[str, Any]:
+    inherited_operation = dict(raw_operation)
+
+    path_parameters = path_item.get("parameters", [])
+    operation_parameters = raw_operation.get("parameters", [])
+    if path_parameters or operation_parameters:
+        inherited_operation["parameters"] = merge_parameter_lists(
+            path_parameters if isinstance(path_parameters, list) else [],
+            operation_parameters if isinstance(operation_parameters, list) else [],
+        )
+
+    if "servers" not in inherited_operation and "servers" in path_item:
+        inherited_operation["servers"] = path_item["servers"]
+
+    return inherited_operation
+
+
+def normalize_operation(raw_operation: dict[str, Any], path_item: dict[str, Any], spec: dict[str, Any]) -> Any:
+    inherited_operation = inherit_path_item_fields(raw_operation, path_item)
+    return strip_doc_only_fields(resolve_local_refs(inherited_operation, spec))
 
 
 def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -144,7 +192,7 @@ def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
                 continue
 
             raw_operation = path_item[method]
-            normalized = normalize_operation(raw_operation, spec)
+            normalized = normalize_operation(raw_operation, path_item, spec)
             operation_key = f"{method.upper()} {path}"
             operations[operation_key] = {
                 "id": operation_key,
@@ -188,7 +236,7 @@ def build_snapshot(spec: dict[str, Any], source_url: str) -> dict[str, Any]:
     }
 
 
-def diff_preview(before: Any, after: Any, max_lines: int) -> list[str]:
+def diff_preview(before: Any, after: Any, max_diff_lines: int) -> list[str]:
     diff_lines = list(
         difflib.unified_diff(
             json.dumps(before, indent=2, sort_keys=True).splitlines(),
@@ -199,11 +247,11 @@ def diff_preview(before: Any, after: Any, max_lines: int) -> list[str]:
         )
     )
 
-    if len(diff_lines) <= max_lines:
+    if len(diff_lines) <= max_diff_lines:
         return diff_lines
 
-    truncated = diff_lines[:max_lines]
-    truncated.append(f"... truncated {len(diff_lines) - max_lines} additional diff line(s) ...")
+    truncated = diff_lines[:max_diff_lines]
+    truncated.append(f"... truncated {len(diff_lines) - max_diff_lines} additional diff line(s) ...")
     return truncated
 
 

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -178,6 +178,45 @@ def merge_parameter_lists(
     return merged
 
 
+def normalize_parameter_order(parameters: Any) -> Any:
+    if not isinstance(parameters, list):
+        return parameters
+
+    def parameter_sort_key(parameter: Any) -> tuple[int, str, str, str]:
+        if isinstance(parameter, dict):
+            name = parameter.get("name")
+            location = parameter.get("in")
+            if isinstance(name, str) and isinstance(location, str):
+                return (0, location, name, canonical_json(parameter))
+
+        return (1, "", "", canonical_json(parameter))
+
+    return sorted(parameters, key=parameter_sort_key)
+
+
+def normalize_security_order(security: Any) -> Any:
+    if not isinstance(security, list):
+        return security
+
+    normalized_requirements: list[Any] = []
+    for requirement in security:
+        if not isinstance(requirement, dict):
+            normalized_requirements.append(requirement)
+            continue
+
+        normalized_requirement: dict[str, Any] = {}
+        for scheme_name in sorted(requirement):
+            scopes = requirement[scheme_name]
+            if isinstance(scopes, list):
+                normalized_requirement[scheme_name] = sorted(scopes, key=canonical_json)
+            else:
+                normalized_requirement[scheme_name] = scopes
+
+        normalized_requirements.append(normalized_requirement)
+
+    return sorted(normalized_requirements, key=canonical_json)
+
+
 def collect_effective_security_schemes(
     effective_security: Any,
     spec: dict[str, Any],
@@ -217,6 +256,9 @@ def inherit_effective_operation_fields(
             path_parameters if isinstance(path_parameters, list) else [],
             operation_parameters if isinstance(operation_parameters, list) else [],
         )
+        inherited_operation["parameters"] = normalize_parameter_order(
+            inherited_operation["parameters"]
+        )
 
     if "servers" not in inherited_operation:
         if "servers" in path_item:
@@ -226,6 +268,10 @@ def inherit_effective_operation_fields(
 
     if "security" not in inherited_operation and "security" in spec:
         inherited_operation["security"] = spec["security"]
+    if "security" in inherited_operation:
+        inherited_operation["security"] = normalize_security_order(
+            inherited_operation["security"]
+        )
 
     resolved_security_schemes = collect_effective_security_schemes(
         inherited_operation.get("security"),

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -79,6 +79,21 @@ def short_hash(value: Any) -> str:
     return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()[:16]
 
 
+def validate_openapi_spec(spec: Any, source: str) -> dict[str, Any]:
+    if not isinstance(spec, dict):
+        raise ValueError(f"{source} did not contain a top-level JSON object.")
+
+    openapi_version = spec.get("openapi")
+    if not isinstance(openapi_version, str) or not openapi_version:
+        raise ValueError(f"{source} is not an OpenAPI document: missing top-level `openapi` string.")
+
+    paths = spec.get("paths")
+    if not isinstance(paths, dict):
+        raise ValueError(f"{source} is not an OpenAPI document: missing top-level `paths` object.")
+
+    return spec
+
+
 def decode_json_pointer_token(token: str) -> str:
     return token.replace("~1", "/").replace("~0", "~")
 
@@ -575,7 +590,9 @@ def write_github_output(path: Path, *, has_drift: bool, report_md: Path, report_
 
 def command_refresh_baseline(args: argparse.Namespace) -> int:
     source_url = args.source_url or UPSTREAM_OPENAPI_URL
-    spec = read_json(args.source_file) if args.source_file else fetch_spec(source_url)
+    source_label = str(args.source_file) if args.source_file else source_url
+    raw_spec = read_json(args.source_file) if args.source_file else fetch_spec(source_url)
+    spec = validate_openapi_spec(raw_spec, source_label)
     reduced_spec = reduce_spec_for_baseline(spec)
     snapshot = build_snapshot(reduced_spec, source_url)
     write_json(args.baseline_json, reduced_spec)
@@ -590,8 +607,10 @@ def command_refresh_baseline(args: argparse.Namespace) -> int:
 
 
 def command_compare(args: argparse.Namespace) -> int:
-    baseline_spec = read_json(args.baseline)
-    candidate_spec = fetch_spec(args.candidate_url) if args.candidate_url else read_json(args.candidate)
+    baseline_spec = validate_openapi_spec(read_json(args.baseline), str(args.baseline))
+    candidate_label = args.candidate_url or str(args.candidate)
+    raw_candidate_spec = fetch_spec(args.candidate_url) if args.candidate_url else read_json(args.candidate)
+    candidate_spec = validate_openapi_spec(raw_candidate_spec, candidate_label)
     report = build_report(
         baseline_spec=baseline_spec,
         candidate_spec=candidate_spec,
@@ -748,7 +767,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    return args.func(args)
+    try:
+        return args.func(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -21,6 +21,7 @@ BASELINE_TOP_LEVEL_FIELDS = (
     "jsonSchemaDialect",
     "openapi",
     "paths",
+    "security",
     "servers",
     "tags",
 )
@@ -177,7 +178,36 @@ def merge_parameter_lists(
     return merged
 
 
-def inherit_path_item_fields(raw_operation: dict[str, Any], path_item: dict[str, Any]) -> dict[str, Any]:
+def collect_effective_security_schemes(
+    effective_security: Any,
+    spec: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not isinstance(effective_security, list):
+        return None
+
+    security_schemes = spec.get("components", {}).get("securitySchemes", {})
+    if not isinstance(security_schemes, dict):
+        return None
+
+    resolved_schemes: dict[str, Any] = {}
+    for requirement in effective_security:
+        if not isinstance(requirement, dict):
+            continue
+
+        for scheme_name in sorted(requirement):
+            scheme_definition = security_schemes.get(scheme_name)
+            if scheme_definition is None:
+                continue
+            resolved_schemes[scheme_name] = resolve_local_refs(scheme_definition, spec)
+
+    return resolved_schemes or None
+
+
+def inherit_effective_operation_fields(
+    raw_operation: dict[str, Any],
+    path_item: dict[str, Any],
+    spec: dict[str, Any],
+) -> dict[str, Any]:
     inherited_operation = dict(raw_operation)
 
     path_parameters = path_item.get("parameters", [])
@@ -188,8 +218,21 @@ def inherit_path_item_fields(raw_operation: dict[str, Any], path_item: dict[str,
             operation_parameters if isinstance(operation_parameters, list) else [],
         )
 
-    if "servers" not in inherited_operation and "servers" in path_item:
-        inherited_operation["servers"] = path_item["servers"]
+    if "servers" not in inherited_operation:
+        if "servers" in path_item:
+            inherited_operation["servers"] = path_item["servers"]
+        elif "servers" in spec:
+            inherited_operation["servers"] = spec["servers"]
+
+    if "security" not in inherited_operation and "security" in spec:
+        inherited_operation["security"] = spec["security"]
+
+    resolved_security_schemes = collect_effective_security_schemes(
+        inherited_operation.get("security"),
+        spec,
+    )
+    if resolved_security_schemes:
+        inherited_operation["_effective_security_schemes"] = resolved_security_schemes
 
     return inherited_operation
 
@@ -201,8 +244,8 @@ def normalize_path_item(path_item: dict[str, Any], spec: dict[str, Any]) -> dict
     return resolved_path_item
 
 
-def normalize_operation(raw_operation: dict[str, Any], path_item: dict[str, Any]) -> Any:
-    inherited_operation = inherit_path_item_fields(raw_operation, path_item)
+def normalize_operation(raw_operation: dict[str, Any], path_item: dict[str, Any], spec: dict[str, Any]) -> Any:
+    inherited_operation = inherit_effective_operation_fields(raw_operation, path_item, spec)
     return strip_doc_only_fields(inherited_operation)
 
 
@@ -219,7 +262,7 @@ def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
             if not isinstance(raw_operation, dict):
                 continue
 
-            normalized = normalize_operation(raw_operation, path_item)
+            normalized = normalize_operation(raw_operation, path_item, spec)
             operation_key = f"{method.upper()} {path}"
             operations[operation_key] = {
                 "id": operation_key,

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -83,12 +83,28 @@ def decode_json_pointer_token(token: str) -> str:
 
 
 def resolve_json_pointer(document: dict[str, Any], pointer: str) -> Any:
+    if pointer == "#":
+        return document
+
     if not pointer.startswith("#/"):
         raise ValueError(f"Only local JSON pointers are supported, got: {pointer}")
 
     current: Any = document
     for token in pointer[2:].split("/"):
-        current = current[decode_json_pointer_token(token)]
+        decoded_token = decode_json_pointer_token(token)
+
+        if isinstance(current, list):
+            try:
+                current = current[int(decoded_token)]
+            except (ValueError, IndexError) as exc:
+                raise KeyError(decoded_token) from exc
+            continue
+
+        if isinstance(current, dict):
+            current = current[decoded_token]
+            continue
+
+        raise TypeError(f"JSON pointer segment {decoded_token!r} cannot be applied to {type(current).__name__}")
     return current
 
 

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -178,21 +178,32 @@ def inherit_path_item_fields(raw_operation: dict[str, Any], path_item: dict[str,
     return inherited_operation
 
 
-def normalize_operation(raw_operation: dict[str, Any], path_item: dict[str, Any], spec: dict[str, Any]) -> Any:
+def normalize_path_item(path_item: dict[str, Any], spec: dict[str, Any]) -> dict[str, Any]:
+    resolved_path_item = resolve_local_refs(path_item, spec)
+    if not isinstance(resolved_path_item, dict):
+        raise TypeError("Resolved Path Item must be an object")
+    return resolved_path_item
+
+
+def normalize_operation(raw_operation: dict[str, Any], path_item: dict[str, Any]) -> Any:
     inherited_operation = inherit_path_item_fields(raw_operation, path_item)
-    return strip_doc_only_fields(resolve_local_refs(inherited_operation, spec))
+    return strip_doc_only_fields(inherited_operation)
 
 
 def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
     operations: dict[str, dict[str, Any]] = {}
 
-    for path, path_item in sorted(spec.get("paths", {}).items()):
+    for path, raw_path_item in sorted(spec.get("paths", {}).items()):
+        path_item = normalize_path_item(raw_path_item, spec)
         for method in HTTP_METHODS:
             if method not in path_item:
                 continue
 
             raw_operation = path_item[method]
-            normalized = normalize_operation(raw_operation, path_item, spec)
+            if not isinstance(raw_operation, dict):
+                continue
+
+            normalized = normalize_operation(raw_operation, path_item)
             operation_key = f"{method.upper()} {path}"
             operations[operation_key] = {
                 "id": operation_key,

--- a/specs/openrouter/README.md
+++ b/specs/openrouter/README.md
@@ -1,0 +1,26 @@
+# OpenRouter Spec Baseline
+
+This directory contains the tracked upstream OpenRouter OpenAPI baseline used by the nightly drift-detection workflow.
+
+Files:
+
+- `openapi-baseline.json`: checked-in baseline snapshot used for path+operation drift comparison
+- `openapi-baseline.operations.json`: normalized operation summary derived from the raw baseline
+
+The initial baseline is seeded from the currently accepted endpoint matrix in this repo. That is
+intentional: drift detection should surface newly added upstream operations instead of silently
+accepting them before docs, tests, and implementation are reviewed.
+
+Refresh the baseline locally with:
+
+```bash
+just openapi-refresh-baseline
+```
+
+Compare the tracked baseline against the latest upstream spec with:
+
+```bash
+just openapi-drift-check
+```
+
+This directory is intentionally limited to baseline tracking for now. Generated-module seams, overlays, and broader spec tooling remain future work under the generated-core scaffold roadmap.

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,0 +1,26948 @@
+{
+  "components": {
+    "parameters": {
+      "AppDisplayName": {
+        "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
+        "in": "header",
+        "name": "X-Title",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "AppIdentifier": {
+        "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
+        "in": "header",
+        "name": "HTTP-Referer",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "schemas": {
+      "ActivityItem": {
+        "example": {
+          "byok_usage_inference": 0.012,
+          "completion_tokens": 125,
+          "date": "2025-08-24",
+          "endpoint_id": "550e8400-e29b-41d4-a716-446655440000",
+          "model": "openai/gpt-4.1",
+          "model_permaslug": "openai/gpt-4.1-2025-04-14",
+          "prompt_tokens": 50,
+          "provider_name": "OpenAI",
+          "reasoning_tokens": 25,
+          "requests": 5,
+          "usage": 0.015
+        },
+        "properties": {
+          "byok_usage_inference": {
+            "description": "BYOK inference cost in USD (external credits spent)",
+            "example": 0.012,
+            "format": "double",
+            "type": "number"
+          },
+          "completion_tokens": {
+            "description": "Total completion tokens generated",
+            "example": 125,
+            "type": "integer"
+          },
+          "date": {
+            "description": "Date of the activity (YYYY-MM-DD format)",
+            "example": "2025-08-24",
+            "type": "string"
+          },
+          "endpoint_id": {
+            "description": "Unique identifier for the endpoint",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "type": "string"
+          },
+          "model": {
+            "description": "Model slug (e.g., \"openai/gpt-4.1\")",
+            "example": "openai/gpt-4.1",
+            "type": "string"
+          },
+          "model_permaslug": {
+            "description": "Model permaslug (e.g., \"openai/gpt-4.1-2025-04-14\")",
+            "example": "openai/gpt-4.1-2025-04-14",
+            "type": "string"
+          },
+          "prompt_tokens": {
+            "description": "Total prompt tokens used",
+            "example": 50,
+            "type": "integer"
+          },
+          "provider_name": {
+            "description": "Name of the provider serving this endpoint",
+            "example": "OpenAI",
+            "type": "string"
+          },
+          "reasoning_tokens": {
+            "description": "Total reasoning tokens used",
+            "example": 25,
+            "type": "integer"
+          },
+          "requests": {
+            "description": "Number of requests made",
+            "example": 5,
+            "type": "integer"
+          },
+          "usage": {
+            "description": "Total cost in USD (OpenRouter credits spent)",
+            "example": 0.015,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "date",
+          "model",
+          "model_permaslug",
+          "endpoint_id",
+          "provider_name",
+          "usage",
+          "byok_usage_inference",
+          "requests",
+          "prompt_tokens",
+          "completion_tokens",
+          "reasoning_tokens"
+        ],
+        "type": "object"
+      },
+      "ActivityResponse": {
+        "example": {
+          "data": [
+            {
+              "byok_usage_inference": 0.012,
+              "completion_tokens": 125,
+              "date": "2025-08-24",
+              "endpoint_id": "550e8400-e29b-41d4-a716-446655440000",
+              "model": "openai/gpt-4.1",
+              "model_permaslug": "openai/gpt-4.1-2025-04-14",
+              "prompt_tokens": 50,
+              "provider_name": "OpenAI",
+              "reasoning_tokens": 25,
+              "requests": 5,
+              "usage": 0.015
+            }
+          ]
+        },
+        "properties": {
+          "data": {
+            "description": "List of activity items",
+            "items": {
+              "$ref": "#/components/schemas/ActivityItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "AnnotationAddedEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseAnnotationAddedEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a text annotation is added to output",
+        "example": {
+          "annotation": {
+            "end_index": 7,
+            "start_index": 0,
+            "title": "Example",
+            "type": "url_citation",
+            "url": "https://example.com"
+          },
+          "annotation_index": 0,
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 5,
+          "type": "response.output_text.annotation.added"
+        }
+      },
+      "AnthropicBase64ImageSource": {
+        "example": {
+          "data": "/9j/4AAQ...",
+          "media_type": "image/jpeg",
+          "type": "base64"
+        },
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "media_type": {
+            "$ref": "#/components/schemas/AnthropicImageMimeType"
+          },
+          "type": {
+            "enum": [
+              "base64"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "media_type",
+          "data"
+        ],
+        "type": "object"
+      },
+      "AnthropicBase64PdfSource": {
+        "example": {
+          "data": "JVBERi0x...",
+          "media_type": "application/pdf",
+          "type": "base64"
+        },
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "media_type": {
+            "enum": [
+              "application/pdf"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "base64"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "media_type",
+          "data"
+        ],
+        "type": "object"
+      },
+      "AnthropicBaseUsageIteration": {
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 50
+        },
+        "properties": {
+          "cache_creation": {
+            "$ref": "#/components/schemas/AnthropicIterationCacheCreation"
+          },
+          "cache_creation_input_tokens": {
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "type": "integer"
+          },
+          "input_tokens": {
+            "type": "integer"
+          },
+          "output_tokens": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AnthropicBashCodeExecutionContent": {
+        "discriminator": {
+          "mapping": {
+            "bash_code_execution_result": "#/components/schemas/AnthropicBashCodeExecutionResult",
+            "bash_code_execution_tool_result_error": "#/components/schemas/AnthropicBashCodeExecutionToolResultError"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "content": [],
+          "return_code": 0,
+          "stderr": "",
+          "stdout": "Hello",
+          "type": "bash_code_execution_result"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicBashCodeExecutionToolResultError"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicBashCodeExecutionResult"
+          }
+        ]
+      },
+      "AnthropicBashCodeExecutionOutput": {
+        "example": {
+          "file_id": "file_01abc",
+          "type": "bash_code_execution_output"
+        },
+        "properties": {
+          "file_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "bash_code_execution_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicBashCodeExecutionResult": {
+        "example": {
+          "content": [],
+          "return_code": 0,
+          "stderr": "",
+          "stdout": "Hello",
+          "type": "bash_code_execution_result"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicBashCodeExecutionOutput"
+            },
+            "type": "array"
+          },
+          "return_code": {
+            "type": "integer"
+          },
+          "stderr": {
+            "type": "string"
+          },
+          "stdout": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "bash_code_execution_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "return_code",
+          "stderr",
+          "stdout",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicBashCodeExecutionToolResult": {
+        "example": {
+          "content": {
+            "content": [],
+            "return_code": 0,
+            "stderr": "",
+            "stdout": "Hello",
+            "type": "bash_code_execution_result"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "bash_code_execution_tool_result"
+        },
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/AnthropicBashCodeExecutionContent"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "bash_code_execution_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicBashCodeExecutionToolResultError": {
+        "example": {
+          "error_code": "unavailable",
+          "type": "bash_code_execution_tool_result_error"
+        },
+        "properties": {
+          "error_code": {
+            "enum": [
+              "invalid_tool_input",
+              "unavailable",
+              "too_many_requests",
+              "execution_time_exceeded",
+              "output_file_too_large"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "bash_code_execution_tool_result_error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "error_code",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicCacheControlDirective": {
+        "example": {
+          "type": "ephemeral"
+        },
+        "properties": {
+          "ttl": {
+            "$ref": "#/components/schemas/AnthropicCacheControlTtl"
+          },
+          "type": {
+            "enum": [
+              "ephemeral"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicCacheControlTtl": {
+        "enum": [
+          "5m",
+          "1h"
+        ],
+        "example": "5m",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicCacheCreation": {
+        "example": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 100
+        },
+        "nullable": true,
+        "properties": {
+          "ephemeral_1h_input_tokens": {
+            "type": "integer"
+          },
+          "ephemeral_5m_input_tokens": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "ephemeral_5m_input_tokens",
+          "ephemeral_1h_input_tokens"
+        ],
+        "type": "object"
+      },
+      "AnthropicCaller": {
+        "discriminator": {
+          "mapping": {
+            "code_execution_20250825": "#/components/schemas/AnthropicCodeExecution20250825Caller",
+            "code_execution_20260120": "#/components/schemas/AnthropicCodeExecution20260120Caller",
+            "direct": "#/components/schemas/AnthropicDirectCaller"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "type": "direct"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicDirectCaller"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecution20250825Caller"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecution20260120Caller"
+          }
+        ]
+      },
+      "AnthropicCitationCharLocation": {
+        "example": {
+          "cited_text": "Example cited text",
+          "document_index": 0,
+          "document_title": null,
+          "end_char_index": 18,
+          "file_id": null,
+          "start_char_index": 0,
+          "type": "char_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "document_index": {
+            "type": "integer"
+          },
+          "document_title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "end_char_index": {
+            "type": "integer"
+          },
+          "file_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "start_char_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "char_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "document_index",
+          "document_title",
+          "start_char_index",
+          "end_char_index",
+          "file_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationCharLocationParam": {
+        "example": {
+          "cited_text": "Example cited text",
+          "document_index": 0,
+          "document_title": null,
+          "end_char_index": 18,
+          "start_char_index": 0,
+          "type": "char_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "document_index": {
+            "type": "integer"
+          },
+          "document_title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "end_char_index": {
+            "type": "integer"
+          },
+          "start_char_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "char_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "document_index",
+          "document_title",
+          "start_char_index",
+          "end_char_index"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationContentBlockLocation": {
+        "example": {
+          "cited_text": "Example cited text",
+          "document_index": 0,
+          "document_title": null,
+          "end_block_index": 1,
+          "file_id": null,
+          "start_block_index": 0,
+          "type": "content_block_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "document_index": {
+            "type": "integer"
+          },
+          "document_title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "end_block_index": {
+            "type": "integer"
+          },
+          "file_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "start_block_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "content_block_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "document_index",
+          "document_title",
+          "start_block_index",
+          "end_block_index",
+          "file_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationContentBlockLocationParam": {
+        "example": {
+          "cited_text": "Example cited text",
+          "document_index": 0,
+          "document_title": null,
+          "end_block_index": 1,
+          "start_block_index": 0,
+          "type": "content_block_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "document_index": {
+            "type": "integer"
+          },
+          "document_title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "end_block_index": {
+            "type": "integer"
+          },
+          "start_block_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "content_block_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "document_index",
+          "document_title",
+          "start_block_index",
+          "end_block_index"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationPageLocation": {
+        "example": {
+          "cited_text": "Example cited text",
+          "document_index": 0,
+          "document_title": null,
+          "end_page_number": 2,
+          "file_id": null,
+          "start_page_number": 1,
+          "type": "page_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "document_index": {
+            "type": "integer"
+          },
+          "document_title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "end_page_number": {
+            "type": "integer"
+          },
+          "file_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "start_page_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "page_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "document_index",
+          "document_title",
+          "start_page_number",
+          "end_page_number",
+          "file_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationPageLocationParam": {
+        "example": {
+          "cited_text": "Example cited text",
+          "document_index": 0,
+          "document_title": null,
+          "end_page_number": 2,
+          "start_page_number": 1,
+          "type": "page_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "document_index": {
+            "type": "integer"
+          },
+          "document_title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "end_page_number": {
+            "type": "integer"
+          },
+          "start_page_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "page_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "document_index",
+          "document_title",
+          "start_page_number",
+          "end_page_number"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationSearchResultLocation": {
+        "example": {
+          "cited_text": "Example cited text",
+          "end_block_index": 1,
+          "search_result_index": 0,
+          "source": "example_source",
+          "start_block_index": 0,
+          "title": "Example Result",
+          "type": "search_result_location"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "end_block_index": {
+            "type": "integer"
+          },
+          "search_result_index": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "start_block_index": {
+            "type": "integer"
+          },
+          "title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "search_result_location"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "search_result_index",
+          "source",
+          "title",
+          "start_block_index",
+          "end_block_index"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationWebSearchResultLocation": {
+        "example": {
+          "cited_text": "Example cited text",
+          "encrypted_index": "enc_idx_0",
+          "title": "Example Page",
+          "type": "web_search_result_location",
+          "url": "https://example.com"
+        },
+        "properties": {
+          "cited_text": {
+            "type": "string"
+          },
+          "encrypted_index": {
+            "type": "string"
+          },
+          "title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "web_search_result_location"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "cited_text",
+          "encrypted_index",
+          "title",
+          "url"
+        ],
+        "type": "object"
+      },
+      "AnthropicCitationsConfig": {
+        "example": {
+          "enabled": true
+        },
+        "nullable": true,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "type": "object"
+      },
+      "AnthropicCodeExecution20250825Caller": {
+        "example": {
+          "tool_id": "toolu_01abc",
+          "type": "code_execution_20250825"
+        },
+        "properties": {
+          "tool_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "code_execution_20250825"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicCodeExecution20260120Caller": {
+        "example": {
+          "tool_id": "toolu_01abc",
+          "type": "code_execution_20260120"
+        },
+        "properties": {
+          "tool_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "code_execution_20260120"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicCodeExecutionContent": {
+        "discriminator": {
+          "mapping": {
+            "code_execution_result": "#/components/schemas/AnthropicCodeExecutionResult",
+            "code_execution_tool_result_error": "#/components/schemas/AnthropicCodeExecutionToolResultError",
+            "encrypted_code_execution_result": "#/components/schemas/AnthropicEncryptedCodeExecutionResult"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "content": [],
+          "return_code": 0,
+          "stderr": "",
+          "stdout": "Hello",
+          "type": "code_execution_result"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecutionToolResultError"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecutionResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicEncryptedCodeExecutionResult"
+          }
+        ]
+      },
+      "AnthropicCodeExecutionOutput": {
+        "example": {
+          "file_id": "file_01abc",
+          "type": "code_execution_output"
+        },
+        "properties": {
+          "file_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "code_execution_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicCodeExecutionResult": {
+        "example": {
+          "content": [],
+          "return_code": 0,
+          "stderr": "",
+          "stdout": "Hello",
+          "type": "code_execution_result"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicCodeExecutionOutput"
+            },
+            "type": "array"
+          },
+          "return_code": {
+            "type": "integer"
+          },
+          "stderr": {
+            "type": "string"
+          },
+          "stdout": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "code_execution_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "return_code",
+          "stderr",
+          "stdout",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicCodeExecutionToolResult": {
+        "example": {
+          "content": {
+            "content": [],
+            "return_code": 0,
+            "stderr": "",
+            "stdout": "Hello",
+            "type": "code_execution_result"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "code_execution_tool_result"
+        },
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/AnthropicCodeExecutionContent"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "code_execution_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicCodeExecutionToolResultError": {
+        "example": {
+          "error_code": "unavailable",
+          "type": "code_execution_tool_result_error"
+        },
+        "properties": {
+          "error_code": {
+            "$ref": "#/components/schemas/AnthropicServerToolErrorCode"
+          },
+          "type": {
+            "enum": [
+              "code_execution_tool_result_error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "error_code",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicCompactionBlock": {
+        "example": {
+          "content": "Compacted summary of conversation.",
+          "type": "compaction"
+        },
+        "properties": {
+          "content": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "compaction"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "AnthropicCompactionUsageIteration": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicBaseUsageIteration"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "compaction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ],
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 50,
+          "output_tokens": 25,
+          "type": "compaction"
+        }
+      },
+      "AnthropicContainer": {
+        "example": {
+          "expires_at": "2026-04-08T00:00:00Z",
+          "id": "ctr_01abc"
+        },
+        "nullable": true,
+        "properties": {
+          "expires_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "expires_at"
+        ],
+        "type": "object"
+      },
+      "AnthropicContainerUpload": {
+        "example": {
+          "file_id": "file_01abc",
+          "type": "container_upload"
+        },
+        "properties": {
+          "file_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "container_upload"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicDirectCaller": {
+        "example": {
+          "type": "direct"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "direct"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicDocumentBlock": {
+        "example": {
+          "citations": null,
+          "source": {
+            "data": "Hello, world!",
+            "media_type": "text/plain",
+            "type": "text"
+          },
+          "title": null,
+          "type": "document"
+        },
+        "properties": {
+          "citations": {
+            "$ref": "#/components/schemas/AnthropicCitationsConfig"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicBase64PdfSource"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicPlainTextSource"
+              }
+            ]
+          },
+          "title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "document"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "citations",
+          "source",
+          "title",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicDocumentBlockParam": {
+        "example": {
+          "source": {
+            "data": "Hello, world!",
+            "media_type": "text/plain",
+            "type": "text"
+          },
+          "type": "document"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "citations": {
+            "nullable": true,
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "context": {
+            "nullable": true,
+            "type": "string"
+          },
+          "source": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicBase64PdfSource"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicPlainTextSource"
+              },
+              {
+                "properties": {
+                  "content": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "discriminator": {
+                            "mapping": {
+                              "image": "#/components/schemas/AnthropicImageBlockParam",
+                              "text": "#/components/schemas/AnthropicTextBlockParam"
+                            },
+                            "propertyName": "type"
+                          },
+                          "oneOf": [
+                            {
+                              "$ref": "#/components/schemas/AnthropicTextBlockParam"
+                            },
+                            {
+                              "$ref": "#/components/schemas/AnthropicImageBlockParam"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "enum": [
+                      "content"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "content"
+                ],
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicUrlPdfSource"
+              }
+            ]
+          },
+          "title": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "document"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "source"
+        ],
+        "type": "object"
+      },
+      "AnthropicEncryptedCodeExecutionResult": {
+        "example": {
+          "content": [],
+          "encrypted_stdout": "enc_stdout",
+          "return_code": 0,
+          "stderr": "",
+          "type": "encrypted_code_execution_result"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicCodeExecutionOutput"
+            },
+            "type": "array"
+          },
+          "encrypted_stdout": {
+            "type": "string"
+          },
+          "return_code": {
+            "type": "integer"
+          },
+          "stderr": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "encrypted_code_execution_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "encrypted_stdout",
+          "return_code",
+          "stderr",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicImageBlockParam": {
+        "example": {
+          "source": {
+            "data": "/9j/4AAQ...",
+            "media_type": "image/jpeg",
+            "type": "base64"
+          },
+          "type": "image"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "source": {
+            "discriminator": {
+              "mapping": {
+                "base64": "#/components/schemas/AnthropicBase64ImageSource",
+                "url": "#/components/schemas/AnthropicUrlImageSource"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicBase64ImageSource"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicUrlImageSource"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "source"
+        ],
+        "type": "object"
+      },
+      "AnthropicImageMimeType": {
+        "enum": [
+          "image/jpeg",
+          "image/png",
+          "image/gif",
+          "image/webp"
+        ],
+        "example": "image/jpeg",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicInputTokensClearAtLeast": {
+        "example": {
+          "type": "input_tokens",
+          "value": 50000
+        },
+        "nullable": true,
+        "properties": {
+          "type": {
+            "enum": [
+              "input_tokens"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AnthropicInputTokensTrigger": {
+        "example": {
+          "type": "input_tokens",
+          "value": 100000
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "input_tokens"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AnthropicIterationCacheCreation": {
+        "default": null,
+        "example": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 0
+        },
+        "nullable": true,
+        "properties": {
+          "ephemeral_1h_input_tokens": {
+            "type": "integer"
+          },
+          "ephemeral_5m_input_tokens": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AnthropicMessageUsageIteration": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicBaseUsageIteration"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "message"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ],
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 50,
+          "type": "message"
+        }
+      },
+      "AnthropicPlainTextSource": {
+        "example": {
+          "data": "Hello, world!",
+          "media_type": "text/plain",
+          "type": "text"
+        },
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "media_type": {
+            "enum": [
+              "text/plain"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "media_type",
+          "data"
+        ],
+        "type": "object"
+      },
+      "AnthropicRedactedThinkingBlock": {
+        "example": {
+          "data": "cmVkYWN0ZWQ=",
+          "type": "redacted_thinking"
+        },
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "redacted_thinking"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "data"
+        ],
+        "type": "object"
+      },
+      "AnthropicRefusalStopDetails": {
+        "description": "Structured information about a refusal",
+        "example": {
+          "category": "cyber",
+          "explanation": "The request was refused due to policy.",
+          "type": "refusal"
+        },
+        "nullable": true,
+        "properties": {
+          "category": {
+            "enum": [
+              "cyber",
+              "bio",
+              null
+            ],
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "explanation": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "refusal"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "category",
+          "explanation"
+        ],
+        "type": "object"
+      },
+      "AnthropicSearchResultBlockParam": {
+        "example": {
+          "content": [
+            {
+              "text": "Result content",
+              "type": "text"
+            }
+          ],
+          "source": "example_source",
+          "title": "Example Result",
+          "type": "search_result"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "citations": {
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicTextBlockParam"
+            },
+            "type": "array"
+          },
+          "source": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "search_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "source",
+          "title",
+          "content"
+        ],
+        "type": "object"
+      },
+      "AnthropicServerToolErrorCode": {
+        "enum": [
+          "invalid_tool_input",
+          "unavailable",
+          "too_many_requests",
+          "execution_time_exceeded"
+        ],
+        "example": "unavailable",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicServerToolName": {
+        "enum": [
+          "web_search",
+          "web_fetch",
+          "code_execution",
+          "bash_code_execution",
+          "text_editor_code_execution",
+          "tool_search_tool_regex",
+          "tool_search_tool_bm25"
+        ],
+        "example": "web_search",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicServerToolUsage": {
+        "example": {
+          "web_fetch_requests": 0,
+          "web_search_requests": 1
+        },
+        "nullable": true,
+        "properties": {
+          "web_fetch_requests": {
+            "type": "integer"
+          },
+          "web_search_requests": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "web_search_requests",
+          "web_fetch_requests"
+        ],
+        "type": "object"
+      },
+      "AnthropicServerToolUseBlock": {
+        "example": {
+          "caller": {
+            "type": "direct"
+          },
+          "id": "srvtoolu_01abc",
+          "input": {
+            "query": "latest news"
+          },
+          "name": "web_search",
+          "type": "server_tool_use"
+        },
+        "properties": {
+          "caller": {
+            "$ref": "#/components/schemas/AnthropicCaller"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "nullable": true
+          },
+          "name": {
+            "$ref": "#/components/schemas/AnthropicServerToolName"
+          },
+          "type": {
+            "enum": [
+              "server_tool_use"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "caller",
+          "name"
+        ],
+        "type": "object"
+      },
+      "AnthropicServiceTier": {
+        "enum": [
+          "standard",
+          "priority",
+          "batch",
+          null
+        ],
+        "example": "standard",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicSpeed": {
+        "enum": [
+          "fast",
+          "standard",
+          null
+        ],
+        "example": "standard",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicTextBlock": {
+        "example": {
+          "citations": null,
+          "text": "Hello, world!",
+          "type": "text"
+        },
+        "properties": {
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicTextCitation"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "citations"
+        ],
+        "type": "object"
+      },
+      "AnthropicTextBlockParam": {
+        "example": {
+          "text": "Hello, world!",
+          "type": "text"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "citations": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "char_location": "#/components/schemas/AnthropicCitationCharLocationParam",
+                  "content_block_location": "#/components/schemas/AnthropicCitationContentBlockLocationParam",
+                  "page_location": "#/components/schemas/AnthropicCitationPageLocationParam",
+                  "search_result_location": "#/components/schemas/AnthropicCitationSearchResultLocation",
+                  "web_search_result_location": "#/components/schemas/AnthropicCitationWebSearchResultLocation"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AnthropicCitationCharLocationParam"
+                },
+                {
+                  "$ref": "#/components/schemas/AnthropicCitationPageLocationParam"
+                },
+                {
+                  "$ref": "#/components/schemas/AnthropicCitationContentBlockLocationParam"
+                },
+                {
+                  "$ref": "#/components/schemas/AnthropicCitationWebSearchResultLocation"
+                },
+                {
+                  "$ref": "#/components/schemas/AnthropicCitationSearchResultLocation"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "AnthropicTextCitation": {
+        "discriminator": {
+          "mapping": {
+            "char_location": "#/components/schemas/AnthropicCitationCharLocation",
+            "content_block_location": "#/components/schemas/AnthropicCitationContentBlockLocation",
+            "page_location": "#/components/schemas/AnthropicCitationPageLocation",
+            "search_result_location": "#/components/schemas/AnthropicCitationSearchResultLocation",
+            "web_search_result_location": "#/components/schemas/AnthropicCitationWebSearchResultLocation"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "cited_text": "Example text",
+          "document_index": 0,
+          "document_title": null,
+          "end_char_index": 10,
+          "file_id": null,
+          "start_char_index": 0,
+          "type": "char_location"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicCitationCharLocation"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCitationPageLocation"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCitationContentBlockLocation"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCitationWebSearchResultLocation"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCitationSearchResultLocation"
+          }
+        ]
+      },
+      "AnthropicTextEditorCodeExecutionContent": {
+        "discriminator": {
+          "mapping": {
+            "text_editor_code_execution_create_result": "#/components/schemas/AnthropicTextEditorCodeExecutionCreateResult",
+            "text_editor_code_execution_str_replace_result": "#/components/schemas/AnthropicTextEditorCodeExecutionStrReplaceResult",
+            "text_editor_code_execution_tool_result_error": "#/components/schemas/AnthropicTextEditorCodeExecutionToolResultError",
+            "text_editor_code_execution_view_result": "#/components/schemas/AnthropicTextEditorCodeExecutionViewResult"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "content": "file content",
+          "file_type": "text",
+          "num_lines": 10,
+          "start_line": 1,
+          "total_lines": 10,
+          "type": "text_editor_code_execution_view_result"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionToolResultError"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionViewResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionCreateResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionStrReplaceResult"
+          }
+        ]
+      },
+      "AnthropicTextEditorCodeExecutionCreateResult": {
+        "example": {
+          "is_file_update": false,
+          "type": "text_editor_code_execution_create_result"
+        },
+        "properties": {
+          "is_file_update": {
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "text_editor_code_execution_create_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "is_file_update",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicTextEditorCodeExecutionStrReplaceResult": {
+        "example": {
+          "lines": null,
+          "new_lines": null,
+          "new_start": null,
+          "old_lines": null,
+          "old_start": null,
+          "type": "text_editor_code_execution_str_replace_result"
+        },
+        "properties": {
+          "lines": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "new_lines": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "new_start": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "old_lines": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "old_start": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "text_editor_code_execution_str_replace_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "lines",
+          "new_lines",
+          "new_start",
+          "old_lines",
+          "old_start",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicTextEditorCodeExecutionToolResult": {
+        "example": {
+          "content": {
+            "content": "file content",
+            "file_type": "text",
+            "num_lines": 10,
+            "start_line": 1,
+            "total_lines": 10,
+            "type": "text_editor_code_execution_view_result"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "text_editor_code_execution_tool_result"
+        },
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionContent"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text_editor_code_execution_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicTextEditorCodeExecutionToolResultError": {
+        "example": {
+          "error_code": "unavailable",
+          "error_message": null,
+          "type": "text_editor_code_execution_tool_result_error"
+        },
+        "properties": {
+          "error_code": {
+            "enum": [
+              "invalid_tool_input",
+              "unavailable",
+              "too_many_requests",
+              "execution_time_exceeded",
+              "file_not_found"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "error_message": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text_editor_code_execution_tool_result_error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "error_code",
+          "error_message",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicTextEditorCodeExecutionViewResult": {
+        "example": {
+          "content": "file content",
+          "file_type": "text",
+          "num_lines": 10,
+          "start_line": 1,
+          "total_lines": 10,
+          "type": "text_editor_code_execution_view_result"
+        },
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "file_type": {
+            "enum": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "num_lines": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "start_line": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "total_lines": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "text_editor_code_execution_view_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "file_type",
+          "num_lines",
+          "start_line",
+          "total_lines",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicThinkingBlock": {
+        "example": {
+          "signature": "sig_abc123",
+          "thinking": "Let me think about this...",
+          "type": "thinking"
+        },
+        "properties": {
+          "signature": {
+            "type": "string"
+          },
+          "thinking": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "thinking"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "thinking",
+          "signature"
+        ],
+        "type": "object"
+      },
+      "AnthropicThinkingDisplay": {
+        "enum": [
+          "summarized",
+          "omitted",
+          null
+        ],
+        "example": "summarized",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AnthropicThinkingTurns": {
+        "example": {
+          "type": "thinking_turns",
+          "value": 3
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "thinking_turns"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolReference": {
+        "example": {
+          "tool_name": "my_tool",
+          "type": "tool_reference"
+        },
+        "properties": {
+          "tool_name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool_reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool_name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolSearchContent": {
+        "discriminator": {
+          "mapping": {
+            "tool_search_tool_result_error": "#/components/schemas/AnthropicToolSearchResultError",
+            "tool_search_tool_search_result": "#/components/schemas/AnthropicToolSearchResult"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "tool_references": [
+            {
+              "tool_name": "my_tool",
+              "type": "tool_reference"
+            }
+          ],
+          "type": "tool_search_tool_search_result"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicToolSearchResultError"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicToolSearchResult"
+          }
+        ]
+      },
+      "AnthropicToolSearchResult": {
+        "example": {
+          "tool_references": [
+            {
+              "tool_name": "my_tool",
+              "type": "tool_reference"
+            }
+          ],
+          "type": "tool_search_tool_search_result"
+        },
+        "properties": {
+          "tool_references": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicToolReference"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "tool_search_tool_search_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool_references",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolSearchResultError": {
+        "example": {
+          "error_code": "unavailable",
+          "error_message": null,
+          "type": "tool_search_tool_result_error"
+        },
+        "properties": {
+          "error_code": {
+            "$ref": "#/components/schemas/AnthropicServerToolErrorCode"
+          },
+          "error_message": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool_search_tool_result_error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "error_code",
+          "error_message",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolSearchToolResult": {
+        "example": {
+          "content": {
+            "tool_references": [
+              {
+                "tool_name": "my_tool",
+                "type": "tool_reference"
+              }
+            ],
+            "type": "tool_search_tool_search_result"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "tool_search_tool_result"
+        },
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/AnthropicToolSearchContent"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool_search_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolUseBlock": {
+        "example": {
+          "caller": {
+            "type": "direct"
+          },
+          "id": "toolu_01abc",
+          "input": {
+            "location": "San Francisco"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        },
+        "properties": {
+          "caller": {
+            "$ref": "#/components/schemas/AnthropicCaller"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool_use"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "caller",
+          "name"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolUsesKeep": {
+        "example": {
+          "type": "tool_uses",
+          "value": 5
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "tool_uses"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolUsesTrigger": {
+        "example": {
+          "type": "tool_uses",
+          "value": 10
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "tool_uses"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AnthropicUnknownUsageIteration": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicBaseUsageIteration"
+          },
+          {
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ],
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 50,
+          "type": "unknown"
+        }
+      },
+      "AnthropicUrlImageSource": {
+        "example": {
+          "type": "url",
+          "url": "https://example.com/image.jpg"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "url"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ],
+        "type": "object"
+      },
+      "AnthropicUrlPdfSource": {
+        "example": {
+          "type": "url",
+          "url": "https://example.com/document.pdf"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "url"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ],
+        "type": "object"
+      },
+      "AnthropicUsage": {
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": null,
+          "cache_read_input_tokens": null,
+          "inference_geo": null,
+          "input_tokens": 100,
+          "output_tokens": 50,
+          "server_tool_use": null,
+          "service_tier": "standard"
+        },
+        "properties": {
+          "cache_creation": {
+            "$ref": "#/components/schemas/AnthropicCacheCreation"
+          },
+          "cache_creation_input_tokens": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "inference_geo": {
+            "nullable": true,
+            "type": "string"
+          },
+          "input_tokens": {
+            "type": "integer"
+          },
+          "output_tokens": {
+            "type": "integer"
+          },
+          "server_tool_use": {
+            "$ref": "#/components/schemas/AnthropicServerToolUsage"
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/AnthropicServiceTier"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "cache_creation_input_tokens",
+          "cache_read_input_tokens",
+          "cache_creation",
+          "inference_geo",
+          "server_tool_use",
+          "service_tier"
+        ],
+        "type": "object"
+      },
+      "AnthropicUsageIteration": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicCompactionUsageIteration"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicMessageUsageIteration"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicUnknownUsageIteration"
+          }
+        ],
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 50,
+          "type": "message"
+        }
+      },
+      "AnthropicWebFetchBlock": {
+        "example": {
+          "content": {
+            "citations": null,
+            "source": {
+              "data": "",
+              "media_type": "text/plain",
+              "type": "text"
+            },
+            "title": null,
+            "type": "document"
+          },
+          "retrieved_at": null,
+          "type": "web_fetch_result",
+          "url": "https://example.com"
+        },
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/AnthropicDocumentBlock"
+          },
+          "retrieved_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "web_fetch_result"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "retrieved_at",
+          "type",
+          "url"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebFetchContent": {
+        "discriminator": {
+          "mapping": {
+            "web_fetch_result": "#/components/schemas/AnthropicWebFetchBlock",
+            "web_fetch_tool_result_error": "#/components/schemas/AnthropicWebFetchToolResultError"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "content": {
+            "citations": null,
+            "source": {
+              "data": "",
+              "media_type": "text/plain",
+              "type": "text"
+            },
+            "title": null,
+            "type": "document"
+          },
+          "retrieved_at": null,
+          "type": "web_fetch_result",
+          "url": "https://example.com"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicWebFetchToolResultError"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicWebFetchBlock"
+          }
+        ]
+      },
+      "AnthropicWebFetchToolResult": {
+        "example": {
+          "caller": {
+            "type": "direct"
+          },
+          "content": {
+            "content": {
+              "citations": null,
+              "source": {
+                "data": "",
+                "media_type": "text/plain",
+                "type": "text"
+              },
+              "title": null,
+              "type": "document"
+            },
+            "retrieved_at": null,
+            "type": "web_fetch_result",
+            "url": "https://example.com"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "web_fetch_tool_result"
+        },
+        "properties": {
+          "caller": {
+            "$ref": "#/components/schemas/AnthropicCaller"
+          },
+          "content": {
+            "$ref": "#/components/schemas/AnthropicWebFetchContent"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "web_fetch_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "caller",
+          "content",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebFetchToolResultError": {
+        "example": {
+          "error_code": "unavailable",
+          "type": "web_fetch_tool_result_error"
+        },
+        "properties": {
+          "error_code": {
+            "enum": [
+              "invalid_tool_input",
+              "url_too_long",
+              "url_not_allowed",
+              "url_not_accessible",
+              "unsupported_content_type",
+              "too_many_requests",
+              "max_uses_exceeded",
+              "unavailable"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "web_fetch_tool_result_error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "error_code"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebSearchResult": {
+        "example": {
+          "encrypted_content": "enc_content_0",
+          "page_age": null,
+          "title": "Example Page",
+          "type": "web_search_result",
+          "url": "https://example.com"
+        },
+        "properties": {
+          "encrypted_content": {
+            "type": "string"
+          },
+          "page_age": {
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "web_search_result"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "encrypted_content",
+          "page_age",
+          "title",
+          "url"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebSearchResultBlockParam": {
+        "example": {
+          "encrypted_content": "enc_content_0",
+          "title": "Example Page",
+          "type": "web_search_result",
+          "url": "https://example.com"
+        },
+        "properties": {
+          "encrypted_content": {
+            "type": "string"
+          },
+          "page_age": {
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "web_search_result"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "encrypted_content",
+          "title",
+          "url"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebSearchToolResult": {
+        "example": {
+          "caller": {
+            "type": "direct"
+          },
+          "content": [],
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "web_search_tool_result"
+        },
+        "properties": {
+          "caller": {
+            "$ref": "#/components/schemas/AnthropicCaller"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicWebSearchResult"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicWebSearchToolResultError"
+              }
+            ]
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "web_search_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "caller",
+          "tool_use_id",
+          "content"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebSearchToolResultError": {
+        "example": {
+          "error_code": "unavailable",
+          "type": "web_search_tool_result_error"
+        },
+        "properties": {
+          "error_code": {
+            "enum": [
+              "invalid_tool_input",
+              "unavailable",
+              "max_uses_exceeded",
+              "too_many_requests",
+              "query_too_long",
+              "request_too_large"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "web_search_tool_result_error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "error_code"
+        ],
+        "type": "object"
+      },
+      "AnthropicWebSearchToolUserLocation": {
+        "example": {
+          "city": "San Francisco",
+          "country": "US",
+          "region": "California",
+          "timezone": "America/Los_Angeles",
+          "type": "approximate"
+        },
+        "nullable": true,
+        "properties": {
+          "city": {
+            "nullable": true,
+            "type": "string"
+          },
+          "country": {
+            "nullable": true,
+            "type": "string"
+          },
+          "region": {
+            "nullable": true,
+            "type": "string"
+          },
+          "timezone": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "approximate"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ApplyPatchServerTool": {
+        "description": "Apply patch tool configuration",
+        "example": {
+          "type": "apply_patch"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "apply_patch"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "AutoRouterPlugin": {
+        "example": {
+          "allowed_models": [
+            "anthropic/*",
+            "openai/gpt-4o"
+          ],
+          "enabled": true,
+          "id": "auto-router"
+        },
+        "properties": {
+          "allowed_models": {
+            "description": "List of model patterns to filter which models the auto-router can route between. Supports wildcards (e.g., \"anthropic/*\" matches all Anthropic models). When not specified, uses the default supported models list.",
+            "example": [
+              "anthropic/*",
+              "openai/gpt-4o",
+              "google/*"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "enabled": {
+            "description": "Set to false to disable the auto-router plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "id": {
+            "enum": [
+              "auto-router"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "BadGatewayResponse": {
+        "description": "Bad Gateway - Provider/upstream API failure",
+        "example": {
+          "error": {
+            "code": 502,
+            "message": "Provider returned error"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/BadGatewayResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "BadGatewayResponseErrorData": {
+        "description": "Error data for BadGatewayResponse",
+        "example": {
+          "code": 502,
+          "message": "Provider returned error"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "BadRequestResponse": {
+        "description": "Bad Request - Invalid request parameters or malformed input",
+        "example": {
+          "error": {
+            "code": 400,
+            "message": "Invalid request parameters"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/BadRequestResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "BadRequestResponseErrorData": {
+        "description": "Error data for BadRequestResponse",
+        "example": {
+          "code": 400,
+          "message": "Invalid request parameters"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "BaseAnnotationAddedEvent": {
+        "description": "Event emitted when a text annotation is added to output",
+        "example": {
+          "annotation": {
+            "end_index": 7,
+            "start_index": 0,
+            "title": "Example",
+            "type": "url_citation",
+            "url": "https://example.com"
+          },
+          "annotation_index": 0,
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 5,
+          "type": "response.output_text.annotation.added"
+        },
+        "properties": {
+          "annotation": {
+            "$ref": "#/components/schemas/OpenAIResponsesAnnotation"
+          },
+          "annotation_index": {
+            "type": "integer"
+          },
+          "content_index": {
+            "type": "integer"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.output_text.annotation.added"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "sequence_number",
+          "annotation_index",
+          "annotation"
+        ],
+        "type": "object"
+      },
+      "BaseContentPartAddedEvent": {
+        "description": "Event emitted when a new content part is added to an output item",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "annotations": [],
+            "text": "",
+            "type": "output_text"
+          },
+          "sequence_number": 3,
+          "type": "response.content_part.added"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "part": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ResponseOutputText"
+              },
+              {
+                "$ref": "#/components/schemas/OpenAIResponsesRefusalContent"
+              }
+            ]
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.content_part.added"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "part",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseContentPartDoneEvent": {
+        "description": "Event emitted when a content part is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "annotations": [],
+            "text": "Hello! How can I help you?",
+            "type": "output_text"
+          },
+          "sequence_number": 7,
+          "type": "response.content_part.done"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "part": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ResponseOutputText"
+              },
+              {
+                "$ref": "#/components/schemas/OpenAIResponsesRefusalContent"
+              }
+            ]
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.content_part.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "part",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseErrorEvent": {
+        "description": "Event emitted when an error occurs during streaming",
+        "example": {
+          "code": "rate_limit_exceeded",
+          "message": "Rate limit exceeded. Please try again later.",
+          "param": null,
+          "sequence_number": 2,
+          "type": "error"
+        },
+        "properties": {
+          "code": {
+            "nullable": true,
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "param": {
+            "nullable": true,
+            "type": "string"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "code",
+          "message",
+          "param",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseFunctionCallArgsDeltaEvent": {
+        "description": "Event emitted when function call arguments are being streamed",
+        "example": {
+          "delta": "{\"city\": \"...\"}",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.function_call_arguments.delta"
+        },
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.function_call_arguments.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "delta",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseFunctionCallArgsDoneEvent": {
+        "description": "Event emitted when function call arguments streaming is complete",
+        "example": {
+          "arguments": "{\"city\": \"San Francisco\", \"units\": \"celsius\"}",
+          "item_id": "item-1",
+          "name": "get_weather",
+          "output_index": 0,
+          "sequence_number": 6,
+          "type": "response.function_call_arguments.done"
+        },
+        "properties": {
+          "arguments": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.function_call_arguments.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "name",
+          "arguments",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseInputs": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "content": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "discriminator": {
+                              "mapping": {
+                                "input_audio": "#/components/schemas/InputAudio",
+                                "input_file": "#/components/schemas/InputFile",
+                                "input_image": "#/components/schemas/InputImage",
+                                "input_text": "#/components/schemas/InputText"
+                              },
+                              "propertyName": "type"
+                            },
+                            "oneOf": [
+                              {
+                                "$ref": "#/components/schemas/InputText"
+                              },
+                              {
+                                "$ref": "#/components/schemas/InputImage"
+                              },
+                              {
+                                "$ref": "#/components/schemas/InputFile"
+                              },
+                              {
+                                "$ref": "#/components/schemas/InputAudio"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "phase": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "commentary"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "final_answer"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "role": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "user"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "system"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "assistant"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "developer"
+                          ],
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "message"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAIResponseInputMessageItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAIResponseFunctionToolCallOutput"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAIResponseFunctionToolCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputMessage"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          {
+            "nullable": true
+          }
+        ],
+        "example": [
+          {
+            "content": "What is the weather today?",
+            "role": "user"
+          }
+        ]
+      },
+      "BaseMessagesResult": {
+        "description": "Base Anthropic Messages API response before OpenRouter extensions",
+        "example": {
+          "container": null,
+          "content": [
+            {
+              "citations": null,
+              "text": "Hello!",
+              "type": "text"
+            }
+          ],
+          "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+          "model": "claude-sonnet-4-5-20250929",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": "end_turn",
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "input_tokens": 12,
+            "output_tokens": 8
+          }
+        },
+        "properties": {
+          "container": {
+            "$ref": "#/components/schemas/AnthropicContainer"
+          },
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/ORAnthropicContentBlock"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "stop_details": {
+            "$ref": "#/components/schemas/AnthropicRefusalStopDetails"
+          },
+          "stop_reason": {
+            "$ref": "#/components/schemas/ORAnthropicStopReason"
+          },
+          "stop_sequence": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicUsage"
+              },
+              {
+                "properties": {
+                  "iterations": {
+                    "items": {
+                      "$ref": "#/components/schemas/AnthropicUsageIteration"
+                    },
+                    "type": "array"
+                  },
+                  "speed": {
+                    "$ref": "#/components/schemas/AnthropicSpeed"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "example": {
+              "cache_creation": null,
+              "cache_creation_input_tokens": null,
+              "cache_read_input_tokens": null,
+              "inference_geo": null,
+              "input_tokens": 100,
+              "output_tokens": 50,
+              "server_tool_use": null,
+              "service_tier": "standard"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "role",
+          "container",
+          "content",
+          "model",
+          "stop_reason",
+          "stop_details",
+          "stop_sequence",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "BaseReasoningConfig": {
+        "example": {
+          "effort": "medium",
+          "summary": "auto"
+        },
+        "nullable": true,
+        "properties": {
+          "effort": {
+            "$ref": "#/components/schemas/ReasoningEffort"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/ReasoningSummaryVerbosity"
+          }
+        },
+        "type": "object"
+      },
+      "BaseReasoningDeltaEvent": {
+        "description": "Event emitted when reasoning text delta is streamed",
+        "example": {
+          "content_index": 0,
+          "delta": "First, we need",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.reasoning_text.delta"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.reasoning_text.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "delta",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseReasoningDoneEvent": {
+        "description": "Event emitted when reasoning text streaming is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 6,
+          "text": "First, we need to identify the key components and then combine them logically.",
+          "type": "response.reasoning_text.done"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "response.reasoning_text.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "text",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseReasoningSummaryPartAddedEvent": {
+        "description": "Event emitted when a reasoning summary part is added",
+        "example": {
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "text": "",
+            "type": "summary_text"
+          },
+          "sequence_number": 3,
+          "summary_index": 0,
+          "type": "response.reasoning_summary_part.added"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "part": {
+            "$ref": "#/components/schemas/ReasoningSummaryText"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "summary_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.reasoning_summary_part.added"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "summary_index",
+          "part",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseReasoningSummaryPartDoneEvent": {
+        "description": "Event emitted when a reasoning summary part is complete",
+        "example": {
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "text": "Analyzing the problem step by step to find the optimal solution.",
+            "type": "summary_text"
+          },
+          "sequence_number": 7,
+          "summary_index": 0,
+          "type": "response.reasoning_summary_part.done"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "part": {
+            "$ref": "#/components/schemas/ReasoningSummaryText"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "summary_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.reasoning_summary_part.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "summary_index",
+          "part",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseReasoningSummaryTextDeltaEvent": {
+        "description": "Event emitted when reasoning summary text delta is streamed",
+        "example": {
+          "delta": "Analyzing",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "summary_index": 0,
+          "type": "response.reasoning_summary_text.delta"
+        },
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "summary_index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.reasoning_summary_text.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "summary_index",
+          "delta",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseReasoningSummaryTextDoneEvent": {
+        "description": "Event emitted when reasoning summary text streaming is complete",
+        "example": {
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 6,
+          "summary_index": 0,
+          "text": "Analyzing the problem step by step to find the optimal solution.",
+          "type": "response.reasoning_summary_text.done"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "summary_index": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "response.reasoning_summary_text.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "summary_index",
+          "text",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseRefusalDeltaEvent": {
+        "description": "Event emitted when a refusal delta is streamed",
+        "example": {
+          "content_index": 0,
+          "delta": "I'm sorry",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.refusal.delta"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.refusal.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "delta",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseRefusalDoneEvent": {
+        "description": "Event emitted when refusal streaming is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "refusal": "I'm sorry, but I can't assist with that request.",
+          "sequence_number": 6,
+          "type": "response.refusal.done"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "refusal": {
+            "type": "string"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.refusal.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "refusal",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseResponsesResult": {
+        "example": {
+          "completed_at": 1704067210,
+          "created_at": 1704067200,
+          "error": null,
+          "id": "resp-abc123",
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "metadata": null,
+          "model": "gpt-4",
+          "object": "response",
+          "output": [],
+          "parallel_tool_calls": true,
+          "status": "completed",
+          "temperature": null,
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": null
+        },
+        "properties": {
+          "background": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "completed_at": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "integer"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ResponsesErrorField"
+          },
+          "frequency_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "incomplete_details": {
+            "$ref": "#/components/schemas/IncompleteDetails"
+          },
+          "instructions": {
+            "$ref": "#/components/schemas/BaseInputs"
+          },
+          "max_output_tokens": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          "model": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "response"
+            ],
+            "type": "string"
+          },
+          "output": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
+                  "function_call": "#/components/schemas/OutputItemFunctionCall",
+                  "image_generation_call": "#/components/schemas/OutputItemImageGenerationCall",
+                  "message": "#/components/schemas/OutputMessage",
+                  "reasoning": "#/components/schemas/OutputItemReasoning",
+                  "web_search_call": "#/components/schemas/OutputItemWebSearchCall"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/OutputMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemReasoning"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemFunctionCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemWebSearchCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemFileSearchCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "output_text": {
+            "type": "string"
+          },
+          "parallel_tool_calls": {
+            "type": "boolean"
+          },
+          "presence_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "previous_response_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "prompt": {
+            "$ref": "#/components/schemas/StoredPromptTemplate"
+          },
+          "prompt_cache_key": {
+            "nullable": true,
+            "type": "string"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/BaseReasoningConfig"
+          },
+          "safety_identifier": {
+            "nullable": true,
+            "type": "string"
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/ServiceTier"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OpenAIResponsesResponseStatus"
+          },
+          "store": {
+            "type": "boolean"
+          },
+          "temperature": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "text": {
+            "$ref": "#/components/schemas/TextConfig"
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
+          },
+          "tools": {
+            "items": {
+              "oneOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/FunctionTool"
+                    },
+                    {
+                      "properties": {},
+                      "type": "object"
+                    }
+                  ],
+                  "description": "Function tool definition",
+                  "example": {
+                    "description": "Get the current weather in a location",
+                    "name": "get_weather",
+                    "parameters": {
+                      "properties": {
+                        "location": {
+                          "description": "The city and state",
+                          "type": "string"
+                        },
+                        "unit": {
+                          "enum": [
+                            "celsius",
+                            "fahrenheit"
+                          ],
+                          "type": "string",
+                          "x-speakeasy-unknown-values": "allow"
+                        }
+                      },
+                      "required": [
+                        "location"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "function"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/Preview_WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/Preview_20250311_WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/Legacy_WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/FileSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ComputerUseServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CodeInterpreterServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/McpServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ImageGenerationServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CodexLocalShellTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ShellServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ApplyPatchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CustomTool"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "top_logprobs": {
+            "type": "integer"
+          },
+          "top_p": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "truncation": {
+            "$ref": "#/components/schemas/Truncation"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/OpenAIResponsesUsage"
+          },
+          "user": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "model",
+          "status",
+          "completed_at",
+          "output",
+          "error",
+          "incomplete_details",
+          "temperature",
+          "top_p",
+          "presence_penalty",
+          "frequency_penalty",
+          "instructions",
+          "metadata",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls"
+        ],
+        "type": "object"
+      },
+      "BaseTextDeltaEvent": {
+        "description": "Event emitted when a text delta is streamed",
+        "example": {
+          "content_index": 0,
+          "delta": "Hello",
+          "item_id": "item-1",
+          "logprobs": [],
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.output_text.delta"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "logprobs": {
+            "items": {
+              "$ref": "#/components/schemas/OpenResponsesLogProbs"
+            },
+            "type": "array"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.output_text.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "logprobs",
+          "output_index",
+          "item_id",
+          "content_index",
+          "delta",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseTextDoneEvent": {
+        "description": "Event emitted when text streaming is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "logprobs": [],
+          "output_index": 0,
+          "sequence_number": 6,
+          "text": "Hello! How can I help you?",
+          "type": "response.output_text.done"
+        },
+        "properties": {
+          "content_index": {
+            "type": "integer"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "logprobs": {
+            "items": {
+              "$ref": "#/components/schemas/OpenResponsesLogProbs"
+            },
+            "type": "array"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "response.output_text.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "content_index",
+          "text",
+          "sequence_number",
+          "logprobs"
+        ],
+        "type": "object"
+      },
+      "BigNumberUnion": {
+        "description": "Price per million prompt tokens",
+        "example": 1000,
+        "type": "string"
+      },
+      "BulkAssignKeysRequest": {
+        "example": {
+          "key_hashes": [
+            "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93"
+          ]
+        },
+        "properties": {
+          "key_hashes": {
+            "description": "Array of API key hashes to assign to the guardrail",
+            "example": [
+              "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93"
+            ],
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "key_hashes"
+        ],
+        "type": "object"
+      },
+      "BulkAssignKeysResponse": {
+        "example": {
+          "assigned_count": 3
+        },
+        "properties": {
+          "assigned_count": {
+            "description": "Number of keys successfully assigned",
+            "example": 3,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "assigned_count"
+        ],
+        "type": "object"
+      },
+      "BulkAssignMembersRequest": {
+        "example": {
+          "member_user_ids": [
+            "user_abc123",
+            "user_def456"
+          ]
+        },
+        "properties": {
+          "member_user_ids": {
+            "description": "Array of member user IDs to assign to the guardrail",
+            "example": [
+              "user_abc123",
+              "user_def456"
+            ],
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "member_user_ids"
+        ],
+        "type": "object"
+      },
+      "BulkAssignMembersResponse": {
+        "example": {
+          "assigned_count": 2
+        },
+        "properties": {
+          "assigned_count": {
+            "description": "Number of members successfully assigned",
+            "example": 2,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "assigned_count"
+        ],
+        "type": "object"
+      },
+      "BulkUnassignKeysRequest": {
+        "example": {
+          "key_hashes": [
+            "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93"
+          ]
+        },
+        "properties": {
+          "key_hashes": {
+            "description": "Array of API key hashes to unassign from the guardrail",
+            "example": [
+              "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93"
+            ],
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "key_hashes"
+        ],
+        "type": "object"
+      },
+      "BulkUnassignKeysResponse": {
+        "example": {
+          "unassigned_count": 3
+        },
+        "properties": {
+          "unassigned_count": {
+            "description": "Number of keys successfully unassigned",
+            "example": 3,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "unassigned_count"
+        ],
+        "type": "object"
+      },
+      "BulkUnassignMembersRequest": {
+        "example": {
+          "member_user_ids": [
+            "user_abc123",
+            "user_def456"
+          ]
+        },
+        "properties": {
+          "member_user_ids": {
+            "description": "Array of member user IDs to unassign from the guardrail",
+            "example": [
+              "user_abc123",
+              "user_def456"
+            ],
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "member_user_ids"
+        ],
+        "type": "object"
+      },
+      "BulkUnassignMembersResponse": {
+        "example": {
+          "unassigned_count": 2
+        },
+        "properties": {
+          "unassigned_count": {
+            "description": "Number of members successfully unassigned",
+            "example": 2,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "unassigned_count"
+        ],
+        "type": "object"
+      },
+      "ChatAssistantImages": {
+        "description": "Generated images from image generation models",
+        "example": [
+          {
+            "image_url": {
+              "url": "data:image/png;base64,iVBORw0KGgo..."
+            }
+          }
+        ],
+        "items": {
+          "properties": {
+            "image_url": {
+              "properties": {
+                "url": {
+                  "description": "URL or base64-encoded data of the generated image",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "image_url"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "ChatAssistantMessage": {
+        "description": "Assistant message for requests and responses",
+        "example": {
+          "content": "The capital of France is Paris.",
+          "role": "assistant"
+        },
+        "properties": {
+          "audio": {
+            "$ref": "#/components/schemas/ChatAudioOutput"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatContentItems"
+                },
+                "type": "array"
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "description": "Assistant message content"
+          },
+          "images": {
+            "$ref": "#/components/schemas/ChatAssistantImages"
+          },
+          "name": {
+            "description": "Optional name for the assistant",
+            "type": "string"
+          },
+          "reasoning": {
+            "description": "Reasoning output",
+            "nullable": true,
+            "type": "string"
+          },
+          "reasoning_details": {
+            "$ref": "#/components/schemas/ChatReasoningDetails"
+          },
+          "refusal": {
+            "description": "Refusal message if content was refused",
+            "nullable": true,
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "tool_calls": {
+            "description": "Tool calls made by the assistant",
+            "items": {
+              "$ref": "#/components/schemas/ChatToolCall"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "type": "object"
+      },
+      "ChatAudioOutput": {
+        "description": "Audio output data or reference",
+        "example": {
+          "data": "UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1f",
+          "expires_at": 1677652400,
+          "id": "audio_abc123",
+          "transcript": "Hello! How can I help you today?"
+        },
+        "properties": {
+          "data": {
+            "description": "Base64 encoded audio data",
+            "type": "string"
+          },
+          "expires_at": {
+            "description": "Audio expiration timestamp",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Audio output identifier",
+            "type": "string"
+          },
+          "transcript": {
+            "description": "Audio transcript",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChatChoice": {
+        "description": "Chat completion choice",
+        "example": {
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null,
+          "message": {
+            "content": "The capital of France is Paris.",
+            "role": "assistant"
+          }
+        },
+        "properties": {
+          "finish_reason": {
+            "$ref": "#/components/schemas/ChatFinishReasonEnum"
+          },
+          "index": {
+            "description": "Choice index",
+            "example": 0,
+            "type": "integer"
+          },
+          "logprobs": {
+            "$ref": "#/components/schemas/ChatTokenLogprobs"
+          },
+          "message": {
+            "$ref": "#/components/schemas/ChatAssistantMessage"
+          }
+        },
+        "required": [
+          "finish_reason",
+          "index",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ChatContentAudio": {
+        "description": "Audio input content part. Supported audio formats vary by provider.",
+        "example": {
+          "input_audio": {
+            "data": "SGVsbG8gV29ybGQ=",
+            "format": "wav"
+          },
+          "type": "input_audio"
+        },
+        "properties": {
+          "input_audio": {
+            "properties": {
+              "data": {
+                "description": "Base64 encoded audio data",
+                "type": "string"
+              },
+              "format": {
+                "description": "Audio format (e.g., wav, mp3, flac, m4a, ogg, aiff, aac, pcm16, pcm24). Supported formats vary by provider.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "format"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "input_audio"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "input_audio"
+        ],
+        "type": "object"
+      },
+      "ChatContentCacheControl": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Cache control for the content part",
+        "example": {
+          "ttl": "5m",
+          "type": "ephemeral"
+        }
+      },
+      "ChatContentFile": {
+        "description": "File content part for document processing",
+        "example": {
+          "file": {
+            "file_data": "https://example.com/document.pdf",
+            "filename": "document.pdf"
+          },
+          "type": "file"
+        },
+        "properties": {
+          "file": {
+            "properties": {
+              "file_data": {
+                "description": "File content as base64 data URL or URL",
+                "type": "string"
+              },
+              "file_id": {
+                "description": "File ID for previously uploaded files",
+                "type": "string"
+              },
+              "filename": {
+                "description": "Original filename",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file"
+        ],
+        "type": "object"
+      },
+      "ChatContentImage": {
+        "description": "Image content part for vision models",
+        "example": {
+          "image_url": {
+            "detail": "auto",
+            "url": "https://example.com/image.jpg"
+          },
+          "type": "image_url"
+        },
+        "properties": {
+          "image_url": {
+            "properties": {
+              "detail": {
+                "description": "Image detail level for vision models",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              },
+              "url": {
+                "description": "URL of the image (data: URLs supported)",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "image_url"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image_url"
+        ],
+        "type": "object"
+      },
+      "ChatContentItems": {
+        "description": "Content part for chat completion messages",
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/ChatContentFile",
+            "image_url": "#/components/schemas/ChatContentImage",
+            "input_audio": "#/components/schemas/ChatContentAudio",
+            "input_video": "#/components/schemas/Legacy_ChatContentVideo",
+            "text": "#/components/schemas/ChatContentText",
+            "video_url": "#/components/schemas/ChatContentVideo"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "text": "Hello, world!",
+          "type": "text"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatContentText"
+          },
+          {
+            "$ref": "#/components/schemas/ChatContentImage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatContentAudio"
+          },
+          {
+            "$ref": "#/components/schemas/Legacy_ChatContentVideo"
+          },
+          {
+            "$ref": "#/components/schemas/ChatContentVideo"
+          },
+          {
+            "$ref": "#/components/schemas/ChatContentFile"
+          }
+        ]
+      },
+      "ChatContentText": {
+        "description": "Text content part",
+        "example": {
+          "text": "Hello, world!",
+          "type": "text"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/ChatContentCacheControl"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "ChatContentVideo": {
+        "description": "Video input content part",
+        "example": {
+          "type": "video_url",
+          "video_url": {
+            "url": "https://example.com/video.mp4"
+          }
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "video_url"
+            ],
+            "type": "string"
+          },
+          "video_url": {
+            "$ref": "#/components/schemas/ChatContentVideoInput"
+          }
+        },
+        "required": [
+          "type",
+          "video_url"
+        ],
+        "type": "object"
+      },
+      "ChatContentVideoInput": {
+        "description": "Video input object",
+        "example": {
+          "url": "https://example.com/video.mp4"
+        },
+        "properties": {
+          "url": {
+            "description": "URL of the video (data: URLs supported)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "ChatDebugOptions": {
+        "description": "Debug options for inspecting request transformations (streaming only)",
+        "example": {
+          "echo_upstream_body": true
+        },
+        "properties": {
+          "echo_upstream_body": {
+            "description": "If true, includes the transformed upstream request body in a debug chunk at the start of the stream. Only works with streaming mode.",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "ChatDeveloperMessage": {
+        "description": "Developer message",
+        "example": {
+          "content": "This is a message from the developer.",
+          "role": "developer"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatContentText"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Developer message content",
+            "example": "This is a message from the developer."
+          },
+          "name": {
+            "description": "Optional name for the developer message",
+            "example": "Developer",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "developer"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChatFinishReasonEnum": {
+        "enum": [
+          "tool_calls",
+          "stop",
+          "length",
+          "content_filter",
+          "error",
+          null
+        ],
+        "example": "stop",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ChatFormatGrammarConfig": {
+        "description": "Custom grammar response format",
+        "example": {
+          "grammar": "root ::= \"yes\" | \"no\"",
+          "type": "grammar"
+        },
+        "properties": {
+          "grammar": {
+            "description": "Custom grammar for text generation",
+            "example": "root ::= \"yes\" | \"no\"",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "grammar"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "grammar"
+        ],
+        "type": "object"
+      },
+      "ChatFormatJsonSchemaConfig": {
+        "description": "JSON Schema response format for structured outputs",
+        "example": {
+          "json_schema": {
+            "name": "math_response",
+            "schema": {
+              "properties": {
+                "answer": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "answer"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "json_schema"
+        },
+        "properties": {
+          "json_schema": {
+            "$ref": "#/components/schemas/ChatJsonSchemaConfig"
+          },
+          "type": {
+            "enum": [
+              "json_schema"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "json_schema"
+        ],
+        "type": "object"
+      },
+      "ChatFormatPythonConfig": {
+        "description": "Python code response format",
+        "example": {
+          "type": "python"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "python"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ChatFormatTextConfig": {
+        "description": "Default text response format",
+        "example": {
+          "type": "text"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ChatFunctionTool": {
+        "anyOf": [
+          {
+            "properties": {
+              "cache_control": {
+                "$ref": "#/components/schemas/ChatContentCacheControl"
+              },
+              "function": {
+                "description": "Function definition for tool calling",
+                "example": {
+                  "description": "Get the current weather for a location",
+                  "name": "get_weather",
+                  "parameters": {
+                    "properties": {
+                      "location": {
+                        "description": "City name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "location"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "properties": {
+                  "description": {
+                    "description": "Function description for the model",
+                    "example": "Get the current weather for a location",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Function name (a-z, A-Z, 0-9, underscores, dashes, max 64 chars)",
+                    "example": "get_weather",
+                    "maxLength": 64,
+                    "type": "string"
+                  },
+                  "parameters": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "description": "Function parameters as JSON Schema object",
+                    "example": {
+                      "properties": {
+                        "location": {
+                          "description": "City name",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "location"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "strict": {
+                    "description": "Enable strict schema adherence",
+                    "example": false,
+                    "nullable": true,
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "function"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "function"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/DatetimeServerTool"
+          },
+          {
+            "$ref": "#/components/schemas/ImageGenerationServerTool_OpenRouter"
+          },
+          {
+            "$ref": "#/components/schemas/ChatSearchModelsServerTool"
+          },
+          {
+            "$ref": "#/components/schemas/OpenRouterWebSearchServerTool"
+          },
+          {
+            "$ref": "#/components/schemas/ChatWebSearchShorthand"
+          }
+        ],
+        "description": "Tool definition for function calling (regular function or OpenRouter built-in server tool)",
+        "example": {
+          "function": {
+            "description": "Get the current weather for a location",
+            "name": "get_weather",
+            "parameters": {
+              "properties": {
+                "location": {
+                  "description": "City name",
+                  "type": "string"
+                },
+                "unit": {
+                  "enum": [
+                    "celsius",
+                    "fahrenheit"
+                  ],
+                  "type": "string",
+                  "x-speakeasy-unknown-values": "allow"
+                }
+              },
+              "required": [
+                "location"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "function"
+        }
+      },
+      "ChatJsonSchemaConfig": {
+        "description": "JSON Schema configuration object",
+        "example": {
+          "description": "A mathematical response",
+          "name": "math_response",
+          "schema": {
+            "properties": {
+              "answer": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "answer"
+            ],
+            "type": "object"
+          },
+          "strict": true
+        },
+        "properties": {
+          "description": {
+            "description": "Schema description for the model",
+            "example": "A mathematical response",
+            "type": "string"
+          },
+          "name": {
+            "description": "Schema name (a-z, A-Z, 0-9, underscores, dashes, max 64 chars)",
+            "example": "math_response",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "schema": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "JSON Schema object",
+            "example": {
+              "properties": {
+                "answer": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "answer"
+              ],
+              "type": "object"
+            },
+            "type": "object"
+          },
+          "strict": {
+            "description": "Enable strict schema adherence",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "ChatMessages": {
+        "description": "Chat completion message with role-based discrimination",
+        "discriminator": {
+          "mapping": {
+            "assistant": "#/components/schemas/ChatAssistantMessage",
+            "developer": "#/components/schemas/ChatDeveloperMessage",
+            "system": "#/components/schemas/ChatSystemMessage",
+            "tool": "#/components/schemas/ChatToolMessage",
+            "user": "#/components/schemas/ChatUserMessage"
+          },
+          "propertyName": "role"
+        },
+        "example": {
+          "content": "What is the capital of France?",
+          "role": "user"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatSystemMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatUserMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatDeveloperMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatAssistantMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatToolMessage"
+          }
+        ]
+      },
+      "ChatModelNames": {
+        "description": "Models to use for completion",
+        "example": [
+          "openai/gpt-4",
+          "openai/gpt-4o"
+        ],
+        "items": {
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/ModelName"
+            },
+            {
+              "description": "Available OpenRouter chat completion models"
+            }
+          ]
+        },
+        "type": "array"
+      },
+      "ChatNamedToolChoice": {
+        "description": "Named tool choice for specific function",
+        "example": {
+          "function": {
+            "name": "get_weather"
+          },
+          "type": "function"
+        },
+        "properties": {
+          "function": {
+            "properties": {
+              "name": {
+                "description": "Function name to call",
+                "example": "get_weather",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "function"
+        ],
+        "type": "object"
+      },
+      "ChatReasoningDetails": {
+        "description": "Reasoning details for extended thinking models",
+        "example": [
+          {
+            "thinking": "Let me work through this step by step...",
+            "type": "thinking"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/ReasoningDetailUnion"
+        },
+        "type": "array"
+      },
+      "ChatReasoningSummaryVerbosityEnum": {
+        "enum": [
+          "auto",
+          "concise",
+          "detailed",
+          null
+        ],
+        "example": "concise",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ChatRequest": {
+        "description": "Chat completion request parameters",
+        "example": {
+          "max_tokens": 150,
+          "messages": [
+            {
+              "content": "You are a helpful assistant.",
+              "role": "system"
+            },
+            {
+              "content": "What is the capital of France?",
+              "role": "user"
+            }
+          ],
+          "model": "openai/gpt-4",
+          "temperature": 0.7
+        },
+        "properties": {
+          "cache_control": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+              },
+              {
+                "description": "Enable automatic prompt caching. When set, the system automatically applies cache breakpoints to the last cacheable block in the request. Currently supported for Anthropic Claude models."
+              }
+            ]
+          },
+          "debug": {
+            "$ref": "#/components/schemas/ChatDebugOptions"
+          },
+          "frequency_penalty": {
+            "description": "Frequency penalty (-2.0 to 2.0)",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "image_config": {
+            "$ref": "#/components/schemas/ImageConfig"
+          },
+          "logit_bias": {
+            "additionalProperties": {
+              "format": "double",
+              "type": "number"
+            },
+            "description": "Token logit bias adjustments",
+            "example": {
+              "50256": -100
+            },
+            "nullable": true,
+            "type": "object"
+          },
+          "logprobs": {
+            "description": "Return log probabilities",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "max_completion_tokens": {
+            "description": "Maximum tokens in completion",
+            "example": 100,
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_tokens": {
+            "description": "Maximum tokens (deprecated, use max_completion_tokens). Note: some providers enforce a minimum of 16.",
+            "example": 100,
+            "nullable": true,
+            "type": "integer"
+          },
+          "messages": {
+            "description": "List of messages for the conversation",
+            "example": [
+              {
+                "content": "Hello!",
+                "role": "user"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ChatMessages"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Key-value pairs for additional object information (max 16 pairs, 64 char keys, 512 char values)",
+            "example": {
+              "session_id": "session-456",
+              "user_id": "user-123"
+            },
+            "type": "object"
+          },
+          "modalities": {
+            "description": "Output modalities for the response. Supported values are \"text\", \"image\", and \"audio\".",
+            "example": [
+              "text",
+              "image"
+            ],
+            "items": {
+              "enum": [
+                "text",
+                "image",
+                "audio"
+              ],
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            },
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/ModelName"
+          },
+          "models": {
+            "$ref": "#/components/schemas/ChatModelNames"
+          },
+          "parallel_tool_calls": {
+            "description": "Whether to enable parallel function calling during tool use. When true, the model may generate multiple tool calls in a single response.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "plugins": {
+            "description": "Plugins you want to enable for this request, including their settings.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "auto-router": "#/components/schemas/AutoRouterPlugin",
+                  "context-compression": "#/components/schemas/ContextCompressionPlugin",
+                  "file-parser": "#/components/schemas/FileParserPlugin",
+                  "moderation": "#/components/schemas/ModerationPlugin",
+                  "response-healing": "#/components/schemas/ResponseHealingPlugin",
+                  "web": "#/components/schemas/WebSearchPlugin"
+                },
+                "propertyName": "id"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AutoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ModerationPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/FileParserPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ResponseHealingPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ContextCompressionPlugin"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "presence_penalty": {
+            "description": "Presence penalty (-2.0 to 2.0)",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/ProviderPreferences"
+          },
+          "reasoning": {
+            "description": "Configuration options for reasoning models",
+            "example": {
+              "effort": "medium",
+              "summary": "concise"
+            },
+            "properties": {
+              "effort": {
+                "description": "Constrains effort on reasoning for reasoning models",
+                "enum": [
+                  "xhigh",
+                  "high",
+                  "medium",
+                  "low",
+                  "minimal",
+                  "none",
+                  null
+                ],
+                "example": "medium",
+                "nullable": true,
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              },
+              "summary": {
+                "$ref": "#/components/schemas/ChatReasoningSummaryVerbosityEnum"
+              }
+            },
+            "type": "object"
+          },
+          "response_format": {
+            "description": "Response format configuration",
+            "discriminator": {
+              "mapping": {
+                "grammar": "#/components/schemas/ChatFormatGrammarConfig",
+                "json_object": "#/components/schemas/FormatJsonObjectConfig",
+                "json_schema": "#/components/schemas/ChatFormatJsonSchemaConfig",
+                "python": "#/components/schemas/ChatFormatPythonConfig",
+                "text": "#/components/schemas/ChatFormatTextConfig"
+              },
+              "propertyName": "type"
+            },
+            "example": {
+              "type": "json_object"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ChatFormatTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/FormatJsonObjectConfig"
+              },
+              {
+                "$ref": "#/components/schemas/ChatFormatJsonSchemaConfig"
+              },
+              {
+                "$ref": "#/components/schemas/ChatFormatGrammarConfig"
+              },
+              {
+                "$ref": "#/components/schemas/ChatFormatPythonConfig"
+              }
+            ]
+          },
+          "route": {
+            "$ref": "#/components/schemas/DeprecatedRoute"
+          },
+          "seed": {
+            "description": "Random seed for deterministic outputs",
+            "example": 42,
+            "nullable": true,
+            "type": "integer"
+          },
+          "service_tier": {
+            "description": "The service tier to use for processing this request.",
+            "enum": [
+              "auto",
+              "default",
+              "flex",
+              "priority",
+              "scale",
+              null
+            ],
+            "example": "auto",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "session_id": {
+            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 4,
+                "type": "array"
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "description": "Stop sequences (up to 4)",
+            "example": [
+              ""
+            ]
+          },
+          "stream": {
+            "default": false,
+            "description": "Enable streaming response",
+            "example": false,
+            "type": "boolean"
+          },
+          "stream_options": {
+            "$ref": "#/components/schemas/ChatStreamOptions"
+          },
+          "temperature": {
+            "description": "Sampling temperature (0-2)",
+            "example": 0.7,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/ChatToolChoice"
+          },
+          "tools": {
+            "description": "Available tools for function calling",
+            "example": [
+              {
+                "function": {
+                  "description": "Get weather",
+                  "name": "get_weather"
+                },
+                "type": "function"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ChatFunctionTool"
+            },
+            "type": "array"
+          },
+          "top_logprobs": {
+            "description": "Number of top log probabilities to return (0-20)",
+            "example": 5,
+            "nullable": true,
+            "type": "integer"
+          },
+          "top_p": {
+            "description": "Nucleus sampling parameter (0-1)",
+            "example": 1,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceConfig"
+          },
+          "user": {
+            "description": "Unique user identifier",
+            "example": "user-123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "messages"
+        ],
+        "type": "object"
+      },
+      "ChatResult": {
+        "description": "Chat completion response",
+        "example": {
+          "choices": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "The capital of France is Paris.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "created": 1677652288,
+          "id": "chatcmpl-123",
+          "model": "openai/gpt-4",
+          "object": "chat.completion",
+          "usage": {
+            "completion_tokens": 15,
+            "prompt_tokens": 10,
+            "total_tokens": 25
+          }
+        },
+        "properties": {
+          "choices": {
+            "description": "List of completion choices",
+            "items": {
+              "$ref": "#/components/schemas/ChatChoice"
+            },
+            "type": "array"
+          },
+          "created": {
+            "description": "Unix timestamp of creation",
+            "example": 1677652288,
+            "type": "integer"
+          },
+          "id": {
+            "description": "Unique completion identifier",
+            "example": "chatcmpl-123",
+            "type": "string"
+          },
+          "model": {
+            "description": "Model used for completion",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "chat.completion"
+            ],
+            "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier used by the upstream provider for this request",
+            "example": "default",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_fingerprint": {
+            "description": "System fingerprint",
+            "example": "fp_44709d6fcb",
+            "nullable": true,
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ChatUsage"
+          }
+        },
+        "required": [
+          "id",
+          "choices",
+          "created",
+          "model",
+          "object",
+          "system_fingerprint"
+        ],
+        "type": "object"
+      },
+      "ChatSearchModelsServerTool": {
+        "description": "OpenRouter built-in server tool: searches and filters AI models available on OpenRouter",
+        "example": {
+          "parameters": {
+            "max_results": 5
+          },
+          "type": "openrouter:experimental__search_models"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/SearchModelsServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:experimental__search_models"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ChatStreamChoice": {
+        "description": "Streaming completion choice chunk",
+        "example": {
+          "delta": {
+            "content": "Hello",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0
+        },
+        "properties": {
+          "delta": {
+            "$ref": "#/components/schemas/ChatStreamDelta"
+          },
+          "finish_reason": {
+            "$ref": "#/components/schemas/ChatFinishReasonEnum"
+          },
+          "index": {
+            "description": "Choice index",
+            "example": 0,
+            "type": "integer"
+          },
+          "logprobs": {
+            "$ref": "#/components/schemas/ChatTokenLogprobs"
+          }
+        },
+        "required": [
+          "delta",
+          "finish_reason",
+          "index"
+        ],
+        "type": "object"
+      },
+      "ChatStreamChunk": {
+        "description": "Streaming chat completion chunk",
+        "example": {
+          "choices": [
+            {
+              "delta": {
+                "content": "Hello",
+                "role": "assistant"
+              },
+              "finish_reason": null,
+              "index": 0
+            }
+          ],
+          "created": 1677652288,
+          "id": "chatcmpl-123",
+          "model": "openai/gpt-4",
+          "object": "chat.completion.chunk"
+        },
+        "properties": {
+          "choices": {
+            "description": "List of streaming chunk choices",
+            "items": {
+              "$ref": "#/components/schemas/ChatStreamChoice"
+            },
+            "type": "array"
+          },
+          "created": {
+            "description": "Unix timestamp of creation",
+            "example": 1677652288,
+            "type": "integer"
+          },
+          "error": {
+            "description": "Error information",
+            "example": {
+              "code": 429,
+              "message": "Rate limit exceeded"
+            },
+            "properties": {
+              "code": {
+                "description": "Error code",
+                "example": 429,
+                "format": "int32",
+                "type": "integer"
+              },
+              "message": {
+                "description": "Error message",
+                "example": "Rate limit exceeded",
+                "type": "string"
+              }
+            },
+            "required": [
+              "message",
+              "code"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "Unique chunk identifier",
+            "example": "chatcmpl-123",
+            "type": "string"
+          },
+          "model": {
+            "description": "Model used for completion",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "chat.completion.chunk"
+            ],
+            "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier used by the upstream provider for this request",
+            "example": "default",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_fingerprint": {
+            "description": "System fingerprint",
+            "example": "fp_44709d6fcb",
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ChatUsage"
+          }
+        },
+        "required": [
+          "id",
+          "choices",
+          "created",
+          "model",
+          "object"
+        ],
+        "type": "object",
+        "x-speakeasy-entity": "ChatStreamChunk"
+      },
+      "ChatStreamDelta": {
+        "description": "Delta changes in streaming response",
+        "example": {
+          "content": "Hello",
+          "role": "assistant"
+        },
+        "properties": {
+          "audio": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChatAudioOutput"
+              },
+              {
+                "description": "Audio output data"
+              }
+            ]
+          },
+          "content": {
+            "description": "Message content delta",
+            "example": "Hello",
+            "nullable": true,
+            "type": "string"
+          },
+          "reasoning": {
+            "description": "Reasoning content delta",
+            "example": "I need to",
+            "nullable": true,
+            "type": "string"
+          },
+          "reasoning_details": {
+            "$ref": "#/components/schemas/ChatStreamReasoningDetails"
+          },
+          "refusal": {
+            "description": "Refusal message delta",
+            "example": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of the message author",
+            "enum": [
+              "assistant"
+            ],
+            "example": "assistant",
+            "type": "string"
+          },
+          "tool_calls": {
+            "description": "Tool calls delta",
+            "items": {
+              "$ref": "#/components/schemas/ChatStreamToolCall"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ChatStreamOptions": {
+        "description": "Streaming configuration options",
+        "example": {
+          "include_usage": true
+        },
+        "nullable": true,
+        "properties": {
+          "include_usage": {
+            "deprecated": true,
+            "description": "Deprecated: This field has no effect. Full usage details are always included.",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "ChatStreamReasoningDetails": {
+        "description": "Reasoning details for extended thinking models",
+        "example": [
+          {
+            "text": "Let me think about this...",
+            "type": "text"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/ReasoningDetailUnion"
+        },
+        "type": "array"
+      },
+      "ChatStreamToolCall": {
+        "description": "Tool call delta for streaming responses",
+        "example": {
+          "function": {
+            "arguments": "{\"location\": \"...\"}",
+            "name": "get_weather"
+          },
+          "id": "call_abc123",
+          "index": 0,
+          "type": "function"
+        },
+        "properties": {
+          "function": {
+            "description": "Function call details",
+            "properties": {
+              "arguments": {
+                "description": "Function arguments as JSON string",
+                "example": "{\"location\": \"...\"}",
+                "type": "string"
+              },
+              "name": {
+                "description": "Function name",
+                "example": "get_weather",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "Tool call identifier",
+            "example": "call_abc123",
+            "type": "string"
+          },
+          "index": {
+            "description": "Tool call index in the array",
+            "example": 0,
+            "type": "integer"
+          },
+          "type": {
+            "description": "Tool call type",
+            "enum": [
+              "function"
+            ],
+            "example": "function",
+            "type": "string"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "ChatSystemMessage": {
+        "description": "System message for setting behavior",
+        "example": {
+          "content": "You are a helpful assistant.",
+          "name": "Assistant Config",
+          "role": "system"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatContentText"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "System message content",
+            "example": "You are a helpful assistant."
+          },
+          "name": {
+            "description": "Optional name for the system message",
+            "example": "Assistant Config",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "system"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChatTokenLogprob": {
+        "description": "Token log probability information",
+        "example": {
+          "bytes": null,
+          "logprob": -0.612345,
+          "token": " Hello",
+          "top_logprobs": [
+            {
+              "bytes": null,
+              "logprob": -0.612345,
+              "token": " Hello"
+            }
+          ]
+        },
+        "properties": {
+          "bytes": {
+            "description": "UTF-8 bytes of the token",
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "logprob": {
+            "description": "Log probability of the token",
+            "format": "double",
+            "type": "number"
+          },
+          "token": {
+            "description": "The token",
+            "type": "string"
+          },
+          "top_logprobs": {
+            "description": "Top alternative tokens with probabilities",
+            "items": {
+              "properties": {
+                "bytes": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "nullable": true,
+                  "type": "array"
+                },
+                "logprob": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "token": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "token",
+                "logprob",
+                "bytes"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "token",
+          "logprob",
+          "bytes",
+          "top_logprobs"
+        ],
+        "type": "object"
+      },
+      "ChatTokenLogprobs": {
+        "description": "Log probabilities for the completion",
+        "example": {
+          "content": [
+            {
+              "bytes": null,
+              "logprob": -0.612345,
+              "token": " Hello",
+              "top_logprobs": []
+            }
+          ],
+          "refusal": null
+        },
+        "nullable": true,
+        "properties": {
+          "content": {
+            "description": "Log probabilities for content tokens",
+            "items": {
+              "$ref": "#/components/schemas/ChatTokenLogprob"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "refusal": {
+            "description": "Log probabilities for refusal tokens",
+            "items": {
+              "$ref": "#/components/schemas/ChatTokenLogprob"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChatToolCall": {
+        "description": "Tool call made by the assistant",
+        "example": {
+          "function": {
+            "arguments": "{\"location\": \"Boston, MA\"}",
+            "name": "get_current_weather"
+          },
+          "id": "call_abc123",
+          "type": "function"
+        },
+        "properties": {
+          "function": {
+            "properties": {
+              "arguments": {
+                "description": "Function arguments as JSON string",
+                "type": "string"
+              },
+              "name": {
+                "description": "Function name to call",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "Tool call identifier",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ],
+        "type": "object"
+      },
+      "ChatToolChoice": {
+        "anyOf": [
+          {
+            "enum": [
+              "none"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "auto"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "required"
+            ],
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/ChatNamedToolChoice"
+          }
+        ],
+        "description": "Tool choice configuration",
+        "example": "auto"
+      },
+      "ChatToolMessage": {
+        "description": "Tool response message",
+        "example": {
+          "content": "The weather in San Francisco is 72\u00b0F and sunny.",
+          "role": "tool",
+          "tool_call_id": "call_abc123"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatContentItems"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Tool response content",
+            "example": "The weather in San Francisco is 72\u00b0F and sunny."
+          },
+          "role": {
+            "enum": [
+              "tool"
+            ],
+            "type": "string"
+          },
+          "tool_call_id": {
+            "description": "ID of the assistant message tool call this message responds to",
+            "example": "call_abc123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content",
+          "tool_call_id"
+        ],
+        "type": "object"
+      },
+      "ChatUsage": {
+        "description": "Token usage statistics",
+        "example": {
+          "completion_tokens": 15,
+          "completion_tokens_details": {
+            "reasoning_tokens": 5
+          },
+          "prompt_tokens": 10,
+          "prompt_tokens_details": {
+            "cached_tokens": 2
+          },
+          "total_tokens": 25
+        },
+        "properties": {
+          "completion_tokens": {
+            "description": "Number of tokens in the completion",
+            "type": "integer"
+          },
+          "completion_tokens_details": {
+            "description": "Detailed completion token usage",
+            "nullable": true,
+            "properties": {
+              "accepted_prediction_tokens": {
+                "description": "Accepted prediction tokens",
+                "nullable": true,
+                "type": "integer"
+              },
+              "audio_tokens": {
+                "description": "Tokens used for audio output",
+                "nullable": true,
+                "type": "integer"
+              },
+              "reasoning_tokens": {
+                "description": "Tokens used for reasoning",
+                "nullable": true,
+                "type": "integer"
+              },
+              "rejected_prediction_tokens": {
+                "description": "Rejected prediction tokens",
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "prompt_tokens": {
+            "description": "Number of tokens in the prompt",
+            "type": "integer"
+          },
+          "prompt_tokens_details": {
+            "description": "Detailed prompt token usage",
+            "nullable": true,
+            "properties": {
+              "audio_tokens": {
+                "description": "Audio input tokens",
+                "type": "integer"
+              },
+              "cache_write_tokens": {
+                "description": "Tokens written to cache. Only returned for models with explicit caching and cache write pricing.",
+                "type": "integer"
+              },
+              "cached_tokens": {
+                "description": "Cached prompt tokens",
+                "type": "integer"
+              },
+              "video_tokens": {
+                "description": "Video input tokens",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "total_tokens": {
+            "description": "Total number of tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "completion_tokens",
+          "prompt_tokens",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "ChatUserMessage": {
+        "description": "User message",
+        "example": {
+          "content": "What is the capital of France?",
+          "role": "user"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatContentItems"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "User message content",
+            "example": "What is the capital of France?"
+          },
+          "name": {
+            "description": "Optional name for the user",
+            "example": "User",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "user"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ChatWebSearchShorthand": {
+        "description": "Web search tool using OpenAI Responses API syntax. Automatically converted to openrouter:web_search.",
+        "example": {
+          "type": "web_search_preview"
+        },
+        "properties": {
+          "allowed_domains": {
+            "description": "Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Firecrawl or Perplexity.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "excluded_domains": {
+            "description": "Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported with Firecrawl, OpenAI (silently ignored), or Perplexity.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "max_total_results": {
+            "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results. Useful for controlling cost and context size in agentic loops.",
+            "example": 20,
+            "type": "integer"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/WebSearchConfig"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchQualityLevel"
+          },
+          "type": {
+            "enum": [
+              "web_search",
+              "web_search_preview",
+              "web_search_preview_2025_03_11",
+              "web_search_2025_08_26"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/WebSearchUserLocationServerTool"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "CodeInterpreterCallItem": {
+        "description": "A code interpreter execution call with outputs",
+        "example": {
+          "code": "print(\"Hello, World!\")",
+          "container_id": "container-xyz789",
+          "id": "code-abc123",
+          "outputs": [
+            {
+              "logs": "Hello, World!",
+              "type": "logs"
+            }
+          ],
+          "status": "completed",
+          "type": "code_interpreter_call"
+        },
+        "properties": {
+          "code": {
+            "nullable": true,
+            "type": "string"
+          },
+          "container_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "outputs": {
+            "items": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "image"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "url"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "properties": {
+                    "logs": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "logs"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "logs"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "code_interpreter_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "code",
+          "outputs",
+          "status",
+          "container_id"
+        ],
+        "type": "object"
+      },
+      "CodeInterpreterServerTool": {
+        "description": "Code interpreter tool configuration",
+        "example": {
+          "container": "auto",
+          "type": "code_interpreter"
+        },
+        "properties": {
+          "container": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "properties": {
+                  "file_ids": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "memory_limit": {
+                    "enum": [
+                      "1g",
+                      "4g",
+                      "16g",
+                      "64g",
+                      null
+                    ],
+                    "nullable": true,
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "type": {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "code_interpreter"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "container"
+        ],
+        "type": "object"
+      },
+      "CodexLocalShellTool": {
+        "description": "Local shell tool configuration",
+        "example": {
+          "type": "local_shell"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "local_shell"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "CompletedEvent": {
+        "description": "Event emitted when a response has completed successfully",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [
+              {
+                "content": [
+                  {
+                    "annotations": [],
+                    "text": "Hello! How can I help you?",
+                    "type": "output_text"
+                  }
+                ],
+                "id": "item-1",
+                "role": "assistant",
+                "status": "completed",
+                "type": "message"
+              }
+            ],
+            "parallel_tool_calls": true,
+            "status": "completed",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 10,
+          "type": "response.completed"
+        },
+        "properties": {
+          "response": {
+            "$ref": "#/components/schemas/BaseResponsesResult"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.completed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "response",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "CompoundFilter": {
+        "description": "A compound filter that combines multiple comparison or compound filters",
+        "example": {
+          "filters": [
+            {
+              "key": "author",
+              "type": "eq",
+              "value": "Alice"
+            }
+          ],
+          "type": "and"
+        },
+        "properties": {
+          "filters": {
+            "items": {
+              "additionalProperties": {
+                "nullable": true
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "and",
+              "or"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "required": [
+          "type",
+          "filters"
+        ],
+        "type": "object"
+      },
+      "ComputerUseServerTool": {
+        "description": "Computer use preview tool configuration",
+        "example": {
+          "display_height": 768,
+          "display_width": 1024,
+          "environment": "linux",
+          "type": "computer_use_preview"
+        },
+        "properties": {
+          "display_height": {
+            "type": "integer"
+          },
+          "display_width": {
+            "type": "integer"
+          },
+          "environment": {
+            "enum": [
+              "windows",
+              "mac",
+              "linux",
+              "ubuntu",
+              "browser"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "computer_use_preview"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "display_height",
+          "display_width",
+          "environment"
+        ],
+        "type": "object"
+      },
+      "ConflictResponse": {
+        "description": "Conflict - Resource conflict or concurrent modification",
+        "example": {
+          "error": {
+            "code": 409,
+            "message": "Resource conflict. Please try again later."
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ConflictResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ConflictResponseErrorData": {
+        "description": "Error data for ConflictResponse",
+        "example": {
+          "code": 409,
+          "message": "Resource conflict. Please try again later."
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ContentPartAddedEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseContentPartAddedEvent"
+          },
+          {
+            "properties": {
+              "part": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ResponseOutputText"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ReasoningTextContent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OpenAIResponsesRefusalContent"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a new content part is added to an output item",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "annotations": [],
+            "text": "",
+            "type": "output_text"
+          },
+          "sequence_number": 3,
+          "type": "response.content_part.added"
+        }
+      },
+      "ContentPartDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseContentPartDoneEvent"
+          },
+          {
+            "properties": {
+              "part": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ResponseOutputText"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ReasoningTextContent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OpenAIResponsesRefusalContent"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a content part is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "annotations": [],
+            "text": "Hello! How can I help you?",
+            "type": "output_text"
+          },
+          "sequence_number": 7,
+          "type": "response.content_part.done"
+        }
+      },
+      "ContentPartImage": {
+        "example": {
+          "image_url": {
+            "url": "https://example.com/image.png"
+          },
+          "type": "image_url"
+        },
+        "properties": {
+          "image_url": {
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "image_url"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image_url"
+        ],
+        "type": "object"
+      },
+      "ContextCompressionEngine": {
+        "description": "The compression engine to use. Defaults to \"middle-out\".",
+        "enum": [
+          "middle-out"
+        ],
+        "example": "middle-out",
+        "type": "string"
+      },
+      "ContextCompressionPlugin": {
+        "example": {
+          "enabled": true,
+          "engine": "middle-out",
+          "id": "context-compression"
+        },
+        "properties": {
+          "enabled": {
+            "description": "Set to false to disable the context-compression plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/ContextCompressionEngine"
+          },
+          "id": {
+            "enum": [
+              "context-compression"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "CreateGuardrailRequest": {
+        "example": {
+          "allowed_models": null,
+          "allowed_providers": [
+            "openai",
+            "anthropic",
+            "deepseek"
+          ],
+          "description": "A guardrail for limiting API usage",
+          "enforce_zdr": false,
+          "ignored_models": null,
+          "ignored_providers": null,
+          "limit_usd": 50,
+          "name": "My New Guardrail",
+          "reset_interval": "monthly"
+        },
+        "properties": {
+          "allowed_models": {
+            "description": "Array of model identifiers (slug or canonical_slug accepted)",
+            "example": [
+              "openai/gpt-5.2",
+              "anthropic/claude-4.5-opus-20251124",
+              "deepseek/deepseek-r1-0528:free"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "allowed_providers": {
+            "description": "List of allowed provider IDs",
+            "example": [
+              "openai",
+              "anthropic",
+              "deepseek"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "description": {
+            "description": "Description of the guardrail",
+            "example": "A guardrail for limiting API usage",
+            "maxLength": 1000,
+            "nullable": true,
+            "type": "string"
+          },
+          "enforce_zdr": {
+            "description": "Whether to enforce zero data retention",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "ignored_models": {
+            "description": "Array of model identifiers to exclude from routing (slug or canonical_slug accepted)",
+            "example": [
+              "openai/gpt-4o-mini"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "ignored_providers": {
+            "description": "List of provider IDs to exclude from routing",
+            "example": [
+              "azure"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "limit_usd": {
+            "description": "Spending limit in USD",
+            "example": 50,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "name": {
+            "description": "Name for the new guardrail",
+            "example": "My New Guardrail",
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          "reset_interval": {
+            "$ref": "#/components/schemas/GuardrailInterval"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "CreateGuardrailResponse": {
+        "example": {
+          "data": {
+            "allowed_models": null,
+            "allowed_providers": [
+              "openai",
+              "anthropic",
+              "google"
+            ],
+            "created_at": "2025-08-24T10:30:00Z",
+            "description": "A guardrail for limiting API usage",
+            "enforce_zdr": false,
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "ignored_models": null,
+            "ignored_providers": null,
+            "limit_usd": 50,
+            "name": "My New Guardrail",
+            "reset_interval": "monthly",
+            "updated_at": null
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Guardrail"
+              },
+              {
+                "description": "The created guardrail"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "CreatedEvent": {
+        "description": "Event emitted when a response is created",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "in_progress",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 0,
+          "type": "response.created"
+        },
+        "properties": {
+          "response": {
+            "$ref": "#/components/schemas/BaseResponsesResult"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.created"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "response",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "CustomTool": {
+        "description": "Custom tool configuration",
+        "example": {
+          "name": "my_tool",
+          "type": "custom"
+        },
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "format": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "definition": {
+                    "type": "string"
+                  },
+                  "syntax": {
+                    "enum": [
+                      "lark",
+                      "regex"
+                    ],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "type": {
+                    "enum": [
+                      "grammar"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "definition",
+                  "syntax"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "custom"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DatetimeServerTool": {
+        "description": "OpenRouter built-in server tool: returns the current date and time",
+        "example": {
+          "parameters": {
+            "timezone": "America/New_York"
+          },
+          "type": "openrouter:datetime"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/DatetimeServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:datetime"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "DatetimeServerToolConfig": {
+        "description": "Configuration for the openrouter:datetime server tool",
+        "example": {
+          "timezone": "America/New_York"
+        },
+        "properties": {
+          "timezone": {
+            "description": "IANA timezone name (e.g. \"America/New_York\"). Defaults to UTC.",
+            "example": "America/New_York",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DefaultParameters": {
+        "additionalProperties": false,
+        "description": "Default parameters for this model",
+        "example": {
+          "frequency_penalty": 0,
+          "presence_penalty": 0,
+          "repetition_penalty": 1,
+          "temperature": 0.7,
+          "top_k": 0,
+          "top_p": 0.9
+        },
+        "nullable": true,
+        "properties": {
+          "frequency_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "presence_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "repetition_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "temperature": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "top_k": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "top_p": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "DeleteGuardrailResponse": {
+        "example": {
+          "deleted": true
+        },
+        "properties": {
+          "deleted": {
+            "const": true,
+            "description": "Confirmation that the guardrail was deleted",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "DeprecatedRoute": {
+        "deprecated": true,
+        "description": "**DEPRECATED** Use providers.sort.partition instead. Backwards-compatible alias for providers.sort.partition. Accepts legacy values: \"fallback\" (maps to \"model\"), \"sort\" (maps to \"none\").",
+        "enum": [
+          "fallback",
+          "sort",
+          null
+        ],
+        "example": "fallback",
+        "nullable": true,
+        "type": "string",
+        "x-fern-ignore": true,
+        "x-speakeasy-deprecation-message": "Use providers.sort.partition instead.",
+        "x-speakeasy-ignore": true,
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "EasyInputMessage": {
+        "example": {
+          "content": "What is the weather today?",
+          "role": "user"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InputText"
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/InputImage"
+                        },
+                        {
+                          "properties": {},
+                          "type": "object"
+                        }
+                      ],
+                      "description": "Image input content item",
+                      "example": {
+                        "detail": "auto",
+                        "image_url": "https://example.com/image.jpg",
+                        "type": "input_image"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputFile"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputAudio"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputVideo"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "enum": [
+                  "commentary"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "final_answer"
+                ],
+                "type": "string"
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "description": "The phase of an assistant message. Use `commentary` for an intermediate assistant message and `final_answer` for the final assistant message. For follow-up requests with models like `gpt-5.3-codex` and later, preserve and resend phase on all assistant messages. Omitting it can degrade performance. Not used for user messages.",
+            "example": "final_answer"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "enum": [
+                  "user"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "system"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "assistant"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "developer"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "type": "object"
+      },
+      "EdgeNetworkTimeoutResponse": {
+        "description": "Infrastructure Timeout - Provider request timed out at edge network",
+        "example": {
+          "error": {
+            "code": 524,
+            "message": "Request timed out. Please try again later."
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/EdgeNetworkTimeoutResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "EdgeNetworkTimeoutResponseErrorData": {
+        "description": "Error data for EdgeNetworkTimeoutResponse",
+        "example": {
+          "code": 524,
+          "message": "Request timed out. Please try again later."
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "EndpointStatus": {
+        "enum": [
+          0,
+          -1,
+          -2,
+          -3,
+          -5,
+          -10
+        ],
+        "example": 0,
+        "type": "integer",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ErrorEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseErrorEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when an error occurs during streaming",
+        "example": {
+          "code": "rate_limit_exceeded",
+          "message": "Rate limit exceeded. Please try again later.",
+          "param": null,
+          "sequence_number": 2,
+          "type": "error"
+        }
+      },
+      "FailedEvent": {
+        "description": "Event emitted when a response has failed",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "failed",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 3,
+          "type": "response.failed"
+        },
+        "properties": {
+          "response": {
+            "$ref": "#/components/schemas/BaseResponsesResult"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "response",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FileCitation": {
+        "example": {
+          "file_id": "file-abc123",
+          "filename": "research_paper.pdf",
+          "index": 0,
+          "type": "file_citation"
+        },
+        "properties": {
+          "file_id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "file_citation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file_id",
+          "filename",
+          "index"
+        ],
+        "type": "object"
+      },
+      "FileParserPlugin": {
+        "example": {
+          "enabled": true,
+          "id": "file-parser",
+          "pdf": {
+            "engine": "cloudflare-ai"
+          }
+        },
+        "properties": {
+          "enabled": {
+            "description": "Set to false to disable the file-parser plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "id": {
+            "enum": [
+              "file-parser"
+            ],
+            "type": "string"
+          },
+          "pdf": {
+            "$ref": "#/components/schemas/PDFParserOptions"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "FilePath": {
+        "example": {
+          "file_id": "file-xyz789",
+          "index": 0,
+          "type": "file_path"
+        },
+        "properties": {
+          "file_id": {
+            "type": "string"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "file_path"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file_id",
+          "index"
+        ],
+        "type": "object"
+      },
+      "FileSearchServerTool": {
+        "description": "File search tool configuration",
+        "example": {
+          "type": "file_search",
+          "vector_store_ids": [
+            "vs_abc123"
+          ]
+        },
+        "properties": {
+          "filters": {
+            "anyOf": [
+              {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "eq",
+                      "ne",
+                      "gt",
+                      "gte",
+                      "lt",
+                      "lte"
+                    ],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "format": "double",
+                              "type": "number"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "key",
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/CompoundFilter"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "max_num_results": {
+            "type": "integer"
+          },
+          "ranking_options": {
+            "properties": {
+              "ranker": {
+                "enum": [
+                  "auto",
+                  "default-2024-11-15"
+                ],
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              },
+              "score_threshold": {
+                "format": "double",
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "file_search"
+            ],
+            "type": "string"
+          },
+          "vector_store_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "type",
+          "vector_store_ids"
+        ],
+        "type": "object"
+      },
+      "ForbiddenResponse": {
+        "description": "Forbidden - Authentication successful but insufficient permissions",
+        "example": {
+          "error": {
+            "code": 403,
+            "message": "Only management keys can perform this operation"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ForbiddenResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ForbiddenResponseErrorData": {
+        "description": "Error data for ForbiddenResponse",
+        "example": {
+          "code": 403,
+          "message": "Only management keys can perform this operation"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "FormatJsonObjectConfig": {
+        "description": "JSON object response format",
+        "example": {
+          "type": "json_object"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "json_object"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "FormatJsonSchemaConfig": {
+        "description": "JSON schema constrained response format",
+        "example": {
+          "description": "User information schema",
+          "name": "user_info",
+          "schema": {
+            "properties": {
+              "age": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "json_schema"
+        },
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "schema": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "strict": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "json_schema"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "schema"
+        ],
+        "type": "object"
+      },
+      "FormatTextConfig": {
+        "description": "Plain text response format",
+        "example": {
+          "type": "text"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Formats": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/FormatTextConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FormatJsonObjectConfig"
+          },
+          {
+            "$ref": "#/components/schemas/FormatJsonSchemaConfig"
+          }
+        ],
+        "description": "Text response format configuration",
+        "example": {
+          "type": "text"
+        }
+      },
+      "FrameImage": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentPartImage"
+          },
+          {
+            "properties": {
+              "frame_type": {
+                "description": "Whether this image represents the first or last frame of the video",
+                "enum": [
+                  "first_frame",
+                  "last_frame"
+                ],
+                "example": "first_frame",
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              }
+            },
+            "required": [
+              "frame_type"
+            ],
+            "type": "object"
+          }
+        ],
+        "example": {
+          "image_url": {
+            "url": "https://example.com/image.png"
+          },
+          "type": "image_url"
+        }
+      },
+      "FunctionCallArgsDeltaEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseFunctionCallArgsDeltaEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when function call arguments are being streamed",
+        "example": {
+          "delta": "{\"city\": \"...\"}",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.function_call_arguments.delta"
+        }
+      },
+      "FunctionCallArgsDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseFunctionCallArgsDoneEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when function call arguments streaming is complete",
+        "example": {
+          "arguments": "{\"city\": \"San Francisco\", \"units\": \"celsius\"}",
+          "item_id": "item-1",
+          "name": "get_weather",
+          "output_index": 0,
+          "sequence_number": 6,
+          "type": "response.function_call_arguments.done"
+        }
+      },
+      "FunctionCallItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponseFunctionToolCall"
+          },
+          {
+            "properties": {},
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "A function call initiated by the model",
+        "example": {
+          "arguments": "{\"location\":\"San Francisco\"}",
+          "call_id": "call-abc123",
+          "id": "call-abc123",
+          "name": "get_weather",
+          "status": "completed",
+          "type": "function_call"
+        }
+      },
+      "FunctionCallOutputItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponseFunctionToolCallOutput"
+          },
+          {
+            "properties": {
+              "output": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/InputText"
+                        },
+                        {
+                          "allOf": [
+                            {
+                              "$ref": "#/components/schemas/InputImage"
+                            },
+                            {
+                              "properties": {},
+                              "type": "object"
+                            }
+                          ],
+                          "description": "Image input content item",
+                          "example": {
+                            "detail": "auto",
+                            "image_url": "https://example.com/image.jpg",
+                            "type": "input_image"
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/InputFile"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "The output from a function call execution",
+        "example": {
+          "call_id": "call-abc123",
+          "id": "output-abc123",
+          "output": "{\"temperature\":72,\"conditions\":\"sunny\"}",
+          "status": "completed",
+          "type": "function_call_output"
+        }
+      },
+      "FunctionTool": {
+        "description": "Function tool definition",
+        "example": {
+          "description": "Get the current weather in a location",
+          "name": "get_weather",
+          "parameters": {
+            "properties": {
+              "location": {
+                "description": "The city and state",
+                "type": "string"
+              },
+              "unit": {
+                "enum": [
+                  "celsius",
+                  "fahrenheit"
+                ],
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "type": "object"
+          },
+          "type": "function"
+        },
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parameters": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
+          "strict": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "parameters"
+        ],
+        "type": "object"
+      },
+      "GetGuardrailResponse": {
+        "example": {
+          "data": {
+            "allowed_models": null,
+            "allowed_providers": [
+              "openai",
+              "anthropic",
+              "google"
+            ],
+            "created_at": "2025-08-24T10:30:00Z",
+            "description": "Guardrail for production environment",
+            "enforce_zdr": false,
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "ignored_models": null,
+            "ignored_providers": null,
+            "limit_usd": 100,
+            "name": "Production Guardrail",
+            "reset_interval": "monthly",
+            "updated_at": "2025-08-24T15:45:00Z"
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Guardrail"
+              },
+              {
+                "description": "The guardrail"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GoneResponse": {
+        "description": "Gone - Endpoint has been permanently removed or deprecated",
+        "example": {
+          "error": {
+            "code": 410,
+            "message": "The Coinbase APIs used by this endpoint have been deprecated, so the Coinbase Commerce credits API has been removed. Use the web credits purchase flow instead."
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/GoneResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "GoneResponseErrorData": {
+        "description": "Error data for GoneResponse",
+        "example": {
+          "code": 410,
+          "message": "The Coinbase APIs used by this endpoint have been deprecated, so the Coinbase Commerce credits API has been removed. Use the web credits purchase flow instead."
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "Guardrail": {
+        "example": {
+          "allowed_models": null,
+          "allowed_providers": [
+            "openai",
+            "anthropic",
+            "google"
+          ],
+          "created_at": "2025-08-24T10:30:00Z",
+          "description": "Guardrail for production environment",
+          "enforce_zdr": false,
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "ignored_models": null,
+          "ignored_providers": null,
+          "limit_usd": 100,
+          "name": "Production Guardrail",
+          "reset_interval": "monthly",
+          "updated_at": "2025-08-24T15:45:00Z"
+        },
+        "properties": {
+          "allowed_models": {
+            "description": "Array of model canonical_slugs (immutable identifiers)",
+            "example": [
+              "openai/gpt-5.2-20251211",
+              "anthropic/claude-4.5-opus-20251124",
+              "deepseek/deepseek-r1-0528:free"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "allowed_providers": {
+            "description": "List of allowed provider IDs",
+            "example": [
+              "openai",
+              "anthropic",
+              "google"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "created_at": {
+            "description": "ISO 8601 timestamp of when the guardrail was created",
+            "example": "2025-08-24T10:30:00Z",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the guardrail",
+            "example": "Guardrail for production environment",
+            "nullable": true,
+            "type": "string"
+          },
+          "enforce_zdr": {
+            "description": "Whether to enforce zero data retention",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Unique identifier for the guardrail",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "ignored_models": {
+            "description": "Array of model canonical_slugs to exclude from routing",
+            "example": [
+              "openai/gpt-4o-mini-2024-07-18"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "ignored_providers": {
+            "description": "List of provider IDs to exclude from routing",
+            "example": [
+              "azure"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "limit_usd": {
+            "description": "Spending limit in USD",
+            "example": 100,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "name": {
+            "description": "Name of the guardrail",
+            "example": "Production Guardrail",
+            "type": "string"
+          },
+          "reset_interval": {
+            "$ref": "#/components/schemas/GuardrailInterval"
+          },
+          "updated_at": {
+            "description": "ISO 8601 timestamp of when the guardrail was last updated",
+            "example": "2025-08-24T15:45:00Z",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "GuardrailInterval": {
+        "description": "Interval at which the limit resets (daily, weekly, monthly)",
+        "enum": [
+          "daily",
+          "weekly",
+          "monthly",
+          null
+        ],
+        "example": "monthly",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ImageConfig": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "items": {
+                "nullable": true
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "description": "Provider-specific image configuration options. Keys and values vary by model/provider. See https://openrouter.ai/docs/guides/overview/multimodal/image-generation for more details.",
+        "example": {
+          "aspect_ratio": "16:9",
+          "quality": "high"
+        },
+        "type": "object"
+      },
+      "ImageGenCallCompletedEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesImageGenCallCompleted"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Image generation call completed",
+        "example": {
+          "item_id": "call-123",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.image_generation_call.completed"
+        }
+      },
+      "ImageGenCallGeneratingEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesImageGenCallGenerating"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Image generation call is generating",
+        "example": {
+          "item_id": "call-123",
+          "output_index": 0,
+          "sequence_number": 2,
+          "type": "response.image_generation_call.generating"
+        }
+      },
+      "ImageGenCallInProgressEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesImageGenCallInProgress"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Image generation call in progress",
+        "example": {
+          "item_id": "call-123",
+          "output_index": 0,
+          "sequence_number": 1,
+          "type": "response.image_generation_call.in_progress"
+        }
+      },
+      "ImageGenCallPartialImageEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesImageGenCallPartialImage"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Image generation call with partial image",
+        "example": {
+          "item_id": "call-123",
+          "output_index": 0,
+          "partial_image_b64": "base64encodedimage...",
+          "partial_image_index": 0,
+          "sequence_number": 3,
+          "type": "response.image_generation_call.partial_image"
+        }
+      },
+      "ImageGenerationServerTool": {
+        "description": "Image generation tool configuration",
+        "example": {
+          "quality": "high",
+          "type": "image_generation"
+        },
+        "properties": {
+          "background": {
+            "enum": [
+              "transparent",
+              "opaque",
+              "auto"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "input_fidelity": {
+            "enum": [
+              "high",
+              "low",
+              null
+            ],
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "input_image_mask": {
+            "properties": {
+              "file_id": {
+                "type": "string"
+              },
+              "image_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "model": {
+            "enum": [
+              "gpt-image-1",
+              "gpt-image-1-mini"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "moderation": {
+            "enum": [
+              "auto",
+              "low"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "output_compression": {
+            "type": "integer"
+          },
+          "output_format": {
+            "enum": [
+              "png",
+              "webp",
+              "jpeg"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "partial_images": {
+            "type": "integer"
+          },
+          "quality": {
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "auto"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "size": {
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "image_generation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ImageGenerationServerToolConfig": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "items": {
+                "nullable": true
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "description": "Configuration for the openrouter:image_generation server tool. Accepts all image_config params (aspect_ratio, quality, size, background, output_format, output_compression, moderation, etc.) plus a model field.",
+        "example": {
+          "aspect_ratio": "16:9",
+          "model": "openai/gpt-5-image",
+          "quality": "high"
+        },
+        "properties": {
+          "model": {
+            "description": "Which image generation model to use (e.g. \"openai/gpt-5-image\"). Defaults to \"openai/gpt-5-image\".",
+            "example": "openai/gpt-5-image",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ImageGenerationServerTool_OpenRouter": {
+        "description": "OpenRouter built-in server tool: generates images from text prompts using an image generation model",
+        "example": {
+          "parameters": {
+            "model": "openai/gpt-image-1",
+            "quality": "high",
+            "size": "1024x1024"
+          },
+          "type": "openrouter:image_generation"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/ImageGenerationServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:image_generation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ImageGenerationStatus": {
+        "enum": [
+          "in_progress",
+          "completed",
+          "generating",
+          "failed"
+        ],
+        "example": "completed",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "InProgressEvent": {
+        "description": "Event emitted when a response is in progress",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "in_progress",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 1,
+          "type": "response.in_progress"
+        },
+        "properties": {
+          "response": {
+            "$ref": "#/components/schemas/BaseResponsesResult"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.in_progress"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "response",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "IncompleteDetails": {
+        "example": {
+          "reason": "max_output_tokens"
+        },
+        "nullable": true,
+        "properties": {
+          "reason": {
+            "enum": [
+              "max_output_tokens",
+              "content_filter"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "type": "object"
+      },
+      "IncompleteEvent": {
+        "description": "Event emitted when a response is incomplete",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "incomplete",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 5,
+          "type": "response.incomplete"
+        },
+        "properties": {
+          "response": {
+            "$ref": "#/components/schemas/BaseResponsesResult"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.incomplete"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "response",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "InputAudio": {
+        "description": "Audio input content item",
+        "example": {
+          "input_audio": {
+            "data": "SGVsbG8gV29ybGQ=",
+            "format": "mp3"
+          },
+          "type": "input_audio"
+        },
+        "properties": {
+          "input_audio": {
+            "properties": {
+              "data": {
+                "type": "string"
+              },
+              "format": {
+                "enum": [
+                  "mp3",
+                  "wav"
+                ],
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              }
+            },
+            "required": [
+              "data",
+              "format"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "input_audio"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "input_audio"
+        ],
+        "type": "object"
+      },
+      "InputFile": {
+        "description": "File input content item",
+        "example": {
+          "file_id": "file-abc123",
+          "filename": "document.pdf",
+          "type": "input_file"
+        },
+        "properties": {
+          "file_data": {
+            "type": "string"
+          },
+          "file_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "file_url": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "input_file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "InputImage": {
+        "description": "Image input content item",
+        "example": {
+          "detail": "auto",
+          "image_url": "https://example.com/image.jpg",
+          "type": "input_image"
+        },
+        "properties": {
+          "detail": {
+            "enum": [
+              "auto",
+              "high",
+              "low"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "image_url": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "input_image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "detail"
+        ],
+        "type": "object"
+      },
+      "InputMessageItem": {
+        "example": {
+          "content": [
+            {
+              "text": "Hello, how are you?",
+              "type": "input_text"
+            }
+          ],
+          "id": "msg-abc123",
+          "role": "user",
+          "type": "message"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/InputText"
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/InputImage"
+                    },
+                    {
+                      "properties": {},
+                      "type": "object"
+                    }
+                  ],
+                  "description": "Image input content item",
+                  "example": {
+                    "detail": "auto",
+                    "image_url": "https://example.com/image.jpg",
+                    "type": "input_image"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/InputFile"
+                },
+                {
+                  "$ref": "#/components/schemas/InputAudio"
+                },
+                {
+                  "$ref": "#/components/schemas/InputVideo"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "enum": [
+                  "user"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "system"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "developer"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "type": "object"
+      },
+      "InputModality": {
+        "enum": [
+          "text",
+          "image",
+          "file",
+          "audio",
+          "video"
+        ],
+        "example": "text",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "InputText": {
+        "description": "Text input content item",
+        "example": {
+          "text": "Hello, how can I help you?",
+          "type": "input_text"
+        },
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "input_text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "InputVideo": {
+        "description": "Video input content item",
+        "example": {
+          "type": "input_video",
+          "video_url": "https://example.com/video.mp4"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "input_video"
+            ],
+            "type": "string"
+          },
+          "video_url": {
+            "description": "A base64 data URL or remote URL that resolves to a video file",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "video_url"
+        ],
+        "type": "object"
+      },
+      "Inputs": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ReasoningItem"
+                },
+                {
+                  "$ref": "#/components/schemas/EasyInputMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/InputMessageItem"
+                },
+                {
+                  "$ref": "#/components/schemas/FunctionCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/FunctionCallOutputItem"
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OutputMessageItem"
+                    },
+                    {
+                      "properties": {
+                        "content": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "$ref": "#/components/schemas/ResponseOutputText"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/OpenAIResponsesRefusalContent"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "nullable": true
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ],
+                  "description": "An output message item",
+                  "example": {
+                    "content": [
+                      {
+                        "annotations": [],
+                        "text": "Hello! How can I help you?",
+                        "type": "output_text"
+                      }
+                    ],
+                    "id": "msg-123",
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message"
+                  }
+                },
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OutputReasoningItem"
+                    },
+                    {
+                      "properties": {
+                        "summary": {
+                          "items": {
+                            "$ref": "#/components/schemas/ReasoningSummaryText"
+                          },
+                          "nullable": true,
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ],
+                  "description": "An output item containing reasoning",
+                  "example": {
+                    "content": [
+                      {
+                        "text": "First, we analyze the problem...",
+                        "type": "reasoning_text"
+                      }
+                    ],
+                    "format": "anthropic-claude-v1",
+                    "id": "reasoning-123",
+                    "signature": "EvcBCkgIChABGAIqQKkSDbRuVEQUk9qN1odC098l9SEj...",
+                    "status": "completed",
+                    "summary": [
+                      {
+                        "text": "Analyzed the problem and found the optimal solution.",
+                        "type": "summary_text"
+                      }
+                    ],
+                    "type": "reasoning"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/OutputFunctionCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputWebSearchCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputFileSearchCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputImageGenerationCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputDatetimeItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputWebSearchServerToolItem"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ],
+        "description": "Input for a response request - can be a string or array of items",
+        "example": [
+          {
+            "content": "What is the weather today?",
+            "role": "user"
+          }
+        ]
+      },
+      "InstructType": {
+        "description": "Instruction format type",
+        "enum": [
+          "none",
+          "airoboros",
+          "alpaca",
+          "alpaca-modif",
+          "chatml",
+          "claude",
+          "code-llama",
+          "gemma",
+          "llama2",
+          "llama3",
+          "mistral",
+          "nemotron",
+          "neural",
+          "openchat",
+          "phi3",
+          "rwkv",
+          "vicuna",
+          "zephyr",
+          "deepseek-r1",
+          "deepseek-v3.1",
+          "qwq",
+          "qwen3",
+          null
+        ],
+        "example": "chatml",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "InternalServerResponse": {
+        "description": "Internal Server Error - Unexpected server error",
+        "example": {
+          "error": {
+            "code": 500,
+            "message": "Internal Server Error"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/InternalServerResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "InternalServerResponseErrorData": {
+        "description": "Error data for InternalServerResponse",
+        "example": {
+          "code": 500,
+          "message": "Internal Server Error"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "KeyAssignment": {
+        "example": {
+          "assigned_by": "user_abc123",
+          "created_at": "2025-08-24T10:30:00Z",
+          "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "key_hash": "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93",
+          "key_label": "prod-key",
+          "key_name": "Production Key"
+        },
+        "properties": {
+          "assigned_by": {
+            "description": "User ID of who made the assignment",
+            "example": "user_abc123",
+            "nullable": true,
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 timestamp of when the assignment was created",
+            "example": "2025-08-24T10:30:00Z",
+            "type": "string"
+          },
+          "guardrail_id": {
+            "description": "ID of the guardrail",
+            "example": "550e8400-e29b-41d4-a716-446655440001",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the assignment",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "key_hash": {
+            "description": "Hash of the assigned API key",
+            "example": "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93",
+            "type": "string"
+          },
+          "key_label": {
+            "description": "Label of the API key",
+            "example": "prod-key",
+            "type": "string"
+          },
+          "key_name": {
+            "description": "Name of the API key",
+            "example": "Production Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "key_hash",
+          "guardrail_id",
+          "key_name",
+          "key_label",
+          "assigned_by",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "Legacy_ChatContentVideo": {
+        "deprecated": true,
+        "description": "Video input content part (legacy format - deprecated)",
+        "example": {
+          "type": "input_video",
+          "video_url": {
+            "url": "https://example.com/video.mp4"
+          }
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "input_video"
+            ],
+            "type": "string"
+          },
+          "video_url": {
+            "$ref": "#/components/schemas/ChatContentVideoInput"
+          }
+        },
+        "required": [
+          "type",
+          "video_url"
+        ],
+        "type": "object"
+      },
+      "Legacy_WebSearchServerTool": {
+        "description": "Web search tool configuration",
+        "example": {
+          "engine": "auto",
+          "filters": {
+            "allowed_domains": [
+              "example.com"
+            ]
+          },
+          "type": "web_search"
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/WebSearchDomainFilter"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchContextSizeEnum"
+          },
+          "type": {
+            "enum": [
+              "web_search"
+            ],
+            "type": "string"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/WebSearchUserLocation"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ListEndpointsResponse": {
+        "description": "List of available endpoints for a model",
+        "example": {
+          "architecture": {
+            "input_modalities": [
+              "text"
+            ],
+            "instruct_type": "chatml",
+            "modality": "text->text",
+            "output_modalities": [
+              "text"
+            ],
+            "tokenizer": "GPT"
+          },
+          "created": 1692901234,
+          "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+          "endpoints": [
+            {
+              "context_length": 8192,
+              "latency_last_30m": {
+                "p50": 0.25,
+                "p75": 0.35,
+                "p90": 0.48,
+                "p99": 0.85
+              },
+              "max_completion_tokens": 4096,
+              "max_prompt_tokens": 8192,
+              "model_name": "GPT-4",
+              "name": "OpenAI: GPT-4",
+              "pricing": {
+                "completion": "0.00006",
+                "image": "0",
+                "prompt": "0.00003",
+                "request": "0"
+              },
+              "provider_name": "OpenAI",
+              "quantization": "fp16",
+              "status": "default",
+              "supported_parameters": [
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty"
+              ],
+              "supports_implicit_caching": true,
+              "tag": "openai",
+              "throughput_last_30m": {
+                "p50": 45.2,
+                "p75": 38.5,
+                "p90": 28.3,
+                "p99": 15.1
+              },
+              "uptime_last_1d": 99.8,
+              "uptime_last_30m": 99.5,
+              "uptime_last_5m": 100
+            }
+          ],
+          "id": "openai/gpt-4",
+          "name": "GPT-4"
+        },
+        "properties": {
+          "architecture": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelArchitecture"
+              },
+              {
+                "example": {
+                  "instruct_type": "chatml",
+                  "modality": "text",
+                  "tokenizer": "GPT"
+                },
+                "properties": {
+                  "input_modalities": {
+                    "description": "Supported input modalities",
+                    "items": {
+                      "$ref": "#/components/schemas/InputModality"
+                    },
+                    "type": "array"
+                  },
+                  "instruct_type": {
+                    "$ref": "#/components/schemas/InstructType"
+                  },
+                  "modality": {
+                    "description": "Primary modality of the model",
+                    "example": "text",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "output_modalities": {
+                    "description": "Supported output modalities",
+                    "items": {
+                      "$ref": "#/components/schemas/OutputModality"
+                    },
+                    "type": "array"
+                  },
+                  "tokenizer": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/ModelGroup"
+                      },
+                      {
+                        "nullable": true
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "tokenizer",
+                  "instruct_type",
+                  "modality",
+                  "input_modalities",
+                  "output_modalities"
+                ]
+              }
+            ]
+          },
+          "created": {
+            "description": "Unix timestamp of when the model was created",
+            "example": 1692901234,
+            "type": "integer"
+          },
+          "description": {
+            "description": "Description of the model",
+            "example": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+            "type": "string"
+          },
+          "endpoints": {
+            "description": "List of available endpoints for this model",
+            "items": {
+              "$ref": "#/components/schemas/PublicEndpoint"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Unique identifier for the model",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the model",
+            "example": "GPT-4",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created",
+          "description",
+          "architecture",
+          "endpoints"
+        ],
+        "type": "object"
+      },
+      "ListGuardrailsResponse": {
+        "example": {
+          "data": [
+            {
+              "allowed_models": null,
+              "allowed_providers": [
+                "openai",
+                "anthropic",
+                "google"
+              ],
+              "created_at": "2025-08-24T10:30:00Z",
+              "description": "Guardrail for production environment",
+              "enforce_zdr": false,
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "ignored_models": null,
+              "ignored_providers": null,
+              "limit_usd": 100,
+              "name": "Production Guardrail",
+              "reset_interval": "monthly",
+              "updated_at": "2025-08-24T15:45:00Z"
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "description": "List of guardrails",
+            "items": {
+              "$ref": "#/components/schemas/Guardrail"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "Total number of guardrails",
+            "example": 25,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
+      "ListKeyAssignmentsResponse": {
+        "example": {
+          "data": [
+            {
+              "assigned_by": "user_abc123",
+              "created_at": "2025-08-24T10:30:00Z",
+              "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "key_hash": "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93",
+              "key_label": "prod-key",
+              "key_name": "Production Key"
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "description": "List of key assignments",
+            "items": {
+              "$ref": "#/components/schemas/KeyAssignment"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "Total number of key assignments for this guardrail",
+            "example": 25,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
+      "ListMemberAssignmentsResponse": {
+        "example": {
+          "data": [
+            {
+              "assigned_by": "user_abc123",
+              "created_at": "2025-08-24T10:30:00Z",
+              "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "organization_id": "org_xyz789",
+              "user_id": "user_abc123"
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "description": "List of member assignments",
+            "items": {
+              "$ref": "#/components/schemas/MemberAssignment"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "Total number of member assignments",
+            "example": 10,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
+      "McpServerTool": {
+        "description": "MCP (Model Context Protocol) tool configuration",
+        "example": {
+          "server_label": "my-server",
+          "server_url": "https://example.com/mcp",
+          "type": "mcp"
+        },
+        "properties": {
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "properties": {
+                  "read_only": {
+                    "type": "boolean"
+                  },
+                  "tool_names": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "authorization": {
+            "type": "string"
+          },
+          "connector_id": {
+            "enum": [
+              "connector_dropbox",
+              "connector_gmail",
+              "connector_googlecalendar",
+              "connector_googledrive",
+              "connector_microsoftteams",
+              "connector_outlookcalendar",
+              "connector_outlookemail",
+              "connector_sharepoint"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "object"
+          },
+          "require_approval": {
+            "anyOf": [
+              {
+                "properties": {
+                  "always": {
+                    "properties": {
+                      "tool_names": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "never": {
+                    "properties": {
+                      "tool_names": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "enum": [
+                  "always"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "never"
+                ],
+                "type": "string"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "server_description": {
+            "type": "string"
+          },
+          "server_label": {
+            "type": "string"
+          },
+          "server_url": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "mcp"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "server_label"
+        ],
+        "type": "object"
+      },
+      "MemberAssignment": {
+        "example": {
+          "assigned_by": "user_abc123",
+          "created_at": "2025-08-24T10:30:00Z",
+          "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "organization_id": "org_xyz789",
+          "user_id": "user_abc123"
+        },
+        "properties": {
+          "assigned_by": {
+            "description": "User ID of who made the assignment",
+            "example": "user_abc123",
+            "nullable": true,
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 timestamp of when the assignment was created",
+            "example": "2025-08-24T10:30:00Z",
+            "type": "string"
+          },
+          "guardrail_id": {
+            "description": "ID of the guardrail",
+            "example": "550e8400-e29b-41d4-a716-446655440001",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the assignment",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "organization_id": {
+            "description": "Organization ID",
+            "example": "org_xyz789",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "Clerk user ID of the assigned member",
+            "example": "user_abc123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "organization_id",
+          "guardrail_id",
+          "assigned_by",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "MessagesContentBlockDeltaEvent": {
+        "description": "Event sent when content is added to a content block",
+        "example": {
+          "delta": {
+            "text": "Hello",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "properties": {
+          "delta": {
+            "oneOf": [
+              {
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "text_delta"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "text"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "partial_json": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "input_json_delta"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "partial_json"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "thinking": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "thinking_delta"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "thinking"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "signature": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "signature_delta"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "signature"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "citation": {
+                    "discriminator": {
+                      "mapping": {
+                        "char_location": "#/components/schemas/AnthropicCitationCharLocation",
+                        "content_block_location": "#/components/schemas/AnthropicCitationContentBlockLocation",
+                        "page_location": "#/components/schemas/AnthropicCitationPageLocation",
+                        "search_result_location": "#/components/schemas/AnthropicCitationSearchResultLocation",
+                        "web_search_result_location": "#/components/schemas/AnthropicCitationWebSearchResultLocation"
+                      },
+                      "propertyName": "type"
+                    },
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/AnthropicCitationCharLocation"
+                      },
+                      {
+                        "$ref": "#/components/schemas/AnthropicCitationPageLocation"
+                      },
+                      {
+                        "$ref": "#/components/schemas/AnthropicCitationContentBlockLocation"
+                      },
+                      {
+                        "$ref": "#/components/schemas/AnthropicCitationWebSearchResultLocation"
+                      },
+                      {
+                        "$ref": "#/components/schemas/AnthropicCitationSearchResultLocation"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "enum": [
+                      "citations_delta"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "citation"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "content": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "compaction_delta"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "content"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "content_block_delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "index",
+          "delta"
+        ],
+        "type": "object"
+      },
+      "MessagesContentBlockStartEvent": {
+        "description": "Event sent when a new content block starts",
+        "example": {
+          "content_block": {
+            "text": "",
+            "type": "text"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "properties": {
+          "content_block": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicTextBlock"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicToolUseBlock"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicThinkingBlock"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicRedactedThinkingBlock"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicServerToolUseBlock"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicWebSearchToolResult"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicWebFetchToolResult"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicCodeExecutionToolResult"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicBashCodeExecutionToolResult"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionToolResult"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicToolSearchToolResult"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicContainerUpload"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicCompactionBlock"
+              },
+              {
+                "properties": {
+                  "content": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "compaction"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "content"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "content_block_start"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "index",
+          "content_block"
+        ],
+        "type": "object"
+      },
+      "MessagesContentBlockStopEvent": {
+        "description": "Event sent when a content block is complete",
+        "example": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "content_block_stop"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "index"
+        ],
+        "type": "object"
+      },
+      "MessagesDeltaEvent": {
+        "description": "Event sent when the message metadata changes (e.g., stop_reason)",
+        "example": {
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "end_turn",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "output_tokens": 15
+          }
+        },
+        "properties": {
+          "delta": {
+            "properties": {
+              "container": {
+                "$ref": "#/components/schemas/AnthropicContainer"
+              },
+              "stop_details": {
+                "$ref": "#/components/schemas/AnthropicRefusalStopDetails"
+              },
+              "stop_reason": {
+                "$ref": "#/components/schemas/ORAnthropicStopReason"
+              },
+              "stop_sequence": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "container",
+              "stop_details",
+              "stop_reason",
+              "stop_sequence"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "message_delta"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "properties": {
+              "cache_creation_input_tokens": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "cache_read_input_tokens": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "input_tokens": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "iterations": {
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicUsageIteration"
+                },
+                "type": "array"
+              },
+              "output_tokens": {
+                "type": "integer"
+              },
+              "server_tool_use": {
+                "nullable": true,
+                "properties": {
+                  "web_fetch_requests": {
+                    "type": "integer"
+                  },
+                  "web_search_requests": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "web_search_requests",
+                  "web_fetch_requests"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "input_tokens",
+              "output_tokens",
+              "cache_creation_input_tokens",
+              "cache_read_input_tokens",
+              "server_tool_use"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "type",
+          "delta",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "MessagesErrorDetail": {
+        "example": {
+          "message": "Invalid request parameters",
+          "type": "invalid_request_error"
+        },
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "MessagesErrorEvent": {
+        "description": "Error event in the stream",
+        "example": {
+          "error": {
+            "message": "Overloaded",
+            "type": "overloaded_error"
+          },
+          "type": "error"
+        },
+        "properties": {
+          "error": {
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "message"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "error"
+        ],
+        "type": "object"
+      },
+      "MessagesErrorResponse": {
+        "example": {
+          "error": {
+            "message": "Invalid request parameters",
+            "type": "invalid_request_error"
+          },
+          "type": "error"
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/MessagesErrorDetail"
+          },
+          "type": {
+            "enum": [
+              "error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "error"
+        ],
+        "type": "object"
+      },
+      "MessagesMessageParam": {
+        "description": "Anthropic message with OpenRouter extensions",
+        "example": {
+          "content": "Hello, how are you?",
+          "role": "user"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/AnthropicTextBlockParam"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AnthropicImageBlockParam"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AnthropicDocumentBlockParam"
+                    },
+                    {
+                      "properties": {
+                        "cache_control": {
+                          "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "input": {
+                          "nullable": true
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "tool_use"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "id",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "cache_control": {
+                          "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                        },
+                        "content": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "$ref": "#/components/schemas/AnthropicTextBlockParam"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/AnthropicImageBlockParam"
+                                  },
+                                  {
+                                    "properties": {
+                                      "tool_name": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "enum": [
+                                          "tool_reference"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "tool_name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/AnthropicSearchResultBlockParam"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/AnthropicDocumentBlockParam"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ]
+                        },
+                        "is_error": {
+                          "type": "boolean"
+                        },
+                        "tool_use_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "tool_result"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "tool_use_id"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "signature": {
+                          "type": "string"
+                        },
+                        "thinking": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "thinking"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "thinking",
+                        "signature"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "redacted_thinking"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "data"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "cache_control": {
+                          "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "input": {
+                          "nullable": true
+                        },
+                        "name": {
+                          "$ref": "#/components/schemas/AnthropicServerToolName"
+                        },
+                        "type": {
+                          "enum": [
+                            "server_tool_use"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "id",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "cache_control": {
+                          "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                        },
+                        "content": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "$ref": "#/components/schemas/AnthropicWebSearchResultBlockParam"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "properties": {
+                                "error_code": {
+                                  "enum": [
+                                    "invalid_tool_input",
+                                    "unavailable",
+                                    "max_uses_exceeded",
+                                    "too_many_requests",
+                                    "query_too_long"
+                                  ],
+                                  "type": "string",
+                                  "x-speakeasy-unknown-values": "allow"
+                                },
+                                "type": {
+                                  "enum": [
+                                    "web_search_tool_result_error"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "error_code"
+                              ],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "tool_use_id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "web_search_tool_result"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "tool_use_id",
+                        "content"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AnthropicSearchResultBlockParam"
+                    },
+                    {
+                      "properties": {
+                        "cache_control": {
+                          "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                        },
+                        "content": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "compaction"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "content"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "role": {
+            "enum": [
+              "user",
+              "assistant"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "MessagesOutputConfig": {
+        "description": "Configuration for controlling output behavior. Supports the effort parameter and structured output format.",
+        "example": {
+          "effort": "medium"
+        },
+        "properties": {
+          "effort": {
+            "description": "How much effort the model should put into its response. Higher effort levels may result in more thorough analysis but take longer. Valid values are `low`, `medium`, `high`, `xhigh`, or `max`.",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max",
+              null
+            ],
+            "example": "medium",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "format": {
+            "description": "A schema to specify Claude's output format in responses. See [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs).",
+            "nullable": true,
+            "properties": {
+              "schema": {
+                "additionalProperties": {
+                  "nullable": true
+                },
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "json_schema"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "schema"
+            ],
+            "type": "object"
+          },
+          "task_budget": {
+            "description": "Task budget for an agentic turn. The model sees a countdown of remaining tokens and uses it to prioritize work and wind down gracefully. Advisory \u2014 does not enforce a hard cap.",
+            "example": {
+              "total": 400000,
+              "type": "tokens"
+            },
+            "nullable": true,
+            "properties": {
+              "remaining": {
+                "minimum": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "total": {
+                "minimum": 20000,
+                "type": "integer"
+              },
+              "type": {
+                "enum": [
+                  "tokens"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "total"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "MessagesPingEvent": {
+        "description": "Keep-alive ping event",
+        "example": {
+          "type": "ping"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "ping"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "MessagesRequest": {
+        "description": "Request schema for Anthropic Messages API endpoint",
+        "example": {
+          "max_tokens": 1024,
+          "messages": [
+            {
+              "content": "Hello, how are you?",
+              "role": "user"
+            }
+          ],
+          "model": "anthropic/claude-4.5-sonnet-20250929",
+          "temperature": 0.7
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "context_management": {
+            "nullable": true,
+            "properties": {
+              "edits": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "clear_at_least": {
+                          "$ref": "#/components/schemas/AnthropicInputTokensClearAtLeast"
+                        },
+                        "clear_tool_inputs": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "exclude_tools": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "type": "array"
+                        },
+                        "keep": {
+                          "$ref": "#/components/schemas/AnthropicToolUsesKeep"
+                        },
+                        "trigger": {
+                          "discriminator": {
+                            "mapping": {
+                              "input_tokens": "#/components/schemas/AnthropicInputTokensTrigger",
+                              "tool_uses": "#/components/schemas/AnthropicToolUsesTrigger"
+                            },
+                            "propertyName": "type"
+                          },
+                          "oneOf": [
+                            {
+                              "$ref": "#/components/schemas/AnthropicInputTokensTrigger"
+                            },
+                            {
+                              "$ref": "#/components/schemas/AnthropicToolUsesTrigger"
+                            }
+                          ]
+                        },
+                        "type": {
+                          "enum": [
+                            "clear_tool_uses_20250919"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "keep": {
+                          "anyOf": [
+                            {
+                              "$ref": "#/components/schemas/AnthropicThinkingTurns"
+                            },
+                            {
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "all"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "enum": [
+                                "all"
+                              ],
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "type": {
+                          "enum": [
+                            "clear_thinking_20251015"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "instructions": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "pause_after_compaction": {
+                          "type": "boolean"
+                        },
+                        "trigger": {
+                          "allOf": [
+                            {
+                              "$ref": "#/components/schemas/AnthropicInputTokensTrigger"
+                            },
+                            {
+                              "nullable": true,
+                              "properties": {},
+                              "type": "object"
+                            }
+                          ],
+                          "example": {
+                            "type": "input_tokens",
+                            "value": 100000
+                          }
+                        },
+                        "type": {
+                          "enum": [
+                            "compact_20260112"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "max_tokens": {
+            "type": "integer"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/MessagesMessageParam"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "user_id": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "model": {
+            "type": "string"
+          },
+          "models": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "output_config": {
+            "$ref": "#/components/schemas/MessagesOutputConfig"
+          },
+          "plugins": {
+            "description": "Plugins you want to enable for this request, including their settings.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "auto-router": "#/components/schemas/AutoRouterPlugin",
+                  "context-compression": "#/components/schemas/ContextCompressionPlugin",
+                  "file-parser": "#/components/schemas/FileParserPlugin",
+                  "moderation": "#/components/schemas/ModerationPlugin",
+                  "response-healing": "#/components/schemas/ResponseHealingPlugin",
+                  "web": "#/components/schemas/WebSearchPlugin"
+                },
+                "propertyName": "id"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AutoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ModerationPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/FileParserPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ResponseHealingPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ContextCompressionPlugin"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/ProviderPreferences"
+          },
+          "route": {
+            "$ref": "#/components/schemas/DeprecatedRoute"
+          },
+          "service_tier": {
+            "enum": [
+              "auto",
+              "standard_only"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "session_id": {
+            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "speed": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AnthropicSpeed"
+              },
+              {
+                "description": "Controls output generation speed. When set to `fast`, uses a higher-speed inference configuration at premium pricing. Defaults to `standard` when omitted.",
+                "example": "fast"
+              }
+            ]
+          },
+          "stop_sequences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stream": {
+            "type": "boolean"
+          },
+          "system": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicTextBlockParam"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "temperature": {
+            "format": "double",
+            "type": "number"
+          },
+          "thinking": {
+            "oneOf": [
+              {
+                "properties": {
+                  "budget_tokens": {
+                    "type": "integer"
+                  },
+                  "display": {
+                    "$ref": "#/components/schemas/AnthropicThinkingDisplay"
+                  },
+                  "type": {
+                    "enum": [
+                      "enabled"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "budget_tokens"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "disabled"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "display": {
+                    "$ref": "#/components/schemas/AnthropicThinkingDisplay"
+                  },
+                  "type": {
+                    "enum": [
+                      "adaptive"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "tool_choice": {
+            "oneOf": [
+              {
+                "properties": {
+                  "disable_parallel_tool_use": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "disable_parallel_tool_use": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "enum": [
+                      "any"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "none"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "disable_parallel_tool_use": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "tool"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "tools": {
+            "items": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "cache_control": {
+                      "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "input_schema": {
+                      "additionalProperties": {
+                        "nullable": true
+                      },
+                      "properties": {
+                        "properties": {
+                          "nullable": true
+                        },
+                        "required": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "type": "array"
+                        },
+                        "type": {
+                          "default": "object",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "custom"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "input_schema"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "properties": {
+                    "cache_control": {
+                      "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                    },
+                    "name": {
+                      "enum": [
+                        "bash"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "bash_20250124"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "properties": {
+                    "cache_control": {
+                      "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                    },
+                    "name": {
+                      "enum": [
+                        "str_replace_editor"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "text_editor_20250124"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "properties": {
+                    "allowed_domains": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array"
+                    },
+                    "blocked_domains": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array"
+                    },
+                    "cache_control": {
+                      "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                    },
+                    "max_uses": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "name": {
+                      "enum": [
+                        "web_search"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "web_search_20250305"
+                      ],
+                      "type": "string"
+                    },
+                    "user_location": {
+                      "$ref": "#/components/schemas/AnthropicWebSearchToolUserLocation"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "properties": {
+                    "allowed_callers": {
+                      "items": {
+                        "enum": [
+                          "direct",
+                          "code_execution_20250825",
+                          "code_execution_20260120"
+                        ],
+                        "type": "string",
+                        "x-speakeasy-unknown-values": "allow"
+                      },
+                      "type": "array"
+                    },
+                    "allowed_domains": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array"
+                    },
+                    "blocked_domains": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array"
+                    },
+                    "cache_control": {
+                      "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                    },
+                    "max_uses": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "name": {
+                      "enum": [
+                        "web_search"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "web_search_20260209"
+                      ],
+                      "type": "string"
+                    },
+                    "user_location": {
+                      "$ref": "#/components/schemas/AnthropicWebSearchToolUserLocation"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/components/schemas/DatetimeServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ImageGenerationServerTool_OpenRouter"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatSearchModelsServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenRouterWebSearchServerTool"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "top_k": {
+            "type": "integer"
+          },
+          "top_p": {
+            "format": "double",
+            "type": "number"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceConfig"
+          },
+          "user": {
+            "description": "A unique identifier representing your end-user, which helps distinguish between different users of your app. This allows your app to identify specific users in case of abuse reports, preventing your entire app from being affected by the actions of individual users. Maximum of 256 characters.",
+            "maxLength": 256,
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "MessagesResult": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseMessagesResult"
+          },
+          {
+            "properties": {
+              "context_management": {
+                "nullable": true,
+                "properties": {
+                  "applied_edits": {
+                    "items": {
+                      "additionalProperties": {
+                        "nullable": true
+                      },
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "applied_edits"
+                ],
+                "type": "object"
+              },
+              "provider": {
+                "$ref": "#/components/schemas/ProviderName"
+              },
+              "usage": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AnthropicUsage"
+                  },
+                  {
+                    "properties": {
+                      "cost": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "cost_details": {
+                        "nullable": true,
+                        "properties": {
+                          "upstream_inference_completions_cost": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "upstream_inference_cost": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "upstream_inference_prompt_cost": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "upstream_inference_prompt_cost",
+                          "upstream_inference_completions_cost"
+                        ],
+                        "type": "object"
+                      },
+                      "is_byok": {
+                        "type": "boolean"
+                      },
+                      "iterations": {
+                        "items": {
+                          "$ref": "#/components/schemas/AnthropicUsageIteration"
+                        },
+                        "type": "array"
+                      },
+                      "service_tier": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "speed": {
+                        "$ref": "#/components/schemas/AnthropicSpeed"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ],
+                "example": {
+                  "cache_creation": null,
+                  "cache_creation_input_tokens": null,
+                  "cache_read_input_tokens": null,
+                  "inference_geo": null,
+                  "input_tokens": 100,
+                  "output_tokens": 50,
+                  "server_tool_use": null,
+                  "service_tier": "standard"
+                }
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Non-streaming response from the Anthropic Messages API with OpenRouter extensions",
+        "example": {
+          "container": null,
+          "content": [
+            {
+              "citations": null,
+              "text": "Hello! I'm doing well, thank you for asking.",
+              "type": "text"
+            }
+          ],
+          "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+          "model": "claude-sonnet-4-5-20250929",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": "end_turn",
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": null,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "inference_geo": null,
+            "input_tokens": 12,
+            "output_tokens": 15,
+            "server_tool_use": null,
+            "service_tier": "standard"
+          }
+        }
+      },
+      "MessagesStartEvent": {
+        "description": "Event sent at the start of a streaming message",
+        "example": {
+          "message": {
+            "content": [],
+            "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+            "model": "claude-sonnet-4-5-20250929",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "input_tokens": 12,
+              "output_tokens": 0
+            }
+          },
+          "type": "message_start"
+        },
+        "properties": {
+          "message": {
+            "properties": {
+              "container": {
+                "$ref": "#/components/schemas/AnthropicContainer"
+              },
+              "content": {
+                "items": {
+                  "$ref": "#/components/schemas/ORAnthropicContentBlock"
+                },
+                "type": "array"
+              },
+              "id": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "provider": {
+                "enum": [
+                  "AnyScale",
+                  "Atoma",
+                  "Cent-ML",
+                  "CrofAI",
+                  "Enfer",
+                  "GoPomelo",
+                  "HuggingFace",
+                  "Hyperbolic 2",
+                  "InoCloud",
+                  "Kluster",
+                  "Lambda",
+                  "Lepton",
+                  "Lynn 2",
+                  "Lynn",
+                  "Mancer",
+                  "Meta",
+                  "Modal",
+                  "Nineteen",
+                  "OctoAI",
+                  "Recursal",
+                  "Reflection",
+                  "Replicate",
+                  "SambaNova 2",
+                  "SF Compute",
+                  "Targon",
+                  "Together 2",
+                  "Ubicloud",
+                  "01.AI",
+                  "AkashML",
+                  "AI21",
+                  "AionLabs",
+                  "Alibaba",
+                  "Ambient",
+                  "Baidu",
+                  "Amazon Bedrock",
+                  "Amazon Nova",
+                  "Anthropic",
+                  "Arcee AI",
+                  "AtlasCloud",
+                  "Avian",
+                  "Azure",
+                  "BaseTen",
+                  "BytePlus",
+                  "Black Forest Labs",
+                  "Cerebras",
+                  "Chutes",
+                  "Cirrascale",
+                  "Clarifai",
+                  "Cloudflare",
+                  "Cohere",
+                  "Crusoe",
+                  "DeepInfra",
+                  "DeepSeek",
+                  "DekaLLM",
+                  "Featherless",
+                  "Fireworks",
+                  "Friendli",
+                  "GMICloud",
+                  "Google",
+                  "Google AI Studio",
+                  "Groq",
+                  "Hyperbolic",
+                  "Inception",
+                  "Inceptron",
+                  "InferenceNet",
+                  "Ionstream",
+                  "Infermatic",
+                  "Io Net",
+                  "Inflection",
+                  "Liquid",
+                  "Mara",
+                  "Mancer 2",
+                  "Minimax",
+                  "ModelRun",
+                  "Mistral",
+                  "Modular",
+                  "Moonshot AI",
+                  "Morph",
+                  "NCompass",
+                  "Nebius",
+                  "NextBit",
+                  "Novita",
+                  "Nvidia",
+                  "OpenAI",
+                  "OpenInference",
+                  "Parasail",
+                  "Perplexity",
+                  "Phala",
+                  "Recraft",
+                  "Reka",
+                  "Relace",
+                  "SambaNova",
+                  "Seed",
+                  "SiliconFlow",
+                  "Sourceful",
+                  "StepFun",
+                  "Stealth",
+                  "StreamLake",
+                  "Switchpoint",
+                  "Together",
+                  "Upstage",
+                  "Venice",
+                  "WandB",
+                  "Xiaomi",
+                  "xAI",
+                  "Z.AI",
+                  "FakeProvider"
+                ],
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              },
+              "role": {
+                "enum": [
+                  "assistant"
+                ],
+                "type": "string"
+              },
+              "stop_details": {
+                "$ref": "#/components/schemas/AnthropicRefusalStopDetails"
+              },
+              "stop_reason": {
+                "nullable": true
+              },
+              "stop_sequence": {
+                "nullable": true
+              },
+              "type": {
+                "enum": [
+                  "message"
+                ],
+                "type": "string"
+              },
+              "usage": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AnthropicUsage"
+                  },
+                  {
+                    "properties": {
+                      "iterations": {
+                        "items": {
+                          "$ref": "#/components/schemas/AnthropicUsageIteration"
+                        },
+                        "type": "array"
+                      },
+                      "speed": {
+                        "$ref": "#/components/schemas/AnthropicSpeed"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ],
+                "example": {
+                  "cache_creation": null,
+                  "cache_creation_input_tokens": null,
+                  "cache_read_input_tokens": null,
+                  "inference_geo": null,
+                  "input_tokens": 100,
+                  "output_tokens": 50,
+                  "server_tool_use": null,
+                  "service_tier": "standard"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "role",
+              "container",
+              "content",
+              "model",
+              "stop_reason",
+              "stop_details",
+              "stop_sequence",
+              "usage"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "message_start"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "MessagesStopEvent": {
+        "description": "Event sent when the message is complete",
+        "example": {
+          "type": "message_stop"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "message_stop"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "MessagesStreamEvents": {
+        "description": "Union of all possible streaming events",
+        "discriminator": {
+          "mapping": {
+            "content_block_delta": "#/components/schemas/MessagesContentBlockDeltaEvent",
+            "content_block_start": "#/components/schemas/MessagesContentBlockStartEvent",
+            "content_block_stop": "#/components/schemas/MessagesContentBlockStopEvent",
+            "error": "#/components/schemas/MessagesErrorEvent",
+            "message_delta": "#/components/schemas/MessagesDeltaEvent",
+            "message_start": "#/components/schemas/MessagesStartEvent",
+            "message_stop": "#/components/schemas/MessagesStopEvent",
+            "ping": "#/components/schemas/MessagesPingEvent"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "delta": {
+            "text": "Hello",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MessagesStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesStopEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesContentBlockStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesContentBlockDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesContentBlockStopEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesPingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessagesErrorEvent"
+          }
+        ]
+      },
+      "Model": {
+        "description": "Information about an AI model available on OpenRouter",
+        "example": {
+          "architecture": {
+            "input_modalities": [
+              "text"
+            ],
+            "instruct_type": "chatml",
+            "modality": "text->text",
+            "output_modalities": [
+              "text"
+            ],
+            "tokenizer": "GPT"
+          },
+          "canonical_slug": "openai/gpt-4",
+          "context_length": 8192,
+          "created": 1692901234,
+          "default_parameters": null,
+          "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+          "expiration_date": null,
+          "id": "openai/gpt-4",
+          "knowledge_cutoff": null,
+          "links": {
+            "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+          },
+          "name": "GPT-4",
+          "per_request_limits": null,
+          "pricing": {
+            "completion": "0.00006",
+            "image": "0",
+            "prompt": "0.00003",
+            "request": "0"
+          },
+          "supported_parameters": [
+            "temperature",
+            "top_p",
+            "max_tokens"
+          ],
+          "top_provider": {
+            "context_length": 8192,
+            "is_moderated": true,
+            "max_completion_tokens": 4096
+          }
+        },
+        "properties": {
+          "architecture": {
+            "$ref": "#/components/schemas/ModelArchitecture"
+          },
+          "canonical_slug": {
+            "description": "Canonical slug for the model",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "context_length": {
+            "description": "Maximum context length in tokens",
+            "example": 8192,
+            "nullable": true,
+            "type": "integer"
+          },
+          "created": {
+            "description": "Unix timestamp of when the model was created",
+            "example": 1692901234,
+            "type": "integer"
+          },
+          "default_parameters": {
+            "$ref": "#/components/schemas/DefaultParameters"
+          },
+          "description": {
+            "description": "Description of the model",
+            "example": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+            "type": "string"
+          },
+          "expiration_date": {
+            "description": "The date after which the model may be removed. ISO 8601 date string (YYYY-MM-DD) or null if no expiration.",
+            "example": "2025-06-01",
+            "nullable": true,
+            "type": "string"
+          },
+          "hugging_face_id": {
+            "description": "Hugging Face model identifier, if applicable",
+            "example": "microsoft/DialoGPT-medium",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the model",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "knowledge_cutoff": {
+            "description": "The date up to which the model was trained on data. ISO 8601 date string (YYYY-MM-DD) or null if unknown.",
+            "example": "2024-10-01",
+            "nullable": true,
+            "type": "string"
+          },
+          "links": {
+            "$ref": "#/components/schemas/ModelLinks"
+          },
+          "name": {
+            "description": "Display name of the model",
+            "example": "GPT-4",
+            "type": "string"
+          },
+          "per_request_limits": {
+            "$ref": "#/components/schemas/PerRequestLimits"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/PublicPricing"
+          },
+          "supported_parameters": {
+            "description": "List of supported parameters for this model",
+            "items": {
+              "$ref": "#/components/schemas/Parameter"
+            },
+            "type": "array"
+          },
+          "top_provider": {
+            "$ref": "#/components/schemas/TopProviderInfo"
+          }
+        },
+        "required": [
+          "id",
+          "canonical_slug",
+          "name",
+          "created",
+          "pricing",
+          "context_length",
+          "architecture",
+          "top_provider",
+          "per_request_limits",
+          "supported_parameters",
+          "default_parameters",
+          "links"
+        ],
+        "type": "object"
+      },
+      "ModelArchitecture": {
+        "description": "Model architecture information",
+        "example": {
+          "input_modalities": [
+            "text"
+          ],
+          "instruct_type": "chatml",
+          "modality": "text->text",
+          "output_modalities": [
+            "text"
+          ],
+          "tokenizer": "GPT"
+        },
+        "properties": {
+          "input_modalities": {
+            "description": "Supported input modalities",
+            "items": {
+              "$ref": "#/components/schemas/InputModality"
+            },
+            "type": "array"
+          },
+          "instruct_type": {
+            "description": "Instruction format type",
+            "enum": [
+              "none",
+              "airoboros",
+              "alpaca",
+              "alpaca-modif",
+              "chatml",
+              "claude",
+              "code-llama",
+              "gemma",
+              "llama2",
+              "llama3",
+              "mistral",
+              "nemotron",
+              "neural",
+              "openchat",
+              "phi3",
+              "rwkv",
+              "vicuna",
+              "zephyr",
+              "deepseek-r1",
+              "deepseek-v3.1",
+              "qwq",
+              "qwen3",
+              null
+            ],
+            "example": "chatml",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "modality": {
+            "description": "Primary modality of the model",
+            "example": "text->text",
+            "nullable": true,
+            "type": "string"
+          },
+          "output_modalities": {
+            "description": "Supported output modalities",
+            "items": {
+              "$ref": "#/components/schemas/OutputModality"
+            },
+            "type": "array"
+          },
+          "tokenizer": {
+            "$ref": "#/components/schemas/ModelGroup"
+          }
+        },
+        "required": [
+          "modality",
+          "input_modalities",
+          "output_modalities"
+        ],
+        "type": "object"
+      },
+      "ModelGroup": {
+        "description": "Tokenizer type used by the model",
+        "enum": [
+          "Router",
+          "Media",
+          "Other",
+          "GPT",
+          "Claude",
+          "Gemini",
+          "Gemma",
+          "Grok",
+          "Cohere",
+          "Nova",
+          "Qwen",
+          "Yi",
+          "DeepSeek",
+          "Mistral",
+          "Llama2",
+          "Llama3",
+          "Llama4",
+          "PaLM",
+          "RWKV",
+          "Qwen3"
+        ],
+        "example": "GPT",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ModelLinks": {
+        "description": "Related API endpoints and resources for this model.",
+        "example": {
+          "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+        },
+        "properties": {
+          "details": {
+            "description": "URL for the model details/endpoints API",
+            "example": "/api/v1/models/openai/gpt-5.4/endpoints",
+            "type": "string"
+          }
+        },
+        "required": [
+          "details"
+        ],
+        "type": "object"
+      },
+      "ModelName": {
+        "description": "Model to use for completion",
+        "example": "openai/gpt-4",
+        "type": "string"
+      },
+      "ModelsCountResponse": {
+        "description": "Model count data",
+        "example": {
+          "data": {
+            "count": 150
+          }
+        },
+        "properties": {
+          "data": {
+            "description": "Model count data",
+            "example": {
+              "count": 150
+            },
+            "properties": {
+              "count": {
+                "description": "Total number of available models",
+                "example": 150,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "count"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ModelsListResponse": {
+        "description": "List of available models",
+        "example": {
+          "data": [
+            {
+              "architecture": {
+                "input_modalities": [
+                  "text"
+                ],
+                "instruct_type": "chatml",
+                "modality": "text->text",
+                "output_modalities": [
+                  "text"
+                ],
+                "tokenizer": "GPT"
+              },
+              "canonical_slug": "openai/gpt-4",
+              "context_length": 8192,
+              "created": 1692901234,
+              "default_parameters": null,
+              "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+              "expiration_date": null,
+              "id": "openai/gpt-4",
+              "knowledge_cutoff": null,
+              "links": {
+                "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+              },
+              "name": "GPT-4",
+              "per_request_limits": null,
+              "pricing": {
+                "completion": "0.00006",
+                "image": "0",
+                "prompt": "0.00003",
+                "request": "0"
+              },
+              "supported_parameters": [
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty"
+              ],
+              "top_provider": {
+                "context_length": 8192,
+                "is_moderated": true,
+                "max_completion_tokens": 4096
+              }
+            }
+          ]
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ModelsListResponseData"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ModelsListResponseData": {
+        "description": "List of available models",
+        "example": [
+          {
+            "architecture": {
+              "input_modalities": [
+                "text"
+              ],
+              "instruct_type": "chatml",
+              "modality": "text->text",
+              "output_modalities": [
+                "text"
+              ],
+              "tokenizer": "GPT"
+            },
+            "canonical_slug": "openai/gpt-4",
+            "context_length": 8192,
+            "created": 1692901234,
+            "default_parameters": null,
+            "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+            "expiration_date": null,
+            "id": "openai/gpt-4",
+            "knowledge_cutoff": null,
+            "links": {
+              "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+            },
+            "name": "GPT-4",
+            "per_request_limits": null,
+            "pricing": {
+              "completion": "0.00006",
+              "image": "0",
+              "prompt": "0.00003",
+              "request": "0"
+            },
+            "supported_parameters": [
+              "temperature",
+              "top_p",
+              "max_tokens"
+            ],
+            "top_provider": {
+              "context_length": 8192,
+              "is_moderated": true,
+              "max_completion_tokens": 4096
+            }
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/Model"
+        },
+        "type": "array"
+      },
+      "ModerationPlugin": {
+        "example": {
+          "id": "moderation"
+        },
+        "properties": {
+          "id": {
+            "enum": [
+              "moderation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "NotFoundResponse": {
+        "description": "Not Found - Resource does not exist",
+        "example": {
+          "error": {
+            "code": 404,
+            "message": "Resource not found"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/NotFoundResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "NotFoundResponseErrorData": {
+        "description": "Error data for NotFoundResponse",
+        "example": {
+          "code": 404,
+          "message": "Resource not found"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ORAnthropicContentBlock": {
+        "discriminator": {
+          "mapping": {
+            "bash_code_execution_tool_result": "#/components/schemas/AnthropicBashCodeExecutionToolResult",
+            "code_execution_tool_result": "#/components/schemas/AnthropicCodeExecutionToolResult",
+            "compaction": "#/components/schemas/AnthropicCompactionBlock",
+            "container_upload": "#/components/schemas/AnthropicContainerUpload",
+            "redacted_thinking": "#/components/schemas/AnthropicRedactedThinkingBlock",
+            "server_tool_use": "#/components/schemas/AnthropicServerToolUseBlock",
+            "text": "#/components/schemas/AnthropicTextBlock",
+            "text_editor_code_execution_tool_result": "#/components/schemas/AnthropicTextEditorCodeExecutionToolResult",
+            "thinking": "#/components/schemas/AnthropicThinkingBlock",
+            "tool_search_tool_result": "#/components/schemas/AnthropicToolSearchToolResult",
+            "tool_use": "#/components/schemas/AnthropicToolUseBlock",
+            "web_fetch_tool_result": "#/components/schemas/AnthropicWebFetchToolResult",
+            "web_search_tool_result": "#/components/schemas/AnthropicWebSearchToolResult"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "citations": null,
+          "text": "Hello, world!",
+          "type": "text"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicTextBlock"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicToolUseBlock"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicThinkingBlock"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicRedactedThinkingBlock"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicServerToolUseBlock"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicWebSearchToolResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicWebFetchToolResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecutionToolResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicBashCodeExecutionToolResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicTextEditorCodeExecutionToolResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicToolSearchToolResult"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicContainerUpload"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCompactionBlock"
+          }
+        ]
+      },
+      "ORAnthropicStopReason": {
+        "enum": [
+          "end_turn",
+          "max_tokens",
+          "stop_sequence",
+          "tool_use",
+          "pause_turn",
+          "refusal",
+          "compaction",
+          null
+        ],
+        "example": "end_turn",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "OpenAIResponseFunctionToolCall": {
+        "example": {
+          "arguments": "{\"location\":\"San Francisco\"}",
+          "call_id": "call-abc123",
+          "id": "fc-abc123",
+          "name": "get_weather",
+          "status": "completed",
+          "type": "function_call"
+        },
+        "properties": {
+          "arguments": {
+            "type": "string"
+          },
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "function_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponseFunctionToolCallOutput": {
+        "example": {
+          "call_id": "call-abc123",
+          "output": "{\"temperature\":72,\"conditions\":\"sunny\"}",
+          "type": "function_call_output"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "input_file": "#/components/schemas/InputFile",
+                      "input_image": "#/components/schemas/InputImage",
+                      "input_text": "#/components/schemas/InputText"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InputText"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputImage"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputFile"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallStatus"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "function_call_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "output"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponseInputMessageItem": {
+        "example": {
+          "content": [
+            {
+              "text": "Hello, how are you?",
+              "type": "input_text"
+            }
+          ],
+          "id": "msg-abc123",
+          "role": "user",
+          "type": "message"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "input_audio": "#/components/schemas/InputAudio",
+                  "input_file": "#/components/schemas/InputFile",
+                  "input_image": "#/components/schemas/InputImage",
+                  "input_text": "#/components/schemas/InputText"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/InputText"
+                },
+                {
+                  "$ref": "#/components/schemas/InputImage"
+                },
+                {
+                  "$ref": "#/components/schemas/InputFile"
+                },
+                {
+                  "$ref": "#/components/schemas/InputAudio"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "enum": [
+                  "user"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "system"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "developer"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesAnnotation": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/FileCitation"
+          },
+          {
+            "$ref": "#/components/schemas/URLCitation"
+          },
+          {
+            "$ref": "#/components/schemas/FilePath"
+          }
+        ],
+        "example": {
+          "file_id": "file-abc123",
+          "filename": "research_paper.pdf",
+          "index": 0,
+          "type": "file_citation"
+        }
+      },
+      "OpenAIResponsesImageGenCallCompleted": {
+        "example": {
+          "item_id": "ig_abc123",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.image_generation_call.completed"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.image_generation_call.completed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesImageGenCallGenerating": {
+        "example": {
+          "item_id": "ig_abc123",
+          "output_index": 0,
+          "sequence_number": 2,
+          "type": "response.image_generation_call.generating"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.image_generation_call.generating"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesImageGenCallInProgress": {
+        "example": {
+          "item_id": "ig_abc123",
+          "output_index": 0,
+          "sequence_number": 1,
+          "type": "response.image_generation_call.in_progress"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.image_generation_call.in_progress"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesImageGenCallPartialImage": {
+        "example": {
+          "item_id": "ig_abc123",
+          "output_index": 0,
+          "partial_image_b64": "iVBORw0KGgo...",
+          "partial_image_index": 0,
+          "sequence_number": 3,
+          "type": "response.image_generation_call.partial_image"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "partial_image_b64": {
+            "type": "string"
+          },
+          "partial_image_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.image_generation_call.partial_image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number",
+          "partial_image_b64",
+          "partial_image_index"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesRefusalContent": {
+        "example": {
+          "refusal": "I'm sorry, I cannot assist with that request",
+          "type": "refusal"
+        },
+        "properties": {
+          "refusal": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "refusal"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "refusal"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesResponseStatus": {
+        "enum": [
+          "completed",
+          "incomplete",
+          "in_progress",
+          "failed",
+          "cancelled",
+          "queued"
+        ],
+        "example": "completed",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "OpenAIResponsesSearchCompleted": {
+        "example": {
+          "item_id": "ws_abc123",
+          "output_index": 0,
+          "sequence_number": 5,
+          "type": "response.web_search_call.completed"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.web_search_call.completed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesToolChoice": {
+        "anyOf": [
+          {
+            "enum": [
+              "auto"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "none"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "required"
+            ],
+            "type": "string"
+          },
+          {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "function"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "web_search_preview_2025_03_11"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "enum": [
+                      "web_search_preview"
+                    ],
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ToolChoiceAllowed"
+          }
+        ],
+        "example": "auto"
+      },
+      "OpenAIResponsesTruncation": {
+        "enum": [
+          "auto",
+          "disabled",
+          null
+        ],
+        "example": "auto",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "OpenAIResponsesUsage": {
+        "example": {
+          "input_tokens": 100,
+          "input_tokens_details": {
+            "cached_tokens": 0
+          },
+          "output_tokens": 50,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 150
+        },
+        "properties": {
+          "input_tokens": {
+            "type": "integer"
+          },
+          "input_tokens_details": {
+            "properties": {
+              "cached_tokens": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "cached_tokens"
+            ],
+            "type": "object"
+          },
+          "output_tokens": {
+            "type": "integer"
+          },
+          "output_tokens_details": {
+            "properties": {
+              "reasoning_tokens": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "reasoning_tokens"
+            ],
+            "type": "object"
+          },
+          "total_tokens": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "input_tokens_details",
+          "output_tokens",
+          "output_tokens_details",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesWebSearchCallInProgress": {
+        "example": {
+          "item_id": "ws_abc123",
+          "output_index": 0,
+          "sequence_number": 1,
+          "type": "response.web_search_call.in_progress"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.web_search_call.in_progress"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponsesWebSearchCallSearching": {
+        "example": {
+          "item_id": "ws_abc123",
+          "output_index": 0,
+          "sequence_number": 2,
+          "type": "response.web_search_call.searching"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.web_search_call.searching"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OpenResponsesCreatedEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreatedEvent"
+          },
+          {
+            "properties": {
+              "response": {
+                "$ref": "#/components/schemas/OpenResponsesResult"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a response is created",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "in_progress",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 0,
+          "type": "response.created"
+        }
+      },
+      "OpenResponsesInProgressEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InProgressEvent"
+          },
+          {
+            "properties": {
+              "response": {
+                "$ref": "#/components/schemas/OpenResponsesResult"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a response is in progress",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "in_progress",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 1,
+          "type": "response.in_progress"
+        }
+      },
+      "OpenResponsesLogProbs": {
+        "description": "Log probability information for a token",
+        "example": {
+          "logprob": -0.1,
+          "token": "world",
+          "top_logprobs": [
+            {
+              "logprob": -0.5,
+              "token": "hello"
+            }
+          ]
+        },
+        "properties": {
+          "bytes": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "logprob": {
+            "format": "double",
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "top_logprobs": {
+            "items": {
+              "$ref": "#/components/schemas/OpenResponsesTopLogprobs"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "logprob",
+          "token"
+        ],
+        "type": "object"
+      },
+      "OpenResponsesResult": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseResponsesResult"
+          },
+          {
+            "properties": {
+              "output": {
+                "items": {
+                  "$ref": "#/components/schemas/OutputItems"
+                },
+                "type": "array"
+              },
+              "service_tier": {
+                "nullable": true,
+                "type": "string"
+              },
+              "text": {
+                "$ref": "#/components/schemas/TextExtendedConfig"
+              },
+              "usage": {
+                "$ref": "#/components/schemas/Usage"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Complete non-streaming response from the Responses API",
+        "example": {
+          "created_at": 1704067200,
+          "error": null,
+          "id": "resp-abc123",
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "metadata": null,
+          "model": "gpt-4",
+          "object": "response",
+          "output": [
+            {
+              "content": [
+                {
+                  "annotations": [],
+                  "text": "Hello! How can I help you today?",
+                  "type": "output_text"
+                }
+              ],
+              "id": "msg-abc123",
+              "role": "assistant",
+              "status": "completed",
+              "type": "message"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "status": "completed",
+          "temperature": null,
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": null,
+          "usage": {
+            "input_tokens": 10,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 25,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 35
+          }
+        }
+      },
+      "OpenResponsesTopLogprobs": {
+        "description": "Alternative token with its log probability",
+        "example": {
+          "logprob": -0.5,
+          "token": "hello"
+        },
+        "properties": {
+          "bytes": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "logprob": {
+            "format": "double",
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "OpenRouterWebSearchServerTool": {
+        "description": "OpenRouter built-in server tool: searches the web for current information",
+        "example": {
+          "parameters": {
+            "max_results": 5
+          },
+          "type": "openrouter:web_search"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/WebSearchConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:web_search"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputApplyPatchServerToolItem": {
+        "description": "An openrouter:apply_patch server tool output item",
+        "example": {
+          "filePath": "/src/main.ts",
+          "id": "ap_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:apply_patch"
+        },
+        "properties": {
+          "filePath": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "patch": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:apply_patch"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputBashServerToolItem": {
+        "description": "An openrouter:bash server tool output item",
+        "example": {
+          "command": "ls -la",
+          "exitCode": 0,
+          "id": "bash_tmp_abc123",
+          "status": "completed",
+          "stdout": "total 0\n",
+          "type": "openrouter:bash"
+        },
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "exitCode": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "stderr": {
+            "type": "string"
+          },
+          "stdout": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openrouter:bash"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputBrowserUseServerToolItem": {
+        "description": "An openrouter:browser_use server tool output item",
+        "example": {
+          "action": "screenshot",
+          "id": "bu_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:browser_use"
+        },
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "screenshotB64": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:browser_use"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputCodeInterpreterCallItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CodeInterpreterCallItem"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "A code interpreter execution call with outputs",
+        "example": {
+          "code": "print(\"hello\")",
+          "container_id": "ctr-xyz789",
+          "id": "ci-abc123",
+          "outputs": [
+            {
+              "logs": "hello\n",
+              "type": "logs"
+            }
+          ],
+          "status": "completed",
+          "type": "code_interpreter_call"
+        }
+      },
+      "OutputCodeInterpreterServerToolItem": {
+        "description": "An openrouter:code_interpreter server tool output item",
+        "example": {
+          "code": "print(\"hello\")",
+          "id": "ci_tmp_abc123",
+          "language": "python",
+          "status": "completed",
+          "stdout": "hello\n",
+          "type": "openrouter:code_interpreter"
+        },
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "exitCode": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "stderr": {
+            "type": "string"
+          },
+          "stdout": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openrouter:code_interpreter"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputComputerCallItem": {
+        "example": {
+          "action": {
+            "type": "screenshot"
+          },
+          "call_id": "call-abc123",
+          "id": "cu-abc123",
+          "pending_safety_checks": [],
+          "status": "completed",
+          "type": "computer_call"
+        },
+        "properties": {
+          "action": {
+            "nullable": true
+          },
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "pending_safety_checks": {
+            "items": {
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "code",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "computer_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "status",
+          "pending_safety_checks"
+        ],
+        "type": "object"
+      },
+      "OutputDatetimeItem": {
+        "description": "An openrouter:datetime server tool output item",
+        "example": {
+          "datetime": "2026-03-12T14:30:00.000Z",
+          "id": "dt_tmp_abc123",
+          "status": "completed",
+          "timezone": "UTC",
+          "type": "openrouter:datetime"
+        },
+        "properties": {
+          "datetime": {
+            "description": "ISO 8601 datetime string",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "timezone": {
+            "description": "IANA timezone name",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openrouter:datetime"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type",
+          "datetime",
+          "timezone"
+        ],
+        "type": "object"
+      },
+      "OutputFileSearchCallItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemFileSearchCall"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "example": {
+          "id": "fs-abc123",
+          "queries": [
+            "search term"
+          ],
+          "results": [],
+          "status": "completed",
+          "type": "file_search_call"
+        }
+      },
+      "OutputFileSearchServerToolItem": {
+        "description": "An openrouter:file_search server tool output item",
+        "example": {
+          "id": "fs_tmp_abc123",
+          "queries": [
+            "search term"
+          ],
+          "status": "completed",
+          "type": "openrouter:file_search"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "queries": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:file_search"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputFunctionCallItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemFunctionCall"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "example": {
+          "arguments": "{\"location\":\"San Francisco\"}",
+          "call_id": "call-abc123",
+          "id": "fc-abc123",
+          "name": "get_weather",
+          "status": "completed",
+          "type": "function_call"
+        }
+      },
+      "OutputImageGenerationCallItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "example": {
+          "id": "img-abc123",
+          "result": null,
+          "status": "completed",
+          "type": "image_generation_call"
+        }
+      },
+      "OutputImageGenerationServerToolItem": {
+        "description": "An openrouter:image_generation server tool output item",
+        "example": {
+          "id": "ig_tmp_abc123",
+          "imageUrl": "https://example.com/image.png",
+          "result": "https://example.com/image.png",
+          "status": "completed",
+          "type": "openrouter:image_generation"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "imageB64": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "result": {
+            "description": "The generated image as a base64-encoded string or URL, matching OpenAI image_generation_call format",
+            "nullable": true,
+            "type": "string"
+          },
+          "revisedPrompt": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:image_generation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputItemAddedEvent": {
+        "description": "Event emitted when a new output item is added to the response",
+        "example": {
+          "item": {
+            "content": [],
+            "id": "item-1",
+            "role": "assistant",
+            "status": "in_progress",
+            "type": "message"
+          },
+          "output_index": 0,
+          "sequence_number": 2,
+          "type": "response.output_item.added"
+        },
+        "properties": {
+          "item": {
+            "discriminator": {
+              "mapping": {
+                "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
+                "function_call": "#/components/schemas/OutputItemFunctionCall",
+                "image_generation_call": "#/components/schemas/OutputItemImageGenerationCall",
+                "message": "#/components/schemas/OutputMessage",
+                "reasoning": "#/components/schemas/OutputItemReasoning",
+                "web_search_call": "#/components/schemas/OutputItemWebSearchCall"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/OutputMessage"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemReasoning"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemFunctionCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemWebSearchCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemFileSearchCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+              }
+            ]
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.output_item.added"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OutputItemDoneEvent": {
+        "description": "Event emitted when an output item is complete",
+        "example": {
+          "item": {
+            "content": [
+              {
+                "annotations": [],
+                "text": "Hello! How can I help you?",
+                "type": "output_text"
+              }
+            ],
+            "id": "item-1",
+            "role": "assistant",
+            "status": "completed",
+            "type": "message"
+          },
+          "output_index": 0,
+          "sequence_number": 8,
+          "type": "response.output_item.done"
+        },
+        "properties": {
+          "item": {
+            "discriminator": {
+              "mapping": {
+                "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
+                "function_call": "#/components/schemas/OutputItemFunctionCall",
+                "image_generation_call": "#/components/schemas/OutputItemImageGenerationCall",
+                "message": "#/components/schemas/OutputMessage",
+                "reasoning": "#/components/schemas/OutputItemReasoning",
+                "web_search_call": "#/components/schemas/OutputItemWebSearchCall"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/OutputMessage"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemReasoning"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemFunctionCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemWebSearchCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemFileSearchCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+              }
+            ]
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.output_item.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OutputItemFileSearchCall": {
+        "example": {
+          "id": "filesearch-abc123",
+          "queries": [
+            "machine learning algorithms",
+            "neural networks"
+          ],
+          "status": "completed",
+          "type": "file_search_call"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "queries": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WebSearchStatus"
+          },
+          "type": {
+            "enum": [
+              "file_search_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "queries",
+          "status"
+        ],
+        "type": "object"
+      },
+      "OutputItemFunctionCall": {
+        "example": {
+          "arguments": "{\"location\":\"San Francisco\",\"unit\":\"celsius\"}",
+          "call_id": "call-abc123",
+          "id": "call-abc123",
+          "name": "get_weather",
+          "type": "function_call"
+        },
+        "properties": {
+          "arguments": {
+            "type": "string"
+          },
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "completed"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "incomplete"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "in_progress"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "function_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "arguments",
+          "call_id"
+        ],
+        "type": "object"
+      },
+      "OutputItemImageGenerationCall": {
+        "example": {
+          "id": "imagegen-abc123",
+          "result": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+          "status": "completed",
+          "type": "image_generation_call"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "result": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ImageGenerationStatus"
+          },
+          "type": {
+            "enum": [
+              "image_generation_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "status"
+        ],
+        "type": "object"
+      },
+      "OutputItemReasoning": {
+        "example": {
+          "id": "reasoning-abc123",
+          "summary": [
+            {
+              "text": "Analyzed the problem using first principles",
+              "type": "summary_text"
+            }
+          ],
+          "type": "reasoning"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/ReasoningTextContent"
+            },
+            "type": "array"
+          },
+          "encrypted_content": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "completed"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "incomplete"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "in_progress"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "summary": {
+            "items": {
+              "$ref": "#/components/schemas/ReasoningSummaryText"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "reasoning"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "OutputItemWebSearchCall": {
+        "example": {
+          "action": {
+            "query": "OpenAI API",
+            "type": "search"
+          },
+          "id": "search-abc123",
+          "status": "completed",
+          "type": "web_search_call"
+        },
+        "properties": {
+          "action": {
+            "oneOf": [
+              {
+                "properties": {
+                  "queries": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "sources": {
+                    "items": {
+                      "$ref": "#/components/schemas/WebSearchSource"
+                    },
+                    "type": "array"
+                  },
+                  "type": {
+                    "enum": [
+                      "search"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "query"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "open_page"
+                    ],
+                    "type": "string"
+                  },
+                  "url": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "pattern": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "find_in_page"
+                    ],
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "pattern",
+                  "url"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WebSearchStatus"
+          },
+          "type": {
+            "enum": [
+              "web_search_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "action",
+          "status"
+        ],
+        "type": "object"
+      },
+      "OutputItems": {
+        "description": "An output item from the response",
+        "discriminator": {
+          "mapping": {
+            "code_interpreter_call": "#/components/schemas/OutputCodeInterpreterCallItem",
+            "computer_call": "#/components/schemas/OutputComputerCallItem",
+            "file_search_call": "#/components/schemas/OutputFileSearchCallItem",
+            "function_call": "#/components/schemas/OutputFunctionCallItem",
+            "image_generation_call": "#/components/schemas/OutputImageGenerationCallItem",
+            "message": "#/components/schemas/OutputMessageItem",
+            "openrouter:apply_patch": "#/components/schemas/OutputApplyPatchServerToolItem",
+            "openrouter:bash": "#/components/schemas/OutputBashServerToolItem",
+            "openrouter:browser_use": "#/components/schemas/OutputBrowserUseServerToolItem",
+            "openrouter:code_interpreter": "#/components/schemas/OutputCodeInterpreterServerToolItem",
+            "openrouter:datetime": "#/components/schemas/OutputDatetimeItem",
+            "openrouter:experimental__search_models": "#/components/schemas/OutputSearchModelsServerToolItem",
+            "openrouter:file_search": "#/components/schemas/OutputFileSearchServerToolItem",
+            "openrouter:image_generation": "#/components/schemas/OutputImageGenerationServerToolItem",
+            "openrouter:mcp": "#/components/schemas/OutputMcpServerToolItem",
+            "openrouter:memory": "#/components/schemas/OutputMemoryServerToolItem",
+            "openrouter:text_editor": "#/components/schemas/OutputTextEditorServerToolItem",
+            "openrouter:tool_search": "#/components/schemas/OutputToolSearchServerToolItem",
+            "openrouter:web_fetch": "#/components/schemas/OutputWebFetchServerToolItem",
+            "openrouter:web_search": "#/components/schemas/OutputWebSearchServerToolItem",
+            "reasoning": "#/components/schemas/OutputReasoningItem",
+            "web_search_call": "#/components/schemas/OutputWebSearchCallItem"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "content": [
+            {
+              "text": "Hello! How can I help you today?",
+              "type": "output_text"
+            }
+          ],
+          "id": "msg-abc123",
+          "role": "assistant",
+          "status": "completed",
+          "type": "message"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OutputMessageItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputReasoningItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputFunctionCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputWebSearchCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputFileSearchCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputImageGenerationCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputCodeInterpreterCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputComputerCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputDatetimeItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputWebSearchServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputCodeInterpreterServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputFileSearchServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputImageGenerationServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputBrowserUseServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputBashServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputTextEditorServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputApplyPatchServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputWebFetchServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputToolSearchServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputMemoryServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputMcpServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputSearchModelsServerToolItem"
+          }
+        ]
+      },
+      "OutputMcpServerToolItem": {
+        "description": "An openrouter:mcp server tool output item",
+        "example": {
+          "id": "mcp_tmp_abc123",
+          "serverLabel": "my-server",
+          "status": "completed",
+          "toolName": "get_data",
+          "type": "openrouter:mcp"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "serverLabel": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openrouter:mcp"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputMemoryServerToolItem": {
+        "description": "An openrouter:memory server tool output item",
+        "example": {
+          "action": "read",
+          "id": "mem_tmp_abc123",
+          "key": "user_preference",
+          "status": "completed",
+          "type": "openrouter:memory"
+        },
+        "properties": {
+          "action": {
+            "enum": [
+              "read",
+              "write",
+              "delete"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "id": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:memory"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputMessage": {
+        "example": {
+          "content": [
+            {
+              "text": "Hello! How can I help you today?",
+              "type": "output_text"
+            }
+          ],
+          "id": "msg-abc123",
+          "role": "assistant",
+          "status": "completed",
+          "type": "message"
+        },
+        "properties": {
+          "content": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ResponseOutputText"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAIResponsesRefusalContent"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "enum": [
+                  "commentary"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "final_answer"
+                ],
+                "type": "string"
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "description": "The phase of an assistant message. Use `commentary` for an intermediate assistant message and `final_answer` for the final assistant message. For follow-up requests with models like `gpt-5.3-codex` and later, preserve and resend phase on all assistant messages. Omitting it can degrade performance. Not used for user messages."
+          },
+          "role": {
+            "enum": [
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "completed"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "incomplete"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "in_progress"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "role",
+          "type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "OutputMessageItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputMessage"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "An output message item",
+        "example": {
+          "content": [
+            {
+              "annotations": [],
+              "text": "Hello! How can I help you?",
+              "type": "output_text"
+            }
+          ],
+          "id": "msg-123",
+          "role": "assistant",
+          "status": "completed",
+          "type": "message"
+        }
+      },
+      "OutputModality": {
+        "enum": [
+          "text",
+          "image",
+          "embeddings",
+          "audio",
+          "video",
+          "rerank"
+        ],
+        "example": "text",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "OutputModalityEnum": {
+        "enum": [
+          "text",
+          "image"
+        ],
+        "example": "text",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "OutputReasoningItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemReasoning"
+          },
+          {
+            "properties": {
+              "content": {
+                "items": {
+                  "$ref": "#/components/schemas/ReasoningTextContent"
+                },
+                "nullable": true,
+                "type": "array"
+              },
+              "format": {
+                "$ref": "#/components/schemas/ReasoningFormat"
+              },
+              "signature": {
+                "description": "A signature for the reasoning content, used for verification",
+                "example": "EvcBCkgIChABGAIqQKkSDbRuVEQUk9qN1odC098l9SEj...",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "An output item containing reasoning",
+        "example": {
+          "content": [
+            {
+              "text": "First, we analyze the problem...",
+              "type": "reasoning_text"
+            }
+          ],
+          "format": "anthropic-claude-v1",
+          "id": "reasoning-123",
+          "signature": "EvcBCkgIChABGAIqQKkSDbRuVEQUk9qN1odC098l9SEj...",
+          "status": "completed",
+          "summary": [
+            {
+              "text": "Analyzed the problem and found the optimal solution.",
+              "type": "summary_text"
+            }
+          ],
+          "type": "reasoning"
+        }
+      },
+      "OutputSearchModelsServerToolItem": {
+        "description": "An openrouter:experimental__search_models server tool output item",
+        "example": {
+          "arguments": "{\"query\":\"Claude Opus\"}",
+          "id": "sm_tmp_abc123",
+          "query": "Claude Opus",
+          "status": "completed",
+          "type": "openrouter:experimental__search_models"
+        },
+        "properties": {
+          "arguments": {
+            "description": "The JSON arguments submitted to the search tool (e.g. {\"query\":\"Claude\"})",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:experimental__search_models"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputTextEditorServerToolItem": {
+        "description": "An openrouter:text_editor server tool output item",
+        "example": {
+          "command": "view",
+          "filePath": "/src/main.ts",
+          "id": "te_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:text_editor"
+        },
+        "properties": {
+          "command": {
+            "enum": [
+              "view",
+              "create",
+              "str_replace",
+              "insert"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "filePath": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:text_editor"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputToolSearchServerToolItem": {
+        "description": "An openrouter:tool_search server tool output item",
+        "example": {
+          "id": "ts_tmp_abc123",
+          "query": "weather tools",
+          "status": "completed",
+          "type": "openrouter:tool_search"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:tool_search"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputWebFetchServerToolItem": {
+        "description": "An openrouter:web_fetch server tool output item",
+        "example": {
+          "id": "wf_tmp_abc123",
+          "status": "completed",
+          "title": "Example Domain",
+          "type": "openrouter:web_fetch",
+          "url": "https://example.com"
+        },
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openrouter:web_fetch"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputWebSearchCallItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemWebSearchCall"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "example": {
+          "id": "ws-abc123",
+          "status": "completed",
+          "type": "web_search_call"
+        }
+      },
+      "OutputWebSearchServerToolItem": {
+        "description": "An openrouter:web_search server tool output item",
+        "example": {
+          "id": "ws_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:web_search"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:web_search"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "PDFParserEngine": {
+        "anyOf": [
+          {
+            "enum": [
+              "mistral-ocr",
+              "native",
+              "cloudflare-ai"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          {
+            "enum": [
+              "pdf-text"
+            ],
+            "type": "string"
+          }
+        ],
+        "description": "The engine to use for parsing PDF files. \"pdf-text\" is deprecated and automatically redirected to \"cloudflare-ai\".",
+        "example": "cloudflare-ai"
+      },
+      "PDFParserOptions": {
+        "description": "Options for PDF parsing.",
+        "example": {
+          "engine": "cloudflare-ai"
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/PDFParserEngine"
+          }
+        },
+        "type": "object"
+      },
+      "Parameter": {
+        "enum": [
+          "temperature",
+          "top_p",
+          "top_k",
+          "min_p",
+          "top_a",
+          "frequency_penalty",
+          "presence_penalty",
+          "repetition_penalty",
+          "max_tokens",
+          "max_completion_tokens",
+          "logit_bias",
+          "logprobs",
+          "top_logprobs",
+          "seed",
+          "response_format",
+          "structured_outputs",
+          "stop",
+          "tools",
+          "tool_choice",
+          "parallel_tool_calls",
+          "include_reasoning",
+          "reasoning",
+          "reasoning_effort",
+          "web_search_options",
+          "verbosity"
+        ],
+        "example": "temperature",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "PayloadTooLargeResponse": {
+        "description": "Payload Too Large - Request payload exceeds size limits",
+        "example": {
+          "error": {
+            "code": 413,
+            "message": "Request payload too large"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/PayloadTooLargeResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "PayloadTooLargeResponseErrorData": {
+        "description": "Error data for PayloadTooLargeResponse",
+        "example": {
+          "code": 413,
+          "message": "Request payload too large"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "PaymentRequiredResponse": {
+        "description": "Payment Required - Insufficient credits or quota to complete request",
+        "example": {
+          "error": {
+            "code": 402,
+            "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/PaymentRequiredResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "PaymentRequiredResponseErrorData": {
+        "description": "Error data for PaymentRequiredResponse",
+        "example": {
+          "code": 402,
+          "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "PerRequestLimits": {
+        "description": "Per-request token limits",
+        "example": {
+          "completion_tokens": 1000,
+          "prompt_tokens": 1000
+        },
+        "nullable": true,
+        "properties": {
+          "completion_tokens": {
+            "description": "Maximum completion tokens per request",
+            "example": 1000,
+            "type": "number"
+          },
+          "prompt_tokens": {
+            "description": "Maximum prompt tokens per request",
+            "example": 1000,
+            "type": "number"
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens"
+        ],
+        "type": "object"
+      },
+      "PercentileLatencyCutoffs": {
+        "description": "Percentile-based latency cutoffs. All specified cutoffs must be met for an endpoint to be preferred.",
+        "example": {
+          "p50": 5,
+          "p90": 10
+        },
+        "properties": {
+          "p50": {
+            "description": "Maximum p50 latency (seconds)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "p75": {
+            "description": "Maximum p75 latency (seconds)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "p90": {
+            "description": "Maximum p90 latency (seconds)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "p99": {
+            "description": "Maximum p99 latency (seconds)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "PercentileStats": {
+        "description": "Latency percentiles in milliseconds over the last 30 minutes. Latency measures time to first token. Only visible when authenticated with an API key or cookie; returns null for unauthenticated requests.",
+        "example": {
+          "p50": 25.5,
+          "p75": 35.2,
+          "p90": 48.7,
+          "p99": 85.3
+        },
+        "nullable": true,
+        "properties": {
+          "p50": {
+            "description": "Median (50th percentile)",
+            "example": 25.5,
+            "format": "double",
+            "type": "number"
+          },
+          "p75": {
+            "description": "75th percentile",
+            "example": 35.2,
+            "format": "double",
+            "type": "number"
+          },
+          "p90": {
+            "description": "90th percentile",
+            "example": 48.7,
+            "format": "double",
+            "type": "number"
+          },
+          "p99": {
+            "description": "99th percentile",
+            "example": 85.3,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "p50",
+          "p75",
+          "p90",
+          "p99"
+        ],
+        "type": "object"
+      },
+      "PercentileThroughputCutoffs": {
+        "description": "Percentile-based throughput cutoffs. All specified cutoffs must be met for an endpoint to be preferred.",
+        "example": {
+          "p50": 100,
+          "p90": 50
+        },
+        "properties": {
+          "p50": {
+            "description": "Minimum p50 throughput (tokens/sec)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "p75": {
+            "description": "Minimum p75 throughput (tokens/sec)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "p90": {
+            "description": "Minimum p90 throughput (tokens/sec)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "p99": {
+            "description": "Minimum p99 throughput (tokens/sec)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "PreferredMaxLatency": {
+        "anyOf": [
+          {
+            "format": "double",
+            "type": "number"
+          },
+          {
+            "$ref": "#/components/schemas/PercentileLatencyCutoffs"
+          },
+          {
+            "nullable": true
+          }
+        ],
+        "description": "Preferred maximum latency (in seconds). Can be a number (applies to p50) or an object with percentile-specific cutoffs. Endpoints above the threshold(s) may still be used, but are deprioritized in routing. When using fallback models, this may cause a fallback model to be used instead of the primary model if it meets the threshold.",
+        "example": 5
+      },
+      "PreferredMinThroughput": {
+        "anyOf": [
+          {
+            "format": "double",
+            "type": "number"
+          },
+          {
+            "$ref": "#/components/schemas/PercentileThroughputCutoffs"
+          },
+          {
+            "nullable": true
+          }
+        ],
+        "description": "Preferred minimum throughput (in tokens per second). Can be a number (applies to p50) or an object with percentile-specific cutoffs. Endpoints below the threshold(s) may still be used, but are deprioritized in routing. When using fallback models, this may cause a fallback model to be used instead of the primary model if it meets the threshold.",
+        "example": 100
+      },
+      "Preview_20250311_WebSearchServerTool": {
+        "description": "Web search preview tool configuration (2025-03-11 version)",
+        "example": {
+          "type": "web_search_preview_2025_03_11"
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/WebSearchDomainFilter"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchContextSizeEnum"
+          },
+          "type": {
+            "enum": [
+              "web_search_preview_2025_03_11"
+            ],
+            "type": "string"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/Preview_WebSearchUserLocation"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Preview_WebSearchServerTool": {
+        "description": "Web search preview tool configuration",
+        "example": {
+          "type": "web_search_preview"
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/WebSearchDomainFilter"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchContextSizeEnum"
+          },
+          "type": {
+            "enum": [
+              "web_search_preview"
+            ],
+            "type": "string"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/Preview_WebSearchUserLocation"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Preview_WebSearchUserLocation": {
+        "example": {
+          "city": "San Francisco",
+          "country": "USA",
+          "region": "California",
+          "timezone": "America/Los_Angeles",
+          "type": "approximate"
+        },
+        "nullable": true,
+        "properties": {
+          "city": {
+            "nullable": true,
+            "type": "string"
+          },
+          "country": {
+            "nullable": true,
+            "type": "string"
+          },
+          "region": {
+            "nullable": true,
+            "type": "string"
+          },
+          "timezone": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "approximate"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ProviderName": {
+        "enum": [
+          "AkashML",
+          "AI21",
+          "AionLabs",
+          "Alibaba",
+          "Ambient",
+          "Baidu",
+          "Amazon Bedrock",
+          "Amazon Nova",
+          "Anthropic",
+          "Arcee AI",
+          "AtlasCloud",
+          "Avian",
+          "Azure",
+          "BaseTen",
+          "BytePlus",
+          "Black Forest Labs",
+          "Cerebras",
+          "Chutes",
+          "Cirrascale",
+          "Clarifai",
+          "Cloudflare",
+          "Cohere",
+          "Crusoe",
+          "DeepInfra",
+          "DeepSeek",
+          "DekaLLM",
+          "Featherless",
+          "Fireworks",
+          "Friendli",
+          "GMICloud",
+          "Google",
+          "Google AI Studio",
+          "Groq",
+          "Hyperbolic",
+          "Inception",
+          "Inceptron",
+          "InferenceNet",
+          "Ionstream",
+          "Infermatic",
+          "Io Net",
+          "Inflection",
+          "Liquid",
+          "Mara",
+          "Mancer 2",
+          "Minimax",
+          "ModelRun",
+          "Mistral",
+          "Modular",
+          "Moonshot AI",
+          "Morph",
+          "NCompass",
+          "Nebius",
+          "NextBit",
+          "Novita",
+          "Nvidia",
+          "OpenAI",
+          "OpenInference",
+          "Parasail",
+          "Perplexity",
+          "Phala",
+          "Recraft",
+          "Reka",
+          "Relace",
+          "SambaNova",
+          "Seed",
+          "SiliconFlow",
+          "Sourceful",
+          "StepFun",
+          "Stealth",
+          "StreamLake",
+          "Switchpoint",
+          "Together",
+          "Upstage",
+          "Venice",
+          "WandB",
+          "Xiaomi",
+          "xAI",
+          "Z.AI",
+          "FakeProvider"
+        ],
+        "example": "OpenAI",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ProviderOverloadedResponse": {
+        "description": "Provider Overloaded - Provider is temporarily overloaded",
+        "example": {
+          "error": {
+            "code": 529,
+            "message": "Provider returned error"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ProviderOverloadedResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ProviderOverloadedResponseErrorData": {
+        "description": "Error data for ProviderOverloadedResponse",
+        "example": {
+          "code": 529,
+          "message": "Provider returned error"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ProviderPreferences": {
+        "additionalProperties": false,
+        "description": "When multiple model providers are available, optionally indicate your routing preference.",
+        "example": {
+          "allow_fallbacks": true
+        },
+        "nullable": true,
+        "properties": {
+          "allow_fallbacks": {
+            "description": "Whether to allow backup providers to serve requests\n- true: (default) when the primary provider (or your custom providers in \"order\") is unavailable, use the next best provider.\n- false: use only the primary/custom provider, and return the upstream error if it's unavailable.\n",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "data_collection": {
+            "description": "Data collection setting. If no available model provider meets the requirement, your request will return an error.\n- allow: (default) allow providers which store user data non-transiently and may train on it\n\n- deny: use only providers which do not collect user data.",
+            "enum": [
+              "deny",
+              "allow",
+              null
+            ],
+            "example": "allow",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "enforce_distillable_text": {
+            "description": "Whether to restrict routing to only models that allow text distillation. When true, only models where the author has allowed distillation will be used.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "ignore": {
+            "description": "List of provider slugs to ignore. If provided, this list is merged with your account-wide ignored provider settings for this request.",
+            "example": [
+              "openai",
+              "anthropic"
+            ],
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderName"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "max_price": {
+            "description": "The object specifying the maximum price you want to pay for this request. USD price per million tokens, for prompt and completion.",
+            "properties": {
+              "audio": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "Price per audio unit"
+                  }
+                ]
+              },
+              "completion": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "Price per million completion tokens"
+                  }
+                ]
+              },
+              "image": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "Price per image"
+                  }
+                ]
+              },
+              "prompt": {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              "request": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "Price per request"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "only": {
+            "description": "List of provider slugs to allow. If provided, this list is merged with your account-wide allowed provider settings for this request.",
+            "example": [
+              "openai",
+              "anthropic"
+            ],
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderName"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "order": {
+            "description": "An ordered list of provider slugs. The router will attempt to use the first provider in the subset of this list that supports your requested model, and fall back to the next if it is unavailable. If no providers are available, the request will fail with an error message.",
+            "example": [
+              "openai",
+              "anthropic"
+            ],
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderName"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "preferred_max_latency": {
+            "$ref": "#/components/schemas/PreferredMaxLatency"
+          },
+          "preferred_min_throughput": {
+            "$ref": "#/components/schemas/PreferredMinThroughput"
+          },
+          "quantizations": {
+            "description": "A list of quantization levels to filter the provider by.",
+            "items": {
+              "$ref": "#/components/schemas/Quantization"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "require_parameters": {
+            "description": "Whether to filter providers to only those that support the parameters you've provided. If this setting is omitted or set to false, then providers will receive only the parameters they support, and ignore the rest.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "sort": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProviderSort"
+              },
+              {
+                "$ref": "#/components/schemas/ProviderSortConfig"
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "description": "The sorting strategy to use for this request, if \"order\" is not specified. When set, no load balancing is performed.",
+            "example": "price"
+          },
+          "zdr": {
+            "description": "Whether to restrict routing to only ZDR (Zero Data Retention) endpoints. When true, only endpoints that do not retain prompts will be used.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "ProviderResponse": {
+        "description": "Details of a provider response for a generation attempt",
+        "example": {
+          "endpoint_id": "ep_abc123",
+          "id": "chatcmpl-abc123",
+          "is_byok": false,
+          "latency": 1200,
+          "model_permaslug": "openai/gpt-4",
+          "provider_name": "OpenAI",
+          "status": 200
+        },
+        "properties": {
+          "endpoint_id": {
+            "description": "Internal endpoint identifier",
+            "example": "ep_abc123",
+            "type": "string"
+          },
+          "id": {
+            "description": "Upstream provider response identifier",
+            "example": "chatcmpl-abc123",
+            "type": "string"
+          },
+          "is_byok": {
+            "description": "Whether the request used a bring-your-own-key",
+            "example": false,
+            "type": "boolean"
+          },
+          "latency": {
+            "description": "Response latency in milliseconds",
+            "example": 1200,
+            "type": "number"
+          },
+          "model_permaslug": {
+            "description": "Canonical model slug",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "provider_name": {
+            "description": "Name of the provider",
+            "enum": [
+              "AnyScale",
+              "Atoma",
+              "Cent-ML",
+              "CrofAI",
+              "Enfer",
+              "GoPomelo",
+              "HuggingFace",
+              "Hyperbolic 2",
+              "InoCloud",
+              "Kluster",
+              "Lambda",
+              "Lepton",
+              "Lynn 2",
+              "Lynn",
+              "Mancer",
+              "Meta",
+              "Modal",
+              "Nineteen",
+              "OctoAI",
+              "Recursal",
+              "Reflection",
+              "Replicate",
+              "SambaNova 2",
+              "SF Compute",
+              "Targon",
+              "Together 2",
+              "Ubicloud",
+              "01.AI",
+              "AkashML",
+              "AI21",
+              "AionLabs",
+              "Alibaba",
+              "Ambient",
+              "Baidu",
+              "Amazon Bedrock",
+              "Amazon Nova",
+              "Anthropic",
+              "Arcee AI",
+              "AtlasCloud",
+              "Avian",
+              "Azure",
+              "BaseTen",
+              "BytePlus",
+              "Black Forest Labs",
+              "Cerebras",
+              "Chutes",
+              "Cirrascale",
+              "Clarifai",
+              "Cloudflare",
+              "Cohere",
+              "Crusoe",
+              "DeepInfra",
+              "DeepSeek",
+              "DekaLLM",
+              "Featherless",
+              "Fireworks",
+              "Friendli",
+              "GMICloud",
+              "Google",
+              "Google AI Studio",
+              "Groq",
+              "Hyperbolic",
+              "Inception",
+              "Inceptron",
+              "InferenceNet",
+              "Ionstream",
+              "Infermatic",
+              "Io Net",
+              "Inflection",
+              "Liquid",
+              "Mara",
+              "Mancer 2",
+              "Minimax",
+              "ModelRun",
+              "Mistral",
+              "Modular",
+              "Moonshot AI",
+              "Morph",
+              "NCompass",
+              "Nebius",
+              "NextBit",
+              "Novita",
+              "Nvidia",
+              "OpenAI",
+              "OpenInference",
+              "Parasail",
+              "Perplexity",
+              "Phala",
+              "Recraft",
+              "Reka",
+              "Relace",
+              "SambaNova",
+              "Seed",
+              "SiliconFlow",
+              "Sourceful",
+              "StepFun",
+              "Stealth",
+              "StreamLake",
+              "Switchpoint",
+              "Together",
+              "Upstage",
+              "Venice",
+              "WandB",
+              "Xiaomi",
+              "xAI",
+              "Z.AI",
+              "FakeProvider"
+            ],
+            "example": "OpenAI",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "status": {
+            "description": "HTTP status code from the provider",
+            "example": 200,
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "ProviderSort": {
+        "description": "The provider sorting strategy (price, throughput, latency)",
+        "enum": [
+          "price",
+          "throughput",
+          "latency",
+          "exacto"
+        ],
+        "example": "price",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ProviderSortConfig": {
+        "description": "The provider sorting strategy (price, throughput, latency)",
+        "example": {
+          "by": "price",
+          "partition": "model"
+        },
+        "properties": {
+          "by": {
+            "description": "The provider sorting strategy (price, throughput, latency)",
+            "enum": [
+              "price",
+              "throughput",
+              "latency",
+              "exacto",
+              null
+            ],
+            "example": "price",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "partition": {
+            "description": "Partitioning strategy for sorting: \"model\" (default) groups endpoints by model before sorting (fallback models remain fallbacks), \"none\" sorts all endpoints together regardless of model.",
+            "enum": [
+              "model",
+              "none",
+              null
+            ],
+            "example": "model",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "type": "object"
+      },
+      "PublicEndpoint": {
+        "description": "Information about a specific model endpoint",
+        "example": {
+          "context_length": 8192,
+          "latency_last_30m": {
+            "p50": 0.25,
+            "p75": 0.35,
+            "p90": 0.48,
+            "p99": 0.85
+          },
+          "max_completion_tokens": 4096,
+          "max_prompt_tokens": 8192,
+          "model_id": "openai/gpt-4",
+          "model_name": "GPT-4",
+          "name": "OpenAI: GPT-4",
+          "pricing": {
+            "completion": "0.00006",
+            "image": "0",
+            "prompt": "0.00003",
+            "request": "0"
+          },
+          "provider_name": "OpenAI",
+          "quantization": "fp16",
+          "status": 0,
+          "supported_parameters": [
+            "temperature",
+            "top_p",
+            "max_tokens"
+          ],
+          "supports_implicit_caching": true,
+          "tag": "openai",
+          "throughput_last_30m": {
+            "p50": 45.2,
+            "p75": 38.5,
+            "p90": 28.3,
+            "p99": 15.1
+          },
+          "uptime_last_1d": 99.8,
+          "uptime_last_30m": 99.5,
+          "uptime_last_5m": 100
+        },
+        "properties": {
+          "context_length": {
+            "type": "integer"
+          },
+          "latency_last_30m": {
+            "$ref": "#/components/schemas/PercentileStats"
+          },
+          "max_completion_tokens": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_prompt_tokens": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "model_id": {
+            "description": "The unique identifier for the model (permaslug)",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "model_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pricing": {
+            "properties": {
+              "audio": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "audio_output": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "completion": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "discount": {
+                "type": "number"
+              },
+              "image": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "image_output": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "image_token": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "input_audio_cache": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "input_cache_read": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "input_cache_write": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "internal_reasoning": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "prompt": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "request": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              },
+              "web_search": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigNumberUnion"
+                  },
+                  {
+                    "description": "A number or string value representing a large number"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "prompt",
+              "completion"
+            ],
+            "type": "object"
+          },
+          "provider_name": {
+            "$ref": "#/components/schemas/ProviderName"
+          },
+          "quantization": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantization"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/EndpointStatus"
+          },
+          "supported_parameters": {
+            "items": {
+              "$ref": "#/components/schemas/Parameter"
+            },
+            "type": "array"
+          },
+          "supports_implicit_caching": {
+            "type": "boolean"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "throughput_last_30m": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PercentileStats"
+              },
+              {
+                "description": "Throughput percentiles in tokens per second over the last 30 minutes. Throughput measures output token generation speed. Only visible when authenticated with an API key or cookie; returns null for unauthenticated requests."
+              }
+            ]
+          },
+          "uptime_last_1d": {
+            "description": "Uptime percentage over the last 1 day, calculated as successful requests / (successful + error requests) * 100. Rate-limited requests are excluded. Returns null if insufficient data.",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "uptime_last_30m": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "uptime_last_5m": {
+            "description": "Uptime percentage over the last 5 minutes, calculated as successful requests / (successful + error requests) * 100. Rate-limited requests are excluded. Returns null if insufficient data.",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "model_id",
+          "model_name",
+          "context_length",
+          "pricing",
+          "provider_name",
+          "tag",
+          "quantization",
+          "max_completion_tokens",
+          "max_prompt_tokens",
+          "supported_parameters",
+          "uptime_last_30m",
+          "uptime_last_5m",
+          "uptime_last_1d",
+          "supports_implicit_caching",
+          "latency_last_30m",
+          "throughput_last_30m"
+        ],
+        "type": "object"
+      },
+      "PublicPricing": {
+        "description": "Pricing information for the model",
+        "example": {
+          "completion": "0.00006",
+          "image": "0",
+          "prompt": "0.00003",
+          "request": "0"
+        },
+        "properties": {
+          "audio": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "audio_output": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "completion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "discount": {
+            "type": "number"
+          },
+          "image": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "image_output": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "image_token": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "input_audio_cache": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "input_cache_read": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "input_cache_write": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "internal_reasoning": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "prompt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "request": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          },
+          "web_search": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigNumberUnion"
+              },
+              {
+                "description": "A number or string value representing a large number"
+              }
+            ]
+          }
+        },
+        "required": [
+          "prompt",
+          "completion"
+        ],
+        "type": "object"
+      },
+      "Quantization": {
+        "enum": [
+          "int4",
+          "int8",
+          "fp4",
+          "fp6",
+          "fp8",
+          "fp16",
+          "bf16",
+          "fp32",
+          "unknown"
+        ],
+        "example": "fp16",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ReasoningConfig": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningConfig"
+          },
+          {
+            "nullable": true,
+            "properties": {
+              "enabled": {
+                "nullable": true,
+                "type": "boolean"
+              },
+              "max_tokens": {
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Configuration for reasoning mode in the response",
+        "example": {
+          "enabled": true,
+          "summary": "auto"
+        }
+      },
+      "ReasoningDeltaEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningDeltaEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when reasoning text delta is streamed",
+        "example": {
+          "content_index": 0,
+          "delta": "First, we need",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.reasoning_text.delta"
+        }
+      },
+      "ReasoningDetailEncrypted": {
+        "description": "Reasoning detail encrypted schema",
+        "example": {
+          "data": "encrypted data",
+          "type": "reasoning.encrypted"
+        },
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/ReasoningFormat"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "reasoning.encrypted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "data"
+        ],
+        "type": "object"
+      },
+      "ReasoningDetailSummary": {
+        "description": "Reasoning detail summary schema",
+        "example": {
+          "summary": "The model analyzed the problem by first identifying key constraints, then evaluating possible solutions...",
+          "type": "reasoning.summary"
+        },
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/ReasoningFormat"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "reasoning.summary"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "ReasoningDetailText": {
+        "description": "Reasoning detail text schema",
+        "example": {
+          "signature": "signature",
+          "text": "The model analyzed the problem by first identifying key constraints, then evaluating possible solutions...",
+          "type": "reasoning.text"
+        },
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/ReasoningFormat"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "signature": {
+            "nullable": true,
+            "type": "string"
+          },
+          "text": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "reasoning.text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ReasoningDetailUnion": {
+        "description": "Reasoning detail union schema",
+        "discriminator": {
+          "mapping": {
+            "reasoning.encrypted": "#/components/schemas/ReasoningDetailEncrypted",
+            "reasoning.summary": "#/components/schemas/ReasoningDetailSummary",
+            "reasoning.text": "#/components/schemas/ReasoningDetailText"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "summary": "The model analyzed the problem by first identifying key constraints, then evaluating possible solutions...",
+          "type": "reasoning.summary"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ReasoningDetailSummary"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningDetailEncrypted"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningDetailText"
+          }
+        ]
+      },
+      "ReasoningDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningDoneEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when reasoning text streaming is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 6,
+          "text": "First, we need to identify the key components and then combine them logically.",
+          "type": "response.reasoning_text.done"
+        }
+      },
+      "ReasoningEffort": {
+        "enum": [
+          "xhigh",
+          "high",
+          "medium",
+          "low",
+          "minimal",
+          "none",
+          null
+        ],
+        "example": "medium",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ReasoningFormat": {
+        "enum": [
+          "unknown",
+          "openai-responses-v1",
+          "azure-openai-responses-v1",
+          "xai-responses-v1",
+          "anthropic-claude-v1",
+          "google-gemini-v1",
+          null
+        ],
+        "example": "unknown",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ReasoningItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemReasoning"
+          },
+          {
+            "properties": {
+              "content": {
+                "items": {
+                  "$ref": "#/components/schemas/ReasoningTextContent"
+                },
+                "nullable": true,
+                "type": "array"
+              },
+              "format": {
+                "$ref": "#/components/schemas/ReasoningFormat"
+              },
+              "signature": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Reasoning output item with signature and format extensions",
+        "example": {
+          "id": "reasoning-abc123",
+          "summary": [
+            {
+              "text": "Step by step analysis",
+              "type": "summary_text"
+            }
+          ],
+          "type": "reasoning"
+        }
+      },
+      "ReasoningSummaryPartAddedEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningSummaryPartAddedEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a reasoning summary part is added",
+        "example": {
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "text": "",
+            "type": "summary_text"
+          },
+          "sequence_number": 3,
+          "summary_index": 0,
+          "type": "response.reasoning_summary_part.added"
+        }
+      },
+      "ReasoningSummaryPartDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningSummaryPartDoneEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a reasoning summary part is complete",
+        "example": {
+          "item_id": "item-1",
+          "output_index": 0,
+          "part": {
+            "text": "Analyzing the problem step by step to find the optimal solution.",
+            "type": "summary_text"
+          },
+          "sequence_number": 7,
+          "summary_index": 0,
+          "type": "response.reasoning_summary_part.done"
+        }
+      },
+      "ReasoningSummaryText": {
+        "example": {
+          "text": "Analyzed the problem using first principles",
+          "type": "summary_text"
+        },
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "summary_text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "ReasoningSummaryTextDeltaEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningSummaryTextDeltaEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when reasoning summary text delta is streamed",
+        "example": {
+          "delta": "Analyzing",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "summary_index": 0,
+          "type": "response.reasoning_summary_text.delta"
+        }
+      },
+      "ReasoningSummaryTextDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseReasoningSummaryTextDoneEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when reasoning summary text streaming is complete",
+        "example": {
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 6,
+          "summary_index": 0,
+          "text": "Analyzing the problem step by step to find the optimal solution.",
+          "type": "response.reasoning_summary_text.done"
+        }
+      },
+      "ReasoningSummaryVerbosity": {
+        "enum": [
+          "auto",
+          "concise",
+          "detailed",
+          null
+        ],
+        "example": "auto",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ReasoningTextContent": {
+        "example": {
+          "text": "Let me think step by step about this problem...",
+          "type": "reasoning_text"
+        },
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "reasoning_text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "RefusalDeltaEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseRefusalDeltaEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a refusal delta is streamed",
+        "example": {
+          "content_index": 0,
+          "delta": "I'm sorry",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.refusal.delta"
+        }
+      },
+      "RefusalDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseRefusalDoneEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when refusal streaming is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "output_index": 0,
+          "refusal": "I'm sorry, but I can't assist with that request.",
+          "sequence_number": 6,
+          "type": "response.refusal.done"
+        }
+      },
+      "RequestMetadata": {
+        "additionalProperties": {
+          "maxLength": 512,
+          "type": "string"
+        },
+        "description": "Metadata key-value pairs for the request. Keys must be \u226464 characters and cannot contain brackets. Values must be \u2264512 characters. Maximum 16 pairs allowed.",
+        "example": {
+          "session_id": "abc-def-ghi",
+          "user_id": "123"
+        },
+        "nullable": true,
+        "type": "object"
+      },
+      "RequestTimeoutResponse": {
+        "description": "Request Timeout - Operation exceeded time limit",
+        "example": {
+          "error": {
+            "code": 408,
+            "message": "Operation timed out. Please try again later."
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/RequestTimeoutResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "RequestTimeoutResponseErrorData": {
+        "description": "Error data for RequestTimeoutResponse",
+        "example": {
+          "code": 408,
+          "message": "Operation timed out. Please try again later."
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ResponseHealingPlugin": {
+        "example": {
+          "enabled": true,
+          "id": "response-healing"
+        },
+        "properties": {
+          "enabled": {
+            "description": "Set to false to disable the response-healing plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "id": {
+            "enum": [
+              "response-healing"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "ResponseIncludesEnum": {
+        "enum": [
+          "file_search_call.results",
+          "message.input_image.image_url",
+          "computer_call_output.output.image_url",
+          "reasoning.encrypted_content",
+          "code_interpreter_call.outputs"
+        ],
+        "example": "file_search_call.results",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ResponseOutputText": {
+        "example": {
+          "annotations": [
+            {
+              "end_index": 42,
+              "start_index": 0,
+              "title": "Paris - Wikipedia",
+              "type": "url_citation",
+              "url": "https://en.wikipedia.org/wiki/Paris"
+            }
+          ],
+          "text": "The capital of France is Paris.",
+          "type": "output_text"
+        },
+        "properties": {
+          "annotations": {
+            "items": {
+              "$ref": "#/components/schemas/OpenAIResponsesAnnotation"
+            },
+            "type": "array"
+          },
+          "logprobs": {
+            "items": {
+              "properties": {
+                "bytes": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "logprob": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "token": {
+                  "type": "string"
+                },
+                "top_logprobs": {
+                  "items": {
+                    "properties": {
+                      "bytes": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "logprob": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "token": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "token",
+                      "bytes",
+                      "logprob"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "token",
+                "bytes",
+                "logprob",
+                "top_logprobs"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "output_text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "ResponsesErrorField": {
+        "description": "Error information returned from the API",
+        "example": {
+          "code": "rate_limit_exceeded",
+          "message": "Rate limit exceeded. Please try again later."
+        },
+        "nullable": true,
+        "properties": {
+          "code": {
+            "enum": [
+              "server_error",
+              "rate_limit_exceeded",
+              "invalid_prompt",
+              "vector_store_timeout",
+              "invalid_image",
+              "invalid_image_format",
+              "invalid_base64_image",
+              "invalid_image_url",
+              "image_too_large",
+              "image_too_small",
+              "image_parse_error",
+              "image_content_policy_violation",
+              "invalid_image_mode",
+              "image_file_too_large",
+              "unsupported_image_media_type",
+              "empty_image_file",
+              "failed_to_download_image",
+              "image_file_not_found"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ResponsesRequest": {
+        "description": "Request schema for Responses endpoint",
+        "example": {
+          "input": [
+            {
+              "content": "Hello, how are you?",
+              "role": "user",
+              "type": "message"
+            }
+          ],
+          "model": "anthropic/claude-4.5-sonnet-20250929",
+          "temperature": 0.7,
+          "tools": [
+            {
+              "description": "Get the current weather in a given location",
+              "name": "get_current_weather",
+              "parameters": {
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "function"
+            }
+          ],
+          "top_p": 0.9
+        },
+        "properties": {
+          "background": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "frequency_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "image_config": {
+            "$ref": "#/components/schemas/ImageConfig"
+          },
+          "include": {
+            "items": {
+              "$ref": "#/components/schemas/ResponseIncludesEnum"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "input": {
+            "$ref": "#/components/schemas/Inputs"
+          },
+          "instructions": {
+            "nullable": true,
+            "type": "string"
+          },
+          "max_output_tokens": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          "modalities": {
+            "description": "Output modalities for the response. Supported values are \"text\" and \"image\".",
+            "example": [
+              "text",
+              "image"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/OutputModalityEnum"
+            },
+            "type": "array"
+          },
+          "model": {
+            "type": "string"
+          },
+          "models": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "parallel_tool_calls": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "plugins": {
+            "description": "Plugins you want to enable for this request, including their settings.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "auto-router": "#/components/schemas/AutoRouterPlugin",
+                  "context-compression": "#/components/schemas/ContextCompressionPlugin",
+                  "file-parser": "#/components/schemas/FileParserPlugin",
+                  "moderation": "#/components/schemas/ModerationPlugin",
+                  "response-healing": "#/components/schemas/ResponseHealingPlugin",
+                  "web": "#/components/schemas/WebSearchPlugin"
+                },
+                "propertyName": "id"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AutoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ModerationPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/FileParserPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ResponseHealingPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ContextCompressionPlugin"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "presence_penalty": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "previous_response_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "prompt": {
+            "$ref": "#/components/schemas/StoredPromptTemplate"
+          },
+          "prompt_cache_key": {
+            "nullable": true,
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/ProviderPreferences"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/ReasoningConfig"
+          },
+          "route": {
+            "$ref": "#/components/schemas/DeprecatedRoute"
+          },
+          "safety_identifier": {
+            "nullable": true,
+            "type": "string"
+          },
+          "service_tier": {
+            "default": "auto",
+            "enum": [
+              "auto",
+              "default",
+              "flex",
+              "priority",
+              "scale",
+              null
+            ],
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "session_id": {
+            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "store": {
+            "const": false,
+            "default": false,
+            "type": "boolean"
+          },
+          "stream": {
+            "default": false,
+            "type": "boolean"
+          },
+          "temperature": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "text": {
+            "$ref": "#/components/schemas/TextExtendedConfig"
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
+          },
+          "tools": {
+            "items": {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/FunctionTool"
+                    },
+                    {
+                      "properties": {},
+                      "type": "object"
+                    }
+                  ],
+                  "description": "Function tool definition",
+                  "example": {
+                    "description": "Get the current weather in a location",
+                    "name": "get_weather",
+                    "parameters": {
+                      "properties": {
+                        "location": {
+                          "description": "The city and state",
+                          "type": "string"
+                        },
+                        "unit": {
+                          "enum": [
+                            "celsius",
+                            "fahrenheit"
+                          ],
+                          "type": "string",
+                          "x-speakeasy-unknown-values": "allow"
+                        }
+                      },
+                      "required": [
+                        "location"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "function"
+                  }
+                },
+                {
+                  "$ref": "#/components/schemas/Preview_WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/Preview_20250311_WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/Legacy_WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/FileSearchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ComputerUseServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CodeInterpreterServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/McpServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ImageGenerationServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CodexLocalShellTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ShellServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ApplyPatchServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CustomTool"
+                },
+                {
+                  "$ref": "#/components/schemas/DatetimeServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ImageGenerationServerTool_OpenRouter"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatSearchModelsServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchServerTool_OpenRouter"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "top_k": {
+            "type": "integer"
+          },
+          "top_logprobs": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "top_p": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceConfig"
+          },
+          "truncation": {
+            "$ref": "#/components/schemas/OpenAIResponsesTruncation"
+          },
+          "user": {
+            "description": "A unique identifier representing your end-user, which helps distinguish between different users of your app. This allows your app to identify specific users in case of abuse reports, preventing your entire app from being affected by the actions of individual users. Maximum of 256 characters.",
+            "maxLength": 256,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SearchContextSizeEnum": {
+        "description": "Size of the search context for web search tools",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "example": "medium",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "SearchModelsServerToolConfig": {
+        "description": "Configuration for the openrouter:experimental__search_models server tool",
+        "example": {
+          "max_results": 5
+        },
+        "properties": {
+          "max_results": {
+            "description": "Maximum number of models to return. Defaults to 5, max 20.",
+            "example": 5,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SearchQualityLevel": {
+        "description": "How much context to retrieve per result. Defaults to medium (15000 chars). Only applies when using the Exa engine; ignored with native provider search.",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "example": "medium",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ServiceTier": {
+        "enum": [
+          "auto",
+          "default",
+          "flex",
+          "priority",
+          "scale",
+          null
+        ],
+        "example": "default",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ServiceUnavailableResponse": {
+        "description": "Service Unavailable - Service temporarily unavailable",
+        "example": {
+          "error": {
+            "code": 503,
+            "message": "Service temporarily unavailable"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ServiceUnavailableResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ServiceUnavailableResponseErrorData": {
+        "description": "Error data for ServiceUnavailableResponse",
+        "example": {
+          "code": 503,
+          "message": "Service temporarily unavailable"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ShellServerTool": {
+        "description": "Shell tool configuration",
+        "example": {
+          "type": "shell"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "shell"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "StoredPromptTemplate": {
+        "example": {
+          "id": "prompt-abc123",
+          "variables": {
+            "name": "John"
+          }
+        },
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "variables": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/InputText"
+                },
+                {
+                  "$ref": "#/components/schemas/InputImage"
+                },
+                {
+                  "$ref": "#/components/schemas/InputFile"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "StreamEvents": {
+        "description": "Union of all possible event types emitted during response streaming",
+        "discriminator": {
+          "mapping": {
+            "error": "#/components/schemas/ErrorEvent",
+            "response.completed": "#/components/schemas/StreamEventsResponseCompleted",
+            "response.content_part.added": "#/components/schemas/ContentPartAddedEvent",
+            "response.content_part.done": "#/components/schemas/ContentPartDoneEvent",
+            "response.created": "#/components/schemas/OpenResponsesCreatedEvent",
+            "response.failed": "#/components/schemas/StreamEventsResponseFailed",
+            "response.function_call_arguments.delta": "#/components/schemas/FunctionCallArgsDeltaEvent",
+            "response.function_call_arguments.done": "#/components/schemas/FunctionCallArgsDoneEvent",
+            "response.image_generation_call.completed": "#/components/schemas/ImageGenCallCompletedEvent",
+            "response.image_generation_call.generating": "#/components/schemas/ImageGenCallGeneratingEvent",
+            "response.image_generation_call.in_progress": "#/components/schemas/ImageGenCallInProgressEvent",
+            "response.image_generation_call.partial_image": "#/components/schemas/ImageGenCallPartialImageEvent",
+            "response.in_progress": "#/components/schemas/OpenResponsesInProgressEvent",
+            "response.incomplete": "#/components/schemas/StreamEventsResponseIncomplete",
+            "response.output_item.added": "#/components/schemas/StreamEventsResponseOutputItemAdded",
+            "response.output_item.done": "#/components/schemas/StreamEventsResponseOutputItemDone",
+            "response.output_text.annotation.added": "#/components/schemas/AnnotationAddedEvent",
+            "response.output_text.delta": "#/components/schemas/TextDeltaEvent",
+            "response.output_text.done": "#/components/schemas/TextDoneEvent",
+            "response.reasoning_summary_part.added": "#/components/schemas/ReasoningSummaryPartAddedEvent",
+            "response.reasoning_summary_part.done": "#/components/schemas/ReasoningSummaryPartDoneEvent",
+            "response.reasoning_summary_text.delta": "#/components/schemas/ReasoningSummaryTextDeltaEvent",
+            "response.reasoning_summary_text.done": "#/components/schemas/ReasoningSummaryTextDoneEvent",
+            "response.reasoning_text.delta": "#/components/schemas/ReasoningDeltaEvent",
+            "response.reasoning_text.done": "#/components/schemas/ReasoningDoneEvent",
+            "response.refusal.delta": "#/components/schemas/RefusalDeltaEvent",
+            "response.refusal.done": "#/components/schemas/RefusalDoneEvent",
+            "response.web_search_call.completed": "#/components/schemas/WebSearchCallCompletedEvent",
+            "response.web_search_call.in_progress": "#/components/schemas/WebSearchCallInProgressEvent",
+            "response.web_search_call.searching": "#/components/schemas/WebSearchCallSearchingEvent"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "in_progress",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 0,
+          "type": "response.created"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenResponsesCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/OpenResponsesInProgressEvent"
+          },
+          {
+            "$ref": "#/components/schemas/StreamEventsResponseCompleted"
+          },
+          {
+            "$ref": "#/components/schemas/StreamEventsResponseIncomplete"
+          },
+          {
+            "$ref": "#/components/schemas/StreamEventsResponseFailed"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/StreamEventsResponseOutputItemAdded"
+          },
+          {
+            "$ref": "#/components/schemas/StreamEventsResponseOutputItemDone"
+          },
+          {
+            "$ref": "#/components/schemas/ContentPartAddedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ContentPartDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/TextDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/TextDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/RefusalDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/RefusalDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/AnnotationAddedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionCallArgsDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionCallArgsDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningSummaryPartAddedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningSummaryPartDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningSummaryTextDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ReasoningSummaryTextDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageGenCallInProgressEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageGenCallGeneratingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageGenCallPartialImageEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageGenCallCompletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/WebSearchCallInProgressEvent"
+          },
+          {
+            "$ref": "#/components/schemas/WebSearchCallSearchingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/WebSearchCallCompletedEvent"
+          }
+        ]
+      },
+      "StreamEventsResponseCompleted": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CompletedEvent"
+          },
+          {
+            "properties": {
+              "response": {
+                "$ref": "#/components/schemas/OpenResponsesResult"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a response has completed successfully",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "completed",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 10,
+          "type": "response.completed"
+        }
+      },
+      "StreamEventsResponseFailed": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FailedEvent"
+          },
+          {
+            "properties": {
+              "response": {
+                "$ref": "#/components/schemas/OpenResponsesResult"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a response has failed",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "failed",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 3,
+          "type": "response.failed"
+        }
+      },
+      "StreamEventsResponseIncomplete": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IncompleteEvent"
+          },
+          {
+            "properties": {
+              "response": {
+                "$ref": "#/components/schemas/OpenResponsesResult"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a response is incomplete",
+        "example": {
+          "response": {
+            "created_at": 1704067200,
+            "error": null,
+            "id": "resp-abc123",
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "metadata": null,
+            "model": "gpt-4",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": true,
+            "status": "incomplete",
+            "temperature": null,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": null
+          },
+          "sequence_number": 5,
+          "type": "response.incomplete"
+        }
+      },
+      "StreamEventsResponseOutputItemAdded": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemAddedEvent"
+          },
+          {
+            "properties": {
+              "item": {
+                "$ref": "#/components/schemas/OutputItems"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a new output item is added to the response",
+        "example": {
+          "item": {
+            "content": [],
+            "id": "item-1",
+            "role": "assistant",
+            "status": "in_progress",
+            "type": "message"
+          },
+          "output_index": 0,
+          "sequence_number": 2,
+          "type": "response.output_item.added"
+        }
+      },
+      "StreamEventsResponseOutputItemDone": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OutputItemDoneEvent"
+          },
+          {
+            "properties": {
+              "item": {
+                "$ref": "#/components/schemas/OutputItems"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when an output item is complete",
+        "example": {
+          "item": {
+            "content": [
+              {
+                "annotations": [],
+                "text": "Hello! How can I help you?",
+                "type": "output_text"
+              }
+            ],
+            "id": "item-1",
+            "role": "assistant",
+            "status": "completed",
+            "type": "message"
+          },
+          "output_index": 0,
+          "sequence_number": 8,
+          "type": "response.output_item.done"
+        }
+      },
+      "StreamLogprob": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenResponsesLogProbs"
+          },
+          {
+            "properties": {
+              "top_logprobs": {
+                "items": {
+                  "$ref": "#/components/schemas/StreamLogprobTopLogprob"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Log probability information for a token",
+        "example": {
+          "bytes": [
+            72,
+            101,
+            108,
+            108,
+            111
+          ],
+          "logprob": -0.5,
+          "token": "Hello",
+          "top_logprobs": []
+        }
+      },
+      "StreamLogprobTopLogprob": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenResponsesTopLogprobs"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Alternative token with its log probability",
+        "example": {
+          "bytes": [
+            72,
+            101,
+            108,
+            108,
+            111
+          ],
+          "logprob": -0.5,
+          "token": "Hello"
+        }
+      },
+      "TextConfig": {
+        "description": "Text output configuration including format and verbosity",
+        "example": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/Formats"
+          },
+          "verbosity": {
+            "enum": [
+              "high",
+              "low",
+              "medium",
+              null
+            ],
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "type": "object"
+      },
+      "TextDeltaEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseTextDeltaEvent"
+          },
+          {
+            "properties": {
+              "logprobs": {
+                "items": {
+                  "$ref": "#/components/schemas/StreamLogprob"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a text delta is streamed",
+        "example": {
+          "content_index": 0,
+          "delta": "Hello",
+          "item_id": "item-1",
+          "logprobs": [],
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.output_text.delta"
+        }
+      },
+      "TextDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseTextDoneEvent"
+          },
+          {
+            "properties": {
+              "logprobs": {
+                "items": {
+                  "$ref": "#/components/schemas/StreamLogprob"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when text streaming is complete",
+        "example": {
+          "content_index": 0,
+          "item_id": "item-1",
+          "logprobs": [],
+          "output_index": 0,
+          "sequence_number": 6,
+          "text": "Hello! How can I help you?",
+          "type": "response.output_text.done"
+        }
+      },
+      "TextExtendedConfig": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextConfig"
+          },
+          {
+            "properties": {
+              "verbosity": {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  null
+                ],
+                "nullable": true,
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Text output configuration including format and verbosity",
+        "example": {
+          "format": {
+            "type": "text"
+          }
+        }
+      },
+      "TooManyRequestsResponse": {
+        "description": "Too Many Requests - Rate limit exceeded",
+        "example": {
+          "error": {
+            "code": 429,
+            "message": "Rate limit exceeded"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/TooManyRequestsResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "TooManyRequestsResponseErrorData": {
+        "description": "Error data for TooManyRequestsResponse",
+        "example": {
+          "code": 429,
+          "message": "Rate limit exceeded"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ToolCallStatus": {
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
+        "example": "completed",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ToolChoiceAllowed": {
+        "description": "Constrains the model to a pre-defined set of allowed tools",
+        "example": {
+          "mode": "auto",
+          "tools": [
+            {
+              "name": "get_weather",
+              "type": "function"
+            }
+          ],
+          "type": "allowed_tools"
+        },
+        "properties": {
+          "mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "auto"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "required"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "tools": {
+            "items": {
+              "additionalProperties": {
+                "nullable": true
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "allowed_tools"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "mode",
+          "tools"
+        ],
+        "type": "object"
+      },
+      "TopProviderInfo": {
+        "description": "Information about the top provider for this model",
+        "example": {
+          "context_length": 8192,
+          "is_moderated": true,
+          "max_completion_tokens": 4096
+        },
+        "properties": {
+          "context_length": {
+            "description": "Context length from the top provider",
+            "example": 8192,
+            "nullable": true,
+            "type": "integer"
+          },
+          "is_moderated": {
+            "description": "Whether the top provider moderates content",
+            "example": true,
+            "type": "boolean"
+          },
+          "max_completion_tokens": {
+            "description": "Maximum completion tokens from the top provider",
+            "example": 4096,
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "is_moderated"
+        ],
+        "type": "object"
+      },
+      "TraceConfig": {
+        "additionalProperties": {
+          "nullable": true
+        },
+        "description": "Metadata for observability and tracing. Known keys (trace_id, trace_name, span_name, generation_name, parent_span_id) have special handling. Additional keys are passed through as custom metadata to configured broadcast destinations.",
+        "example": {
+          "trace_id": "trace-abc123",
+          "trace_name": "my-app-trace"
+        },
+        "properties": {
+          "generation_name": {
+            "type": "string"
+          },
+          "parent_span_id": {
+            "type": "string"
+          },
+          "span_name": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "trace_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Truncation": {
+        "enum": [
+          "auto",
+          "disabled",
+          null
+        ],
+        "example": "auto",
+        "nullable": true,
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "URLCitation": {
+        "example": {
+          "end_index": 42,
+          "start_index": 0,
+          "title": "OpenRouter Documentation",
+          "type": "url_citation",
+          "url": "https://openrouter.ai/docs"
+        },
+        "properties": {
+          "end_index": {
+            "type": "integer"
+          },
+          "start_index": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "url_citation"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "url",
+          "title",
+          "start_index",
+          "end_index"
+        ],
+        "type": "object"
+      },
+      "UnauthorizedResponse": {
+        "description": "Unauthorized - Authentication required or invalid credentials",
+        "example": {
+          "error": {
+            "code": 401,
+            "message": "Missing Authentication header"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/UnauthorizedResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "UnauthorizedResponseErrorData": {
+        "description": "Error data for UnauthorizedResponse",
+        "example": {
+          "code": 401,
+          "message": "Missing Authentication header"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "UnprocessableEntityResponse": {
+        "description": "Unprocessable Entity - Semantic validation failure",
+        "example": {
+          "error": {
+            "code": 422,
+            "message": "Invalid argument"
+          }
+        },
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/UnprocessableEntityResponseErrorData"
+          },
+          "user_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "UnprocessableEntityResponseErrorData": {
+        "description": "Error data for UnprocessableEntityResponse",
+        "example": {
+          "code": 422,
+          "message": "Invalid argument"
+        },
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "UpdateGuardrailRequest": {
+        "example": {
+          "description": "Updated description",
+          "limit_usd": 75,
+          "name": "Updated Guardrail Name",
+          "reset_interval": "weekly"
+        },
+        "properties": {
+          "allowed_models": {
+            "description": "Array of model identifiers (slug or canonical_slug accepted)",
+            "example": [
+              "openai/gpt-5.2"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "allowed_providers": {
+            "description": "New list of allowed provider IDs",
+            "example": [
+              "openai",
+              "anthropic",
+              "deepseek"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "description": {
+            "description": "New description for the guardrail",
+            "example": "Updated description",
+            "maxLength": 1000,
+            "nullable": true,
+            "type": "string"
+          },
+          "enforce_zdr": {
+            "description": "Whether to enforce zero data retention",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "ignored_models": {
+            "description": "Array of model identifiers to exclude from routing (slug or canonical_slug accepted)",
+            "example": [
+              "openai/gpt-4o-mini"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "ignored_providers": {
+            "description": "List of provider IDs to exclude from routing",
+            "example": [
+              "azure"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "limit_usd": {
+            "description": "New spending limit in USD",
+            "example": 75,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "name": {
+            "description": "New name for the guardrail",
+            "example": "Updated Guardrail Name",
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          "reset_interval": {
+            "$ref": "#/components/schemas/GuardrailInterval"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateGuardrailResponse": {
+        "example": {
+          "data": {
+            "allowed_models": null,
+            "allowed_providers": [
+              "openai"
+            ],
+            "created_at": "2025-08-24T10:30:00Z",
+            "description": "Updated description",
+            "enforce_zdr": true,
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "ignored_models": null,
+            "ignored_providers": null,
+            "limit_usd": 75,
+            "name": "Updated Guardrail Name",
+            "reset_interval": "weekly",
+            "updated_at": "2025-08-24T16:00:00Z"
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Guardrail"
+              },
+              {
+                "description": "The updated guardrail"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "Usage": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesUsage"
+          },
+          {
+            "nullable": true,
+            "properties": {
+              "cost": {
+                "description": "Cost of the completion",
+                "format": "double",
+                "nullable": true,
+                "type": "number"
+              },
+              "cost_details": {
+                "properties": {
+                  "upstream_inference_cost": {
+                    "format": "double",
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "upstream_inference_input_cost": {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "upstream_inference_output_cost": {
+                    "format": "double",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "upstream_inference_input_cost",
+                  "upstream_inference_output_cost"
+                ],
+                "type": "object"
+              },
+              "is_byok": {
+                "description": "Whether a request was made using a Bring Your Own Key configuration",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Token usage information for the response",
+        "example": {
+          "cost": 0.0012,
+          "cost_details": {
+            "upstream_inference_cost": null,
+            "upstream_inference_input_cost": 0.0008,
+            "upstream_inference_output_cost": 0.0004
+          },
+          "input_tokens": 10,
+          "input_tokens_details": {
+            "cached_tokens": 0
+          },
+          "output_tokens": 25,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 35
+        }
+      },
+      "VideoGenerationRequest": {
+        "example": {
+          "aspect_ratio": "16:9",
+          "duration": 8,
+          "model": "google/veo-3.1",
+          "prompt": "A serene mountain landscape at sunset",
+          "resolution": "720p"
+        },
+        "properties": {
+          "aspect_ratio": {
+            "description": "Aspect ratio of the generated video",
+            "enum": [
+              "16:9",
+              "9:16",
+              "1:1",
+              "4:3",
+              "3:4",
+              "21:9",
+              "9:21"
+            ],
+            "example": "16:9",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "duration": {
+            "description": "Duration of the generated video in seconds",
+            "example": 8,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "frame_images": {
+            "description": "Images to use as the first and/or last frame of the generated video. Each image must specify a frame_type of first_frame or last_frame.",
+            "items": {
+              "$ref": "#/components/schemas/FrameImage"
+            },
+            "type": "array"
+          },
+          "generate_audio": {
+            "description": "Whether to generate audio alongside the video. Defaults to the endpoint's generate_audio capability flag, false if not set.",
+            "example": true,
+            "type": "boolean"
+          },
+          "input_references": {
+            "description": "Reference images to guide video generation",
+            "items": {
+              "$ref": "#/components/schemas/ContentPartImage"
+            },
+            "type": "array"
+          },
+          "model": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "provider": {
+            "description": "Provider-specific passthrough configuration",
+            "properties": {
+              "options": {
+                "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
+                "example": {
+                  "google-vertex": {
+                    "output_config": {
+                      "effort": "low"
+                    }
+                  }
+                },
+                "properties": {
+                  "01ai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ai21": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "aion-labs": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "akashml": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "alibaba": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "amazon-bedrock": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "amazon-nova": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ambient": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "anthropic": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "anyscale": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "arcee-ai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "atlas-cloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "atoma": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "avian": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "azure": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "baidu": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "baseten": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "black-forest-labs": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "byteplus": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "centml": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cerebras": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "chutes": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cirrascale": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "clarifai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cloudflare": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cohere": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "crofai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "crusoe": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "deepinfra": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "deepseek": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "dekallm": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "enfer": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "fake-provider": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "featherless": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "fireworks": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "friendli": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "gmicloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "google-ai-studio": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "google-vertex": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "gopomelo": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "groq": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "huggingface": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "hyperbolic": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "hyperbolic-quantized": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inception": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inceptron": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inference-net": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "infermatic": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inflection": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inocloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "io-net": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ionstream": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "klusterai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lambda": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lepton": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "liquid": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lynn": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lynn-private": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mancer": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mancer-old": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mara": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "meta": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "minimax": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mistral": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "modal": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "modelrun": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "modular": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "moonshotai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "morph": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ncompass": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nebius": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nextbit": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nineteen": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "novita": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nvidia": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "octoai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "open-inference": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "openai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "parasail": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "perplexity": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "phala": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "recraft": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "recursal": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "reflection": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "reka": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "relace": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "replicate": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sambanova": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sambanova-cloaked": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "seed": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sf-compute": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "siliconflow": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sourceful": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "stealth": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "stepfun": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "streamlake": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "switchpoint": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "targon": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "together": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "together-lite": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ubicloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "upstage": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "venice": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "wandb": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "xai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "xiaomi": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "z-ai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "resolution": {
+            "description": "Resolution of the generated video",
+            "enum": [
+              "480p",
+              "720p",
+              "1080p",
+              "1K",
+              "2K",
+              "4K"
+            ],
+            "example": "720p",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "seed": {
+            "description": "If specified, the generation will sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism is not guaranteed for all providers.",
+            "type": "integer"
+          },
+          "size": {
+            "description": "Exact pixel dimensions of the generated video in \"WIDTHxHEIGHT\" format (e.g. \"1280x720\"). Interchangeable with resolution + aspect_ratio.",
+            "example": "1280x720",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt",
+          "model"
+        ],
+        "type": "object"
+      },
+      "VideoGenerationResponse": {
+        "example": {
+          "generation_id": "gen-xyz789",
+          "id": "job-abc123",
+          "polling_url": "/api/v1/videos/job-abc123",
+          "status": "pending"
+        },
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "generation_id": {
+            "description": "The generation ID associated with this video generation job. Available once the job has been processed.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "polling_url": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "in_progress",
+              "completed",
+              "failed",
+              "cancelled",
+              "expired"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "unsigned_urls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/VideoGenerationUsage"
+          }
+        },
+        "required": [
+          "id",
+          "polling_url",
+          "status"
+        ],
+        "type": "object"
+      },
+      "VideoGenerationUsage": {
+        "description": "Usage and cost information for the video generation. Available once the job has completed.",
+        "example": {
+          "cost": 0.5,
+          "is_byok": false
+        },
+        "properties": {
+          "cost": {
+            "description": "The cost of the video generation in USD.",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "is_byok": {
+            "description": "Whether the request was made using a Bring Your Own Key configuration.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "VideoModel": {
+        "example": {
+          "allowed_passthrough_parameters": [],
+          "canonical_slug": "google/veo-3.1",
+          "created": 1700000000,
+          "description": "Google video generation model",
+          "generate_audio": true,
+          "id": "google/veo-3.1",
+          "name": "Veo 3.1",
+          "pricing_skus": {
+            "generate": "0.50"
+          },
+          "seed": null,
+          "supported_aspect_ratios": [
+            "16:9"
+          ],
+          "supported_durations": [
+            5,
+            8
+          ],
+          "supported_frame_images": [
+            "first_frame",
+            "last_frame"
+          ],
+          "supported_resolutions": [
+            "720p"
+          ],
+          "supported_sizes": null
+        },
+        "properties": {
+          "allowed_passthrough_parameters": {
+            "description": "List of parameters that are allowed to be passed through to the provider",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "canonical_slug": {
+            "description": "Canonical slug for the model",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp of when the model was created",
+            "example": 1692901234,
+            "type": "integer"
+          },
+          "description": {
+            "description": "Description of the model",
+            "example": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+            "type": "string"
+          },
+          "generate_audio": {
+            "description": "Whether the model supports generating audio alongside video",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "hugging_face_id": {
+            "description": "Hugging Face model identifier, if applicable",
+            "example": "microsoft/DialoGPT-medium",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the model",
+            "example": "openai/gpt-4",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the model",
+            "example": "GPT-4",
+            "type": "string"
+          },
+          "pricing_skus": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Pricing SKUs with provider prefix stripped, values as strings",
+            "nullable": true,
+            "type": "object"
+          },
+          "seed": {
+            "description": "Whether the model supports deterministic generation via seed parameter",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "supported_aspect_ratios": {
+            "description": "Supported output aspect ratios",
+            "items": {
+              "enum": [
+                "16:9",
+                "9:16",
+                "1:1",
+                "4:3",
+                "3:4",
+                "21:9",
+                "9:21"
+              ],
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "supported_durations": {
+            "description": "Supported video durations in seconds",
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "supported_frame_images": {
+            "description": "Supported frame image types (e.g. first_frame, last_frame)",
+            "items": {
+              "enum": [
+                "first_frame",
+                "last_frame"
+              ],
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "supported_resolutions": {
+            "description": "Supported output resolutions",
+            "items": {
+              "enum": [
+                "480p",
+                "720p",
+                "1080p",
+                "1K",
+                "2K",
+                "4K"
+              ],
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "supported_sizes": {
+            "description": "Supported output sizes (width x height)",
+            "items": {
+              "enum": [
+                "480x480",
+                "480x640",
+                "480x854",
+                "480x1120",
+                "640x480",
+                "720x720",
+                "720x960",
+                "720x1280",
+                "720x1680",
+                "854x480",
+                "960x720",
+                "1080x1080",
+                "1080x1440",
+                "1080x1920",
+                "1080x2520",
+                "1120x480",
+                "1280x720",
+                "1440x1080",
+                "1680x720",
+                "1920x1080",
+                "2160x2160",
+                "2160x2880",
+                "2160x3840",
+                "2160x5040",
+                "2520x1080",
+                "2880x2160",
+                "3840x2160",
+                "5040x2160"
+              ],
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "canonical_slug",
+          "name",
+          "created",
+          "supported_resolutions",
+          "supported_aspect_ratios",
+          "supported_sizes",
+          "supported_durations",
+          "supported_frame_images",
+          "generate_audio",
+          "seed",
+          "allowed_passthrough_parameters"
+        ],
+        "type": "object"
+      },
+      "VideoModelsListResponse": {
+        "example": {
+          "data": [
+            {
+              "allowed_passthrough_parameters": [],
+              "canonical_slug": "google/veo-3.1",
+              "created": 1700000000,
+              "description": "Google video generation model",
+              "generate_audio": true,
+              "id": "google/veo-3.1",
+              "name": "Veo 3.1",
+              "pricing_skus": {
+                "generate": "0.50"
+              },
+              "seed": null,
+              "supported_aspect_ratios": [
+                "16:9"
+              ],
+              "supported_durations": [
+                5,
+                8
+              ],
+              "supported_frame_images": [
+                "first_frame",
+                "last_frame"
+              ],
+              "supported_resolutions": [
+                "720p"
+              ],
+              "supported_sizes": null
+            }
+          ]
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/VideoModel"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "WebSearchCallCompletedEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesSearchCompleted"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Web search call completed",
+        "example": {
+          "item_id": "ws-123",
+          "output_index": 0,
+          "sequence_number": 3,
+          "type": "response.web_search_call.completed"
+        }
+      },
+      "WebSearchCallInProgressEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesWebSearchCallInProgress"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Web search call in progress",
+        "example": {
+          "item_id": "ws-123",
+          "output_index": 0,
+          "sequence_number": 1,
+          "type": "response.web_search_call.in_progress"
+        }
+      },
+      "WebSearchCallSearchingEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponsesWebSearchCallSearching"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Web search call is searching",
+        "example": {
+          "item_id": "ws-123",
+          "output_index": 0,
+          "sequence_number": 2,
+          "type": "response.web_search_call.searching"
+        }
+      },
+      "WebSearchConfig": {
+        "example": {
+          "max_results": 5,
+          "search_context_size": "medium"
+        },
+        "properties": {
+          "allowed_domains": {
+            "description": "Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Firecrawl or Perplexity.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "excluded_domains": {
+            "description": "Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported with Firecrawl, OpenAI (silently ignored), or Perplexity.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "max_total_results": {
+            "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results. Useful for controlling cost and context size in agentic loops.",
+            "example": 20,
+            "type": "integer"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchQualityLevel"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/WebSearchUserLocationServerTool"
+          }
+        },
+        "type": "object"
+      },
+      "WebSearchDomainFilter": {
+        "example": {
+          "allowed_domains": [
+            "example.com"
+          ],
+          "excluded_domains": [
+            "spam.com"
+          ]
+        },
+        "nullable": true,
+        "properties": {
+          "allowed_domains": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "excluded_domains": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "WebSearchEngine": {
+        "description": "The search engine to use for web search.",
+        "enum": [
+          "native",
+          "exa",
+          "firecrawl",
+          "parallel"
+        ],
+        "example": "exa",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "WebSearchEngineEnum": {
+        "description": "Which search engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in search. \"exa\" forces the Exa search API. \"firecrawl\" uses Firecrawl (requires BYOK). \"parallel\" uses the Parallel search API.",
+        "enum": [
+          "auto",
+          "native",
+          "exa",
+          "firecrawl",
+          "parallel"
+        ],
+        "example": "auto",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "WebSearchPlugin": {
+        "example": {
+          "enabled": true,
+          "id": "web",
+          "max_results": 5
+        },
+        "properties": {
+          "enabled": {
+            "description": "Set to false to disable the web-search plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngine"
+          },
+          "exclude_domains": {
+            "description": "A list of domains to exclude from web search results. Supports wildcards (e.g. \"*.substack.com\") and path filtering (e.g. \"openai.com/blog\").",
+            "example": [
+              "example.com",
+              "*.substack.com",
+              "openai.com/blog"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "enum": [
+              "web"
+            ],
+            "type": "string"
+          },
+          "include_domains": {
+            "description": "A list of domains to restrict web search results to. Supports wildcards (e.g. \"*.substack.com\") and path filtering (e.g. \"openai.com/blog\").",
+            "example": [
+              "example.com",
+              "*.substack.com",
+              "openai.com/blog"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "max_results": {
+            "type": "integer"
+          },
+          "search_prompt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "WebSearchServerTool": {
+        "description": "Web search tool configuration (2025-08-26 version)",
+        "example": {
+          "engine": "auto",
+          "filters": {
+            "allowed_domains": [
+              "example.com"
+            ]
+          },
+          "type": "web_search_2025_08_26"
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/WebSearchDomainFilter"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchContextSizeEnum"
+          },
+          "type": {
+            "enum": [
+              "web_search_2025_08_26"
+            ],
+            "type": "string"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/WebSearchUserLocation"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "WebSearchServerTool_OpenRouter": {
+        "description": "OpenRouter built-in server tool: searches the web for current information",
+        "example": {
+          "parameters": {
+            "max_results": 5
+          },
+          "type": "openrouter:web_search"
+        },
+        "properties": {
+          "parameters": {
+            "properties": {
+              "max_results": {
+                "description": "Maximum number of search results to return per search call. Defaults to 5.",
+                "example": 5,
+                "type": "integer"
+              },
+              "max_total_results": {
+                "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results.",
+                "example": 20,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "openrouter:web_search"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "WebSearchSource": {
+        "example": {
+          "type": "url",
+          "url": "https://example.com/article"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "url"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ],
+        "type": "object"
+      },
+      "WebSearchStatus": {
+        "enum": [
+          "completed",
+          "searching",
+          "in_progress",
+          "failed"
+        ],
+        "example": "completed",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "WebSearchUserLocation": {
+        "description": "User location information for web search",
+        "example": {
+          "city": "San Francisco",
+          "country": "USA",
+          "region": "California",
+          "timezone": "America/Los_Angeles",
+          "type": "approximate"
+        },
+        "nullable": true,
+        "properties": {
+          "city": {
+            "nullable": true,
+            "type": "string"
+          },
+          "country": {
+            "nullable": true,
+            "type": "string"
+          },
+          "region": {
+            "nullable": true,
+            "type": "string"
+          },
+          "timezone": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "approximate"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WebSearchUserLocationServerTool": {
+        "description": "Approximate user location for location-biased results.",
+        "example": {
+          "city": "San Francisco",
+          "country": "US",
+          "region": "California",
+          "timezone": "America/Los_Angeles",
+          "type": "approximate"
+        },
+        "properties": {
+          "city": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "approximate"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "description": "API key as bearer token in Authorization header",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "bearer": {
+        "description": "API key as bearer token in Authorization header",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "support@openrouter.ai",
+      "name": "OpenRouter Support",
+      "url": "https://openrouter.ai/docs"
+    },
+    "description": "OpenAI-compatible API with additional OpenRouter features",
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "title": "OpenRouter API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/activity": {
+      "get": {
+        "description": "Returns user activity data grouped by endpoint for the last 30 (completed) UTC days. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getUserActivity",
+        "parameters": [
+          {
+            "description": "Filter by a single UTC date in the last 30 days (YYYY-MM-DD format).",
+            "in": "query",
+            "name": "date",
+            "required": false,
+            "schema": {
+              "description": "Filter by a single UTC date in the last 30 days (YYYY-MM-DD format).",
+              "example": "2025-08-24",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by API key hash (SHA-256 hex string, as returned by the keys API).",
+            "in": "query",
+            "name": "api_key_hash",
+            "required": false,
+            "schema": {
+              "description": "Filter by API key hash (SHA-256 hex string, as returned by the keys API).",
+              "example": "abc123def456...",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by org member user ID. Only applicable for organization accounts.",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "description": "Filter by org member user ID. Only applicable for organization accounts.",
+              "example": "user_abc123",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "byok_usage_inference": 0.012,
+                      "completion_tokens": 125,
+                      "date": "2025-08-24",
+                      "endpoint_id": "550e8400-e29b-41d4-a716-446655440000",
+                      "model": "openai/gpt-4.1",
+                      "model_permaslug": "openai/gpt-4.1-2025-04-14",
+                      "prompt_tokens": 50,
+                      "provider_name": "OpenAI",
+                      "reasoning_tokens": 25,
+                      "requests": 5,
+                      "usage": 0.015
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            },
+            "description": "Returns user activity data grouped by endpoint"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get user activity grouped by endpoint",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/auth/keys": {
+      "post": {
+        "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
+        "operationId": "exchangeAuthCodeForAPIKey",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "code": "auth_code_abc123def456",
+                "code_challenge_method": "S256",
+                "code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+              },
+              "schema": {
+                "example": {
+                  "code": "auth_code_abc123def456",
+                  "code_challenge_method": "S256",
+                  "code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+                },
+                "properties": {
+                  "code": {
+                    "description": "The authorization code received from the OAuth redirect",
+                    "example": "auth_code_abc123def456",
+                    "type": "string"
+                  },
+                  "code_challenge_method": {
+                    "description": "The method used to generate the code challenge",
+                    "enum": [
+                      "S256",
+                      "plain",
+                      null
+                    ],
+                    "example": "S256",
+                    "nullable": true,
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "code_verifier": {
+                    "description": "The code verifier if code_challenge was used in the authorization request",
+                    "example": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "key": "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",
+                  "user_id": "user_2yOPcMpKoQhcd4bVgSMlELRaIah"
+                },
+                "schema": {
+                  "example": {
+                    "key": "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",
+                    "user_id": "user_2yOPcMpKoQhcd4bVgSMlELRaIah"
+                  },
+                  "properties": {
+                    "key": {
+                      "description": "The API key to use for OpenRouter requests",
+                      "example": "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",
+                      "type": "string"
+                    },
+                    "user_id": {
+                      "description": "User ID associated with the API key",
+                      "example": "user_2yOPcMpKoQhcd4bVgSMlELRaIah",
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "user_id"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successfully exchanged code for an API key"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Exchange authorization code for API key",
+        "tags": [
+          "OAuth"
+        ]
+      }
+    },
+    "/auth/keys/code": {
+      "post": {
+        "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
+        "operationId": "createAuthKeysCode",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "callback_url": "https://myapp.com/auth/callback",
+                "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                "code_challenge_method": "S256",
+                "limit": 100
+              },
+              "schema": {
+                "example": {
+                  "callback_url": "https://myapp.com/auth/callback",
+                  "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                  "code_challenge_method": "S256",
+                  "limit": 100
+                },
+                "properties": {
+                  "callback_url": {
+                    "description": "The callback URL to redirect to after authorization. Note, only https URLs on ports 443 and 3000 are allowed.",
+                    "example": "https://myapp.com/auth/callback",
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "code_challenge": {
+                    "description": "PKCE code challenge for enhanced security",
+                    "example": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                    "type": "string"
+                  },
+                  "code_challenge_method": {
+                    "description": "The method used to generate the code challenge",
+                    "enum": [
+                      "S256",
+                      "plain"
+                    ],
+                    "example": "S256",
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "expires_at": {
+                    "description": "Optional expiration time for the API key to be created",
+                    "example": "2027-12-31T23:59:59Z",
+                    "format": "date-time",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "key_label": {
+                    "description": "Optional custom label for the API key. Defaults to the app name if not provided.",
+                    "example": "My Custom Key",
+                    "maxLength": 100,
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Credit limit for the API key to be created",
+                    "example": 100,
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "spawn_agent": {
+                    "description": "Agent identifier for spawn telemetry",
+                    "example": "my-agent",
+                    "type": "string",
+                    "x-fern-ignore": true,
+                    "x-speakeasy-ignore": true
+                  },
+                  "spawn_cloud": {
+                    "description": "Cloud identifier for spawn telemetry",
+                    "example": "aws-us-east-1",
+                    "type": "string",
+                    "x-fern-ignore": true,
+                    "x-speakeasy-ignore": true
+                  },
+                  "usage_limit_type": {
+                    "description": "Optional credit limit reset interval. When set, the credit limit resets on this interval.",
+                    "enum": [
+                      "daily",
+                      "weekly",
+                      "monthly"
+                    ],
+                    "example": "monthly",
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  }
+                },
+                "required": [
+                  "callback_url"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "app_id": 12345,
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "id": "auth_code_xyz789"
+                  }
+                },
+                "schema": {
+                  "example": {
+                    "data": {
+                      "app_id": 12345,
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "id": "auth_code_xyz789"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "Auth code data",
+                      "example": {
+                        "app_id": 12345,
+                        "created_at": "2025-08-24T10:30:00Z",
+                        "id": "auth_code_xyz789"
+                      },
+                      "properties": {
+                        "app_id": {
+                          "description": "The application ID associated with this auth code",
+                          "example": 12345,
+                          "type": "integer"
+                        },
+                        "created_at": {
+                          "description": "ISO 8601 timestamp of when the auth code was created",
+                          "example": "2025-08-24T10:30:00Z",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "The authorization code ID to use in the exchange request",
+                          "example": "auth_code_xyz789",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "app_id",
+                        "created_at"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successfully created authorization code"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 409,
+                    "message": "Resource conflict. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictResponse"
+                }
+              }
+            },
+            "description": "Conflict - Resource conflict or concurrent modification"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Create authorization code",
+        "tags": [
+          "OAuth"
+        ],
+        "x-speakeasy-name-override": "createAuthCode"
+      }
+    },
+    "/chat/completions": {
+      "post": {
+        "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
+        "operationId": "sendChatCompletionRequest",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "max_tokens": 150,
+                "messages": [
+                  {
+                    "content": "You are a helpful assistant.",
+                    "role": "system"
+                  },
+                  {
+                    "content": "What is the capital of France?",
+                    "role": "user"
+                  }
+                ],
+                "model": "openai/gpt-4",
+                "temperature": 0.7
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "choices": [
+                    {
+                      "finish_reason": "stop",
+                      "index": 0,
+                      "message": {
+                        "content": "The capital of France is Paris.",
+                        "role": "assistant"
+                      }
+                    }
+                  ],
+                  "created": 1677652288,
+                  "id": "chatcmpl-123",
+                  "model": "openai/gpt-4",
+                  "object": "chat.completion",
+                  "usage": {
+                    "completion_tokens": 10,
+                    "prompt_tokens": 25,
+                    "total_tokens": 35
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResult"
+                }
+              },
+              "text/event-stream": {
+                "example": {
+                  "data": {
+                    "choices": [
+                      {
+                        "delta": {
+                          "content": "Hello",
+                          "role": "assistant"
+                        },
+                        "finish_reason": null,
+                        "index": 0
+                      }
+                    ],
+                    "created": 1677652288,
+                    "id": "chatcmpl-123",
+                    "model": "openai/gpt-4",
+                    "object": "chat.completion.chunk"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ChatStreamChunk"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            },
+            "description": "Successful chat completion response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 408,
+                    "message": "Operation timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RequestTimeoutResponse"
+                }
+              }
+            },
+            "description": "Request Timeout - Operation exceeded time limit"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 413,
+                    "message": "Request payload too large"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PayloadTooLargeResponse"
+                }
+              }
+            },
+            "description": "Payload Too Large - Request payload exceeds size limits"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 422,
+                    "message": "Invalid argument"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityResponse"
+                }
+              }
+            },
+            "description": "Unprocessable Entity - Semantic validation failure"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Create a chat completion",
+        "tags": [
+          "Chat"
+        ],
+        "x-speakeasy-group": "chat",
+        "x-speakeasy-name-override": "send",
+        "x-speakeasy-stream-request-field": "stream"
+      }
+    },
+    "/credits": {
+      "get": {
+        "description": "Get total credits purchased and used for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getCredits",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "total_credits": 100.5,
+                    "total_usage": 25.75
+                  }
+                },
+                "schema": {
+                  "description": "Total credits purchased and used",
+                  "example": {
+                    "data": {
+                      "total_credits": 100.5,
+                      "total_usage": 25.75
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "example": {
+                        "total_credits": 100.5,
+                        "total_usage": 25.75
+                      },
+                      "properties": {
+                        "total_credits": {
+                          "description": "Total credits purchased",
+                          "example": 100.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "total_usage": {
+                          "description": "Total credits used",
+                          "example": 25.75,
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "total_credits",
+                        "total_usage"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Returns the total credits purchased and used"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get remaining credits",
+        "tags": [
+          "Credits"
+        ],
+        "x-speakeasy-name-override": "getCredits"
+      }
+    },
+    "/credits/coinbase": {
+      "post": {
+        "deprecated": true,
+        "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
+        "operationId": "createCoinbaseCharge",
+        "responses": {
+          "200": {
+            "description": "This endpoint is deprecated and will never return a 200 response."
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 410,
+                    "message": "The Coinbase APIs used by this endpoint have been deprecated, so the Coinbase Commerce credits API has been removed. Use the web credits purchase flow instead."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GoneResponse"
+                }
+              }
+            },
+            "description": "Gone - Endpoint has been permanently removed or deprecated"
+          }
+        },
+        "security": [],
+        "summary": "Deprecated Coinbase Commerce charge endpoint",
+        "tags": [
+          "Credits"
+        ],
+        "x-fern-ignore": true,
+        "x-speakeasy-ignore": true,
+        "x-speakeasy-name-override": "createCoinbaseCharge"
+      }
+    },
+    "/embeddings": {
+      "post": {
+        "description": "Submits an embedding request to the embeddings router",
+        "operationId": "createEmbeddings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Embeddings request input",
+                "example": {
+                  "dimensions": 1536,
+                  "input": "The quick brown fox jumps over the lazy dog",
+                  "model": "openai/text-embedding-3-small"
+                },
+                "properties": {
+                  "dimensions": {
+                    "description": "The number of dimensions for the output embeddings",
+                    "example": 1536,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "encoding_format": {
+                    "description": "The format of the output embeddings",
+                    "enum": [
+                      "float",
+                      "base64"
+                    ],
+                    "example": "float",
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "input": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "items": {
+                          "type": "number"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "items": {
+                          "items": {
+                            "type": "number"
+                          },
+                          "type": "array"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "items": {
+                          "properties": {
+                            "content": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "enum": [
+                                          "text"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "text"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "properties": {
+                                      "image_url": {
+                                        "properties": {
+                                          "url": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": {
+                                        "enum": [
+                                          "image_url"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "image_url"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "content"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "Text, token, or multimodal input(s) to embed",
+                    "example": "The quick brown fox jumps over the lazy dog"
+                  },
+                  "input_type": {
+                    "description": "The type of input (e.g. search_query, search_document)",
+                    "example": "search_query",
+                    "type": "string"
+                  },
+                  "model": {
+                    "description": "The model to use for embeddings",
+                    "example": "openai/text-embedding-3-small",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/ProviderPreferences"
+                      },
+                      {
+                        "description": "Provider routing preferences for the request."
+                      }
+                    ]
+                  },
+                  "user": {
+                    "description": "A unique identifier for the end-user",
+                    "example": "user-1234",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "input",
+                  "model"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Embeddings response containing embedding vectors",
+                  "example": {
+                    "data": [
+                      {
+                        "embedding": [
+                          0.0023064255,
+                          -0.009327292,
+                          0.015797347
+                        ],
+                        "index": 0,
+                        "object": "embedding"
+                      }
+                    ],
+                    "model": "openai/text-embedding-3-small",
+                    "object": "list",
+                    "usage": {
+                      "prompt_tokens": 8,
+                      "total_tokens": 8
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "List of embedding objects",
+                      "example": [
+                        {
+                          "embedding": [
+                            0.0023064255,
+                            -0.009327292,
+                            0.015797347
+                          ],
+                          "index": 0,
+                          "object": "embedding"
+                        }
+                      ],
+                      "items": {
+                        "description": "A single embedding object",
+                        "example": {
+                          "embedding": [
+                            0.0023064255,
+                            -0.009327292,
+                            0.015797347
+                          ],
+                          "index": 0,
+                          "object": "embedding"
+                        },
+                        "properties": {
+                          "embedding": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "type": "number"
+                                },
+                                "type": "array"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Embedding vector as an array of floats or a base64 string",
+                            "example": [
+                              0.0023064255,
+                              -0.009327292,
+                              0.015797347
+                            ]
+                          },
+                          "index": {
+                            "description": "Index of the embedding in the input list",
+                            "example": 0,
+                            "type": "integer"
+                          },
+                          "object": {
+                            "enum": [
+                              "embedding"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "object",
+                          "embedding"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "Unique identifier for the embeddings response",
+                      "example": "embd-1234567890",
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "The model used for embeddings",
+                      "example": "openai/text-embedding-3-small",
+                      "type": "string"
+                    },
+                    "object": {
+                      "enum": [
+                        "list"
+                      ],
+                      "type": "string"
+                    },
+                    "usage": {
+                      "description": "Token usage statistics",
+                      "example": {
+                        "prompt_tokens": 8,
+                        "total_tokens": 8
+                      },
+                      "properties": {
+                        "cost": {
+                          "description": "Cost of the request in credits",
+                          "example": 0.0001,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "prompt_tokens": {
+                          "description": "Number of tokens in the input",
+                          "example": 8,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "description": "Total number of tokens used",
+                          "example": 8,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "prompt_tokens",
+                        "total_tokens"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "object",
+                    "data",
+                    "model"
+                  ],
+                  "type": "object"
+                }
+              },
+              "text/event-stream": {
+                "example": "data: [DONE]",
+                "schema": {
+                  "description": "Not used for embeddings - embeddings do not support streaming",
+                  "type": "string"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            },
+            "description": "Embedding response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Submit an embedding request",
+        "tags": [
+          "Embeddings"
+        ],
+        "x-speakeasy-name-override": "generate"
+      }
+    },
+    "/embeddings/models": {
+      "get": {
+        "description": "Returns a list of all available embeddings models and their properties",
+        "operationId": "listEmbeddingsModels",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "architecture": {
+                        "input_modalities": [
+                          "text"
+                        ],
+                        "instruct_type": null,
+                        "modality": "text->text",
+                        "output_modalities": [
+                          "embeddings"
+                        ],
+                        "tokenizer": "GPT"
+                      },
+                      "canonical_slug": "openai/text-embedding-3-small",
+                      "context_length": 8192,
+                      "created": 1692901234,
+                      "default_parameters": null,
+                      "description": "OpenAI text embedding model optimized for performance.",
+                      "expiration_date": null,
+                      "id": "openai/text-embedding-3-small",
+                      "knowledge_cutoff": null,
+                      "links": {
+                        "details": "/api/v1/models/openai/text-embedding-3-small/endpoints"
+                      },
+                      "name": "Text Embedding 3 Small",
+                      "per_request_limits": null,
+                      "pricing": {
+                        "completion": "0",
+                        "image": "0",
+                        "prompt": "0.00000002",
+                        "request": "0"
+                      },
+                      "supported_parameters": [],
+                      "top_provider": {
+                        "context_length": 8192,
+                        "is_moderated": false,
+                        "max_completion_tokens": null
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsListResponse"
+                }
+              }
+            },
+            "description": "Returns a list of embeddings models"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all embeddings models",
+        "tags": [
+          "Embeddings"
+        ],
+        "x-speakeasy-name-override": "listModels"
+      }
+    },
+    "/endpoints/zdr": {
+      "get": {
+        "operationId": "listEndpointsZdr",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "context_length": 8192,
+                      "latency_last_30m": {
+                        "p50": 0.25,
+                        "p75": 0.35,
+                        "p90": 0.48,
+                        "p99": 0.85
+                      },
+                      "max_completion_tokens": 4096,
+                      "max_prompt_tokens": 8192,
+                      "model_id": "openai/gpt-4",
+                      "model_name": "GPT-4",
+                      "name": "OpenAI: GPT-4",
+                      "pricing": {
+                        "completion": "0.00006",
+                        "image": "0",
+                        "prompt": "0.00003",
+                        "request": "0"
+                      },
+                      "provider_name": "OpenAI",
+                      "quantization": "fp16",
+                      "status": "default",
+                      "supported_parameters": [
+                        "temperature",
+                        "top_p",
+                        "max_tokens"
+                      ],
+                      "supports_implicit_caching": true,
+                      "tag": "openai",
+                      "throughput_last_30m": {
+                        "p50": 45.2,
+                        "p75": 38.5,
+                        "p90": 28.3,
+                        "p99": 15.1
+                      },
+                      "uptime_last_1d": 99.8,
+                      "uptime_last_30m": 99.5,
+                      "uptime_last_5m": 100
+                    }
+                  ]
+                },
+                "schema": {
+                  "example": {
+                    "data": [
+                      {
+                        "context_length": 8192,
+                        "latency_last_30m": {
+                          "p50": 0.25,
+                          "p75": 0.35,
+                          "p90": 0.48,
+                          "p99": 0.85
+                        },
+                        "max_completion_tokens": 4096,
+                        "max_prompt_tokens": 8192,
+                        "model_id": "openai/gpt-4",
+                        "model_name": "GPT-4",
+                        "name": "OpenAI: GPT-4",
+                        "pricing": {
+                          "completion": "0.00006",
+                          "image": "0",
+                          "prompt": "0.00003",
+                          "request": "0"
+                        },
+                        "provider_name": "OpenAI",
+                        "quantization": "fp16",
+                        "status": "default",
+                        "supported_parameters": [
+                          "temperature",
+                          "top_p",
+                          "max_tokens"
+                        ],
+                        "supports_implicit_caching": true,
+                        "tag": "openai",
+                        "throughput_last_30m": {
+                          "p50": 45.2,
+                          "p75": 38.5,
+                          "p90": 28.3,
+                          "p99": 15.1
+                        },
+                        "uptime_last_1d": 99.8,
+                        "uptime_last_30m": 99.5,
+                        "uptime_last_5m": 100
+                      }
+                    ]
+                  },
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/PublicEndpoint"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Returns a list of endpoints"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Preview the impact of ZDR on the available endpoints",
+        "tags": [
+          "Endpoints"
+        ],
+        "x-speakeasy-name-override": "listZdrEndpoints"
+      }
+    },
+    "/generation": {
+      "get": {
+        "operationId": "getGeneration",
+        "parameters": [
+          {
+            "description": "The generation ID",
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The generation ID",
+              "example": "gen-1234567890",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "api_type": null,
+                    "app_id": 12345,
+                    "cache_discount": 0.0002,
+                    "cancelled": false,
+                    "created_at": "2024-07-15T23:33:19.433273+00:00",
+                    "external_user": "user-123",
+                    "finish_reason": "stop",
+                    "generation_time": 1200,
+                    "http_referer": null,
+                    "id": "gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG",
+                    "is_byok": false,
+                    "latency": 1250,
+                    "model": "sao10k/l3-stheno-8b",
+                    "moderation_latency": 50,
+                    "native_finish_reason": "stop",
+                    "native_tokens_cached": 3,
+                    "native_tokens_completion": 25,
+                    "native_tokens_completion_images": 0,
+                    "native_tokens_prompt": 10,
+                    "native_tokens_reasoning": 5,
+                    "num_input_audio_prompt": 0,
+                    "num_media_completion": 0,
+                    "num_media_prompt": 1,
+                    "num_search_results": 5,
+                    "origin": "https://openrouter.ai/",
+                    "provider_name": "Infermatic",
+                    "provider_responses": null,
+                    "request_id": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
+                    "router": null,
+                    "streamed": true,
+                    "tokens_completion": 25,
+                    "tokens_prompt": 10,
+                    "total_cost": 0.0015,
+                    "upstream_id": "chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946",
+                    "upstream_inference_cost": 0.0012,
+                    "usage": 0.0015,
+                    "user_agent": null
+                  }
+                },
+                "schema": {
+                  "description": "Generation response",
+                  "properties": {
+                    "data": {
+                      "description": "Generation data",
+                      "properties": {
+                        "api_type": {
+                          "description": "Type of API used for the generation",
+                          "enum": [
+                            "completions",
+                            "embeddings",
+                            "rerank",
+                            "video",
+                            null
+                          ],
+                          "nullable": true,
+                          "type": "string",
+                          "x-speakeasy-unknown-values": "allow"
+                        },
+                        "app_id": {
+                          "description": "ID of the app that made the request",
+                          "example": 12345,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "cache_discount": {
+                          "description": "Discount applied due to caching",
+                          "example": 0.0002,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "cancelled": {
+                          "description": "Whether the generation was cancelled",
+                          "example": false,
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "description": "ISO 8601 timestamp of when the generation was created",
+                          "example": "2024-07-15T23:33:19.433273+00:00",
+                          "type": "string"
+                        },
+                        "external_user": {
+                          "description": "External user identifier",
+                          "example": "user-123",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "finish_reason": {
+                          "description": "Reason the generation finished",
+                          "example": "stop",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "generation_time": {
+                          "description": "Time taken for generation in milliseconds",
+                          "example": 1200,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "http_referer": {
+                          "description": "Referer header from the request",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "Unique identifier for the generation",
+                          "example": "gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG",
+                          "type": "string"
+                        },
+                        "is_byok": {
+                          "description": "Whether this used bring-your-own-key",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "latency": {
+                          "description": "Total latency in milliseconds",
+                          "example": 1250,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "model": {
+                          "description": "Model used for the generation",
+                          "example": "sao10k/l3-stheno-8b",
+                          "type": "string"
+                        },
+                        "moderation_latency": {
+                          "description": "Moderation latency in milliseconds",
+                          "example": 50,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "native_finish_reason": {
+                          "description": "Native finish reason as reported by provider",
+                          "example": "stop",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "native_tokens_cached": {
+                          "description": "Native cached tokens as reported by provider",
+                          "example": 3,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "native_tokens_completion": {
+                          "description": "Native completion tokens as reported by provider",
+                          "example": 25,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "native_tokens_completion_images": {
+                          "description": "Native completion image tokens as reported by provider",
+                          "example": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "native_tokens_prompt": {
+                          "description": "Native prompt tokens as reported by provider",
+                          "example": 10,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "native_tokens_reasoning": {
+                          "description": "Native reasoning tokens as reported by provider",
+                          "example": 5,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "num_input_audio_prompt": {
+                          "description": "Number of audio inputs in the prompt",
+                          "example": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "num_media_completion": {
+                          "description": "Number of media items in the completion",
+                          "example": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "num_media_prompt": {
+                          "description": "Number of media items in the prompt",
+                          "example": 1,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "num_search_results": {
+                          "description": "Number of search results included",
+                          "example": 5,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "origin": {
+                          "description": "Origin URL of the request",
+                          "example": "https://openrouter.ai/",
+                          "type": "string"
+                        },
+                        "provider_name": {
+                          "description": "Name of the provider that served the request",
+                          "example": "Infermatic",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "provider_responses": {
+                          "description": "List of provider responses for this generation, including fallback attempts",
+                          "items": {
+                            "$ref": "#/components/schemas/ProviderResponse"
+                          },
+                          "nullable": true,
+                          "type": "array"
+                        },
+                        "request_id": {
+                          "description": "Unique identifier grouping all generations from a single API request",
+                          "example": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "router": {
+                          "description": "Router used for the request (e.g., openrouter/auto)",
+                          "example": "openrouter/auto",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "session_id": {
+                          "description": "Session identifier grouping multiple generations in the same session",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "streamed": {
+                          "description": "Whether the response was streamed",
+                          "example": true,
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "tokens_completion": {
+                          "description": "Number of tokens in the completion",
+                          "example": 25,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "tokens_prompt": {
+                          "description": "Number of tokens in the prompt",
+                          "example": 10,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "total_cost": {
+                          "description": "Total cost of the generation in USD",
+                          "example": 0.0015,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "upstream_id": {
+                          "description": "Upstream provider's identifier for this generation",
+                          "example": "chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "upstream_inference_cost": {
+                          "description": "Cost charged by the upstream provider",
+                          "example": 0.0012,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "usage": {
+                          "description": "Usage amount in USD",
+                          "example": 0.0015,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "user_agent": {
+                          "description": "User-Agent header from the request",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "web_search_engine": {
+                          "description": "The resolved web search engine used for this generation (e.g. exa, firecrawl, parallel)",
+                          "example": "exa",
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "upstream_id",
+                        "total_cost",
+                        "cache_discount",
+                        "upstream_inference_cost",
+                        "created_at",
+                        "model",
+                        "app_id",
+                        "streamed",
+                        "cancelled",
+                        "provider_name",
+                        "latency",
+                        "moderation_latency",
+                        "generation_time",
+                        "finish_reason",
+                        "tokens_prompt",
+                        "tokens_completion",
+                        "native_tokens_prompt",
+                        "native_tokens_completion",
+                        "native_tokens_completion_images",
+                        "native_tokens_reasoning",
+                        "native_tokens_cached",
+                        "num_media_prompt",
+                        "num_input_audio_prompt",
+                        "num_media_completion",
+                        "num_search_results",
+                        "web_search_engine",
+                        "origin",
+                        "usage",
+                        "is_byok",
+                        "native_finish_reason",
+                        "external_user",
+                        "api_type",
+                        "router",
+                        "provider_responses",
+                        "user_agent",
+                        "http_referer"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Returns the request metadata for this generation"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Get request & usage metadata for a generation",
+        "tags": [
+          "Generations"
+        ]
+      }
+    },
+    "/guardrails": {
+      "get": {
+        "description": "List all guardrails for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listGuardrails",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "allowed_models": null,
+                      "allowed_providers": [
+                        "openai",
+                        "anthropic",
+                        "google"
+                      ],
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "description": "Guardrail for production environment",
+                      "enforce_zdr": false,
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "ignored_models": null,
+                      "ignored_providers": null,
+                      "limit_usd": 100,
+                      "name": "Production Guardrail",
+                      "reset_interval": "monthly",
+                      "updated_at": "2025-08-24T15:45:00Z"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListGuardrailsResponse"
+                }
+              }
+            },
+            "description": "List of guardrails"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List guardrails",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "list",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "post": {
+        "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "createGuardrail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "allowed_models": null,
+                "allowed_providers": [
+                  "openai",
+                  "anthropic",
+                  "deepseek"
+                ],
+                "description": "A guardrail for limiting API usage",
+                "enforce_zdr": false,
+                "ignored_models": null,
+                "ignored_providers": null,
+                "limit_usd": 50,
+                "name": "My New Guardrail",
+                "reset_interval": "monthly"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateGuardrailRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "allowed_models": null,
+                    "allowed_providers": [
+                      "openai",
+                      "anthropic",
+                      "google"
+                    ],
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "description": "A guardrail for limiting API usage",
+                    "enforce_zdr": false,
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "ignored_models": null,
+                    "ignored_providers": null,
+                    "limit_usd": 50,
+                    "name": "My New Guardrail",
+                    "reset_interval": "monthly",
+                    "updated_at": null
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreateGuardrailResponse"
+                }
+              }
+            },
+            "description": "Guardrail created successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Create a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/guardrails/assignments/keys": {
+      "get": {
+        "description": "List all API key guardrail assignments for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listKeyAssignments",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "assigned_by": "user_abc123",
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "key_hash": "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93",
+                      "key_label": "prod-key",
+                      "key_name": "Production Key"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListKeyAssignmentsResponse"
+                }
+              }
+            },
+            "description": "List of key assignments"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all key assignments",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "listKeyAssignments",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      }
+    },
+    "/guardrails/assignments/members": {
+      "get": {
+        "description": "List all organization member guardrail assignments for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listMemberAssignments",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "assigned_by": "user_abc123",
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "organization_id": "org_xyz789",
+                      "user_id": "user_abc123"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListMemberAssignmentsResponse"
+                }
+              }
+            },
+            "description": "List of member assignments"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all member assignments",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "listMemberAssignments",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      }
+    },
+    "/guardrails/{id}": {
+      "delete": {
+        "description": "Delete an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "deleteGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail to delete",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail to delete",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "deleted": true
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteGuardrailResponse"
+                }
+              }
+            },
+            "description": "Guardrail deleted successfully"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Delete a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "description": "Get a single guardrail by ID. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail to retrieve",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail to retrieve",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "allowed_models": null,
+                    "allowed_providers": [
+                      "openai",
+                      "anthropic",
+                      "google"
+                    ],
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "description": "Guardrail for production environment",
+                    "enforce_zdr": false,
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "ignored_models": null,
+                    "ignored_providers": null,
+                    "limit_usd": 100,
+                    "name": "Production Guardrail",
+                    "reset_interval": "monthly",
+                    "updated_at": "2025-08-24T15:45:00Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GetGuardrailResponse"
+                }
+              }
+            },
+            "description": "Guardrail details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "get"
+      },
+      "patch": {
+        "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "updateGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail to update",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail to update",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "description": "Updated description",
+                "limit_usd": 75,
+                "name": "Updated Guardrail Name",
+                "reset_interval": "weekly"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGuardrailRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "allowed_models": null,
+                    "allowed_providers": [
+                      "openai"
+                    ],
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "description": "Updated description",
+                    "enforce_zdr": true,
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "ignored_models": null,
+                    "ignored_providers": null,
+                    "limit_usd": 75,
+                    "name": "Updated Guardrail Name",
+                    "reset_interval": "weekly",
+                    "updated_at": "2025-08-24T16:00:00Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateGuardrailResponse"
+                }
+              }
+            },
+            "description": "Guardrail updated successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Update a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "update"
+      }
+    },
+    "/guardrails/{id}/assignments/keys": {
+      "get": {
+        "description": "List all API key assignments for a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listGuardrailKeyAssignments",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "assigned_by": "user_abc123",
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "key_hash": "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93",
+                      "key_label": "prod-key",
+                      "key_name": "Production Key"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListKeyAssignmentsResponse"
+                }
+              }
+            },
+            "description": "List of key assignments"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List key assignments for a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "listGuardrailKeyAssignments",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "post": {
+        "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "bulkAssignKeysToGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "key_hashes": [
+                  "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BulkAssignKeysRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "assigned_count": 3
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BulkAssignKeysResponse"
+                }
+              }
+            },
+            "description": "Assignment result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Bulk assign keys to a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "bulkAssignKeys"
+      }
+    },
+    "/guardrails/{id}/assignments/keys/remove": {
+      "post": {
+        "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "bulkUnassignKeysFromGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "key_hashes": [
+                  "c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BulkUnassignKeysRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "unassigned_count": 3
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BulkUnassignKeysResponse"
+                }
+              }
+            },
+            "description": "Unassignment result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Bulk unassign keys from a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "bulkUnassignKeys"
+      }
+    },
+    "/guardrails/{id}/assignments/members": {
+      "get": {
+        "description": "List all organization member assignments for a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listGuardrailMemberAssignments",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "assigned_by": "user_abc123",
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "guardrail_id": "550e8400-e29b-41d4-a716-446655440001",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "organization_id": "org_xyz789",
+                      "user_id": "user_abc123"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListMemberAssignmentsResponse"
+                }
+              }
+            },
+            "description": "List of member assignments"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List member assignments for a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "listGuardrailMemberAssignments",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "post": {
+        "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "bulkAssignMembersToGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "member_user_ids": [
+                  "user_abc123",
+                  "user_def456"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BulkAssignMembersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "assigned_count": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BulkAssignMembersResponse"
+                }
+              }
+            },
+            "description": "Assignment result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Bulk assign members to a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "bulkAssignMembers"
+      }
+    },
+    "/guardrails/{id}/assignments/members/remove": {
+      "post": {
+        "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "bulkUnassignMembersFromGuardrail",
+        "parameters": [
+          {
+            "description": "The unique identifier of the guardrail",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The unique identifier of the guardrail",
+              "example": "550e8400-e29b-41d4-a716-446655440000",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "member_user_ids": [
+                  "user_abc123",
+                  "user_def456"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BulkUnassignMembersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "unassigned_count": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BulkUnassignMembersResponse"
+                }
+              }
+            },
+            "description": "Unassignment result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Bulk unassign members from a guardrail",
+        "tags": [
+          "Guardrails"
+        ],
+        "x-speakeasy-name-override": "bulkUnassignMembers"
+      }
+    },
+    "/key": {
+      "get": {
+        "description": "Get information on the API key associated with the current authentication session",
+        "operationId": "getCurrentKey",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "byok_usage": 17.38,
+                    "byok_usage_daily": 17.38,
+                    "byok_usage_monthly": 17.38,
+                    "byok_usage_weekly": 17.38,
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "expires_at": "2027-12-31T23:59:59Z",
+                    "include_byok_in_limit": false,
+                    "is_free_tier": false,
+                    "is_management_key": false,
+                    "is_provisioning_key": false,
+                    "label": "sk-or-v1-au7...890",
+                    "limit": 100,
+                    "limit_remaining": 74.5,
+                    "limit_reset": "monthly",
+                    "rate_limit": {
+                      "interval": "1h",
+                      "note": "This field is deprecated and safe to ignore.",
+                      "requests": 1000
+                    },
+                    "usage": 25.5,
+                    "usage_daily": 25.5,
+                    "usage_monthly": 25.5,
+                    "usage_weekly": 25.5
+                  }
+                },
+                "schema": {
+                  "example": {
+                    "data": {
+                      "byok_usage": 17.38,
+                      "byok_usage_daily": 17.38,
+                      "byok_usage_monthly": 17.38,
+                      "byok_usage_weekly": 17.38,
+                      "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "expires_at": "2027-12-31T23:59:59Z",
+                      "include_byok_in_limit": false,
+                      "is_free_tier": false,
+                      "is_management_key": false,
+                      "is_provisioning_key": false,
+                      "label": "sk-or-v1-au7...890",
+                      "limit": 100,
+                      "limit_remaining": 74.5,
+                      "limit_reset": "monthly",
+                      "rate_limit": {
+                        "interval": "1h",
+                        "note": "This field is deprecated and safe to ignore.",
+                        "requests": 1000
+                      },
+                      "usage": 25.5,
+                      "usage_daily": 25.5,
+                      "usage_monthly": 25.5,
+                      "usage_weekly": 25.5
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "Current API key information",
+                      "example": {
+                        "byok_usage": 17.38,
+                        "byok_usage_daily": 17.38,
+                        "byok_usage_monthly": 17.38,
+                        "byok_usage_weekly": 17.38,
+                        "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                        "expires_at": "2027-12-31T23:59:59Z",
+                        "include_byok_in_limit": false,
+                        "is_free_tier": false,
+                        "is_management_key": false,
+                        "is_provisioning_key": false,
+                        "label": "sk-or-v1-au7...890",
+                        "limit": 100,
+                        "limit_remaining": 74.5,
+                        "limit_reset": "monthly",
+                        "rate_limit": {
+                          "interval": "1h",
+                          "note": "This field is deprecated and safe to ignore.",
+                          "requests": 1000
+                        },
+                        "usage": 25.5,
+                        "usage_daily": 25.5,
+                        "usage_monthly": 25.5,
+                        "usage_weekly": 25.5
+                      },
+                      "properties": {
+                        "byok_usage": {
+                          "description": "Total external BYOK usage (in USD) for the API key",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_daily": {
+                          "description": "External BYOK usage (in USD) for the current UTC day",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_monthly": {
+                          "description": "External BYOK usage (in USD) for current UTC month",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_weekly": {
+                          "description": "External BYOK usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "creator_user_id": {
+                          "description": "The user ID of the key creator. For organization-owned keys, this is the member who created the key. For individual users, this is the user's own ID.",
+                          "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "expires_at": {
+                          "description": "ISO 8601 UTC timestamp when the API key expires, or null if no expiration",
+                          "example": "2027-12-31T23:59:59Z",
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "include_byok_in_limit": {
+                          "description": "Whether to include external BYOK usage in the credit limit",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "is_free_tier": {
+                          "description": "Whether this is a free tier API key",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "is_management_key": {
+                          "description": "Whether this is a management key",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "is_provisioning_key": {
+                          "deprecated": true,
+                          "description": "Whether this is a management key",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "description": "Human-readable label for the API key",
+                          "example": "sk-or-v1-0e6...1c96",
+                          "type": "string"
+                        },
+                        "limit": {
+                          "description": "Spending limit for the API key in USD",
+                          "example": 100,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_remaining": {
+                          "description": "Remaining spending limit in USD",
+                          "example": 74.5,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_reset": {
+                          "description": "Type of limit reset for the API key",
+                          "example": "monthly",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "rate_limit": {
+                          "deprecated": true,
+                          "description": "Legacy rate limit information about a key. Will always return -1.",
+                          "example": {
+                            "interval": "1h",
+                            "note": "This field is deprecated and safe to ignore.",
+                            "requests": 1000
+                          },
+                          "properties": {
+                            "interval": {
+                              "description": "Rate limit interval",
+                              "example": "1h",
+                              "type": "string"
+                            },
+                            "note": {
+                              "description": "Note about the rate limit",
+                              "example": "This field is deprecated and safe to ignore.",
+                              "type": "string"
+                            },
+                            "requests": {
+                              "description": "Number of requests allowed per interval",
+                              "example": 1000,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "requests",
+                            "interval",
+                            "note"
+                          ],
+                          "type": "object"
+                        },
+                        "usage": {
+                          "description": "Total OpenRouter credit usage (in USD) for the API key",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_daily": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC day",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_monthly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC month",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_weekly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "limit",
+                        "usage",
+                        "usage_daily",
+                        "usage_weekly",
+                        "usage_monthly",
+                        "byok_usage",
+                        "byok_usage_daily",
+                        "byok_usage_weekly",
+                        "byok_usage_monthly",
+                        "is_free_tier",
+                        "is_management_key",
+                        "is_provisioning_key",
+                        "limit_remaining",
+                        "limit_reset",
+                        "include_byok_in_limit",
+                        "creator_user_id",
+                        "rate_limit"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API key details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get current API key",
+        "tags": [
+          "API Keys"
+        ],
+        "x-speakeasy-name-override": "getCurrentKeyMetadata"
+      }
+    },
+    "/keys": {
+      "get": {
+        "description": "List all API keys for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "list",
+        "parameters": [
+          {
+            "description": "Whether to include disabled API keys in the response",
+            "in": "query",
+            "name": "include_disabled",
+            "required": false,
+            "schema": {
+              "description": "Whether to include disabled API keys in the response",
+              "example": "false",
+              "type": "boolean",
+              "x-openrouter-type": "boolean"
+            }
+          },
+          {
+            "description": "Number of API keys to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of API keys to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "byok_usage": 17.38,
+                      "byok_usage_daily": 17.38,
+                      "byok_usage_monthly": 17.38,
+                      "byok_usage_weekly": 17.38,
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "disabled": false,
+                      "expires_at": "2027-12-31T23:59:59Z",
+                      "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                      "include_byok_in_limit": false,
+                      "label": "Production API Key",
+                      "limit": 100,
+                      "limit_remaining": 74.5,
+                      "limit_reset": "monthly",
+                      "name": "My Production Key",
+                      "updated_at": "2025-08-24T15:45:00Z",
+                      "usage": 25.5,
+                      "usage_daily": 25.5,
+                      "usage_monthly": 25.5,
+                      "usage_weekly": 25.5
+                    }
+                  ]
+                },
+                "schema": {
+                  "example": {
+                    "data": [
+                      {
+                        "byok_usage": 17.38,
+                        "byok_usage_daily": 17.38,
+                        "byok_usage_monthly": 17.38,
+                        "byok_usage_weekly": 17.38,
+                        "created_at": "2025-08-24T10:30:00Z",
+                        "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                        "disabled": false,
+                        "expires_at": "2027-12-31T23:59:59Z",
+                        "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                        "include_byok_in_limit": false,
+                        "label": "Production API Key",
+                        "limit": 100,
+                        "limit_remaining": 74.5,
+                        "limit_reset": "monthly",
+                        "name": "My Production Key",
+                        "updated_at": "2025-08-24T15:45:00Z",
+                        "usage": 25.5,
+                        "usage_daily": 25.5,
+                        "usage_monthly": 25.5,
+                        "usage_weekly": 25.5
+                      }
+                    ]
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "List of API keys",
+                      "items": {
+                        "example": {
+                          "byok_usage": 17.38,
+                          "byok_usage_daily": 17.38,
+                          "byok_usage_monthly": 17.38,
+                          "byok_usage_weekly": 17.38,
+                          "created_at": "2025-08-24T10:30:00Z",
+                          "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                          "disabled": false,
+                          "expires_at": "2027-12-31T23:59:59Z",
+                          "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                          "include_byok_in_limit": false,
+                          "label": "sk-or-v1-0e6...1c96",
+                          "limit": 100,
+                          "limit_remaining": 74.5,
+                          "limit_reset": "monthly",
+                          "name": "My Production Key",
+                          "updated_at": "2025-08-24T15:45:00Z",
+                          "usage": 25.5,
+                          "usage_daily": 25.5,
+                          "usage_monthly": 25.5,
+                          "usage_weekly": 25.5
+                        },
+                        "properties": {
+                          "byok_usage": {
+                            "description": "Total external BYOK usage (in USD) for the API key",
+                            "example": 17.38,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "byok_usage_daily": {
+                            "description": "External BYOK usage (in USD) for the current UTC day",
+                            "example": 17.38,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "byok_usage_monthly": {
+                            "description": "External BYOK usage (in USD) for current UTC month",
+                            "example": 17.38,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "byok_usage_weekly": {
+                            "description": "External BYOK usage (in USD) for the current UTC week (Monday-Sunday)",
+                            "example": 17.38,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "created_at": {
+                            "description": "ISO 8601 timestamp of when the API key was created",
+                            "example": "2025-08-24T10:30:00Z",
+                            "type": "string"
+                          },
+                          "creator_user_id": {
+                            "description": "The user ID of the key creator. For organization-owned keys, this is the member who created the key. For individual users, this is the user's own ID.",
+                            "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "disabled": {
+                            "description": "Whether the API key is disabled",
+                            "example": false,
+                            "type": "boolean"
+                          },
+                          "expires_at": {
+                            "description": "ISO 8601 UTC timestamp when the API key expires, or null if no expiration",
+                            "example": "2027-12-31T23:59:59Z",
+                            "format": "date-time",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "hash": {
+                            "description": "Unique hash identifier for the API key",
+                            "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                            "type": "string"
+                          },
+                          "include_byok_in_limit": {
+                            "description": "Whether to include external BYOK usage in the credit limit",
+                            "example": false,
+                            "type": "boolean"
+                          },
+                          "label": {
+                            "description": "Human-readable label for the API key",
+                            "example": "sk-or-v1-0e6...1c96",
+                            "type": "string"
+                          },
+                          "limit": {
+                            "description": "Spending limit for the API key in USD",
+                            "example": 100,
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "limit_remaining": {
+                            "description": "Remaining spending limit in USD",
+                            "example": 74.5,
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "limit_reset": {
+                            "description": "Type of limit reset for the API key",
+                            "example": "monthly",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the API key",
+                            "example": "My Production Key",
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "description": "ISO 8601 timestamp of when the API key was last updated",
+                            "example": "2025-08-24T15:45:00Z",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "usage": {
+                            "description": "Total OpenRouter credit usage (in USD) for the API key",
+                            "example": 25.5,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "usage_daily": {
+                            "description": "OpenRouter credit usage (in USD) for the current UTC day",
+                            "example": 25.5,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "usage_monthly": {
+                            "description": "OpenRouter credit usage (in USD) for the current UTC month",
+                            "example": 25.5,
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "usage_weekly": {
+                            "description": "OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)",
+                            "example": 25.5,
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "hash",
+                          "name",
+                          "label",
+                          "disabled",
+                          "limit",
+                          "limit_remaining",
+                          "limit_reset",
+                          "include_byok_in_limit",
+                          "usage",
+                          "usage_daily",
+                          "usage_weekly",
+                          "usage_monthly",
+                          "byok_usage",
+                          "byok_usage_daily",
+                          "byok_usage_weekly",
+                          "byok_usage_monthly",
+                          "created_at",
+                          "updated_at",
+                          "creator_user_id"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "List of API keys"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List API keys",
+        "tags": [
+          "API Keys"
+        ],
+        "x-speakeasy-name-override": "list"
+      },
+      "post": {
+        "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "createKeys",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "expires_at": "2027-12-31T23:59:59Z",
+                "include_byok_in_limit": true,
+                "limit": 50,
+                "limit_reset": "monthly",
+                "name": "My New API Key"
+              },
+              "schema": {
+                "example": {
+                  "expires_at": "2027-12-31T23:59:59Z",
+                  "include_byok_in_limit": true,
+                  "limit": 50,
+                  "limit_reset": "monthly",
+                  "name": "My New API Key"
+                },
+                "properties": {
+                  "creator_user_id": {
+                    "description": "Optional user ID of the key creator. Only meaningful for organization-owned keys where a specific member is creating the key.",
+                    "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "minLength": 1,
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "expires_at": {
+                    "description": "Optional ISO 8601 UTC timestamp when the API key should expire. Must be UTC, other timezones will be rejected",
+                    "example": "2027-12-31T23:59:59Z",
+                    "format": "date-time",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "include_byok_in_limit": {
+                    "description": "Whether to include BYOK usage in the limit",
+                    "example": true,
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "description": "Optional spending limit for the API key in USD",
+                    "example": 50,
+                    "format": "double",
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "limit_reset": {
+                    "description": "Type of limit reset for the API key (daily, weekly, monthly, or null for no reset). Resets happen automatically at midnight UTC, and weeks are Monday through Sunday.",
+                    "enum": [
+                      "daily",
+                      "weekly",
+                      "monthly",
+                      null
+                    ],
+                    "example": "monthly",
+                    "nullable": true,
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "name": {
+                    "description": "Name for the new API key",
+                    "example": "My New API Key",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "byok_usage": 0,
+                    "byok_usage_daily": 0,
+                    "byok_usage_monthly": 0,
+                    "byok_usage_weekly": 0,
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "disabled": false,
+                    "expires_at": "2027-12-31T23:59:59Z",
+                    "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                    "include_byok_in_limit": true,
+                    "label": "My New API Key",
+                    "limit": 50,
+                    "limit_remaining": 50,
+                    "limit_reset": "monthly",
+                    "name": "My New API Key",
+                    "updated_at": null,
+                    "usage": 0,
+                    "usage_daily": 0,
+                    "usage_monthly": 0,
+                    "usage_weekly": 0
+                  },
+                  "key": "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"
+                },
+                "schema": {
+                  "example": {
+                    "data": {
+                      "byok_usage": 0,
+                      "byok_usage_daily": 0,
+                      "byok_usage_monthly": 0,
+                      "byok_usage_weekly": 0,
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "disabled": false,
+                      "expires_at": "2027-12-31T23:59:59Z",
+                      "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                      "include_byok_in_limit": true,
+                      "label": "My New API Key",
+                      "limit": 50,
+                      "limit_remaining": 50,
+                      "limit_reset": "monthly",
+                      "name": "My New API Key",
+                      "updated_at": null,
+                      "usage": 0,
+                      "usage_daily": 0,
+                      "usage_monthly": 0,
+                      "usage_weekly": 0
+                    },
+                    "key": "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"
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "The created API key information",
+                      "example": {
+                        "byok_usage": 17.38,
+                        "byok_usage_daily": 17.38,
+                        "byok_usage_monthly": 17.38,
+                        "byok_usage_weekly": 17.38,
+                        "created_at": "2025-08-24T10:30:00Z",
+                        "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                        "disabled": false,
+                        "expires_at": "2027-12-31T23:59:59Z",
+                        "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                        "include_byok_in_limit": false,
+                        "label": "sk-or-v1-0e6...1c96",
+                        "limit": 100,
+                        "limit_remaining": 74.5,
+                        "limit_reset": "monthly",
+                        "name": "My Production Key",
+                        "updated_at": "2025-08-24T15:45:00Z",
+                        "usage": 25.5,
+                        "usage_daily": 25.5,
+                        "usage_monthly": 25.5,
+                        "usage_weekly": 25.5
+                      },
+                      "properties": {
+                        "byok_usage": {
+                          "description": "Total external BYOK usage (in USD) for the API key",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_daily": {
+                          "description": "External BYOK usage (in USD) for the current UTC day",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_monthly": {
+                          "description": "External BYOK usage (in USD) for current UTC month",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_weekly": {
+                          "description": "External BYOK usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "created_at": {
+                          "description": "ISO 8601 timestamp of when the API key was created",
+                          "example": "2025-08-24T10:30:00Z",
+                          "type": "string"
+                        },
+                        "creator_user_id": {
+                          "description": "The user ID of the key creator. For organization-owned keys, this is the member who created the key. For individual users, this is the user's own ID.",
+                          "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "disabled": {
+                          "description": "Whether the API key is disabled",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "expires_at": {
+                          "description": "ISO 8601 UTC timestamp when the API key expires, or null if no expiration",
+                          "example": "2027-12-31T23:59:59Z",
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "hash": {
+                          "description": "Unique hash identifier for the API key",
+                          "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                          "type": "string"
+                        },
+                        "include_byok_in_limit": {
+                          "description": "Whether to include external BYOK usage in the credit limit",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "description": "Human-readable label for the API key",
+                          "example": "sk-or-v1-0e6...1c96",
+                          "type": "string"
+                        },
+                        "limit": {
+                          "description": "Spending limit for the API key in USD",
+                          "example": 100,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_remaining": {
+                          "description": "Remaining spending limit in USD",
+                          "example": 74.5,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_reset": {
+                          "description": "Type of limit reset for the API key",
+                          "example": "monthly",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the API key",
+                          "example": "My Production Key",
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "description": "ISO 8601 timestamp of when the API key was last updated",
+                          "example": "2025-08-24T15:45:00Z",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "usage": {
+                          "description": "Total OpenRouter credit usage (in USD) for the API key",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_daily": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC day",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_monthly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC month",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_weekly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "hash",
+                        "name",
+                        "label",
+                        "disabled",
+                        "limit",
+                        "limit_remaining",
+                        "limit_reset",
+                        "include_byok_in_limit",
+                        "usage",
+                        "usage_daily",
+                        "usage_weekly",
+                        "usage_monthly",
+                        "byok_usage",
+                        "byok_usage_daily",
+                        "byok_usage_weekly",
+                        "byok_usage_monthly",
+                        "created_at",
+                        "updated_at",
+                        "creator_user_id"
+                      ],
+                      "type": "object"
+                    },
+                    "key": {
+                      "description": "The actual API key string (only shown once)",
+                      "example": "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",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "key"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API key created successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Create a new API key",
+        "tags": [
+          "API Keys"
+        ],
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/keys/{hash}": {
+      "delete": {
+        "description": "Delete an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "deleteKeys",
+        "parameters": [
+          {
+            "description": "The hash identifier of the API key to delete",
+            "in": "path",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "description": "The hash identifier of the API key to delete",
+              "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "deleted": true
+                },
+                "schema": {
+                  "example": {
+                    "deleted": true
+                  },
+                  "properties": {
+                    "deleted": {
+                      "const": true,
+                      "description": "Confirmation that the API key was deleted",
+                      "example": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "deleted"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API key deleted successfully"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Delete an API key",
+        "tags": [
+          "API Keys"
+        ],
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "description": "Get a single API key by hash. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getKey",
+        "parameters": [
+          {
+            "description": "The hash identifier of the API key to retrieve",
+            "in": "path",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "description": "The hash identifier of the API key to retrieve",
+              "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "byok_usage": 17.38,
+                    "byok_usage_daily": 17.38,
+                    "byok_usage_monthly": 17.38,
+                    "byok_usage_weekly": 17.38,
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "disabled": false,
+                    "expires_at": "2027-12-31T23:59:59Z",
+                    "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                    "include_byok_in_limit": false,
+                    "label": "Production API Key",
+                    "limit": 100,
+                    "limit_remaining": 74.5,
+                    "limit_reset": "monthly",
+                    "name": "My Production Key",
+                    "updated_at": "2025-08-24T15:45:00Z",
+                    "usage": 25.5,
+                    "usage_daily": 25.5,
+                    "usage_monthly": 25.5,
+                    "usage_weekly": 25.5
+                  }
+                },
+                "schema": {
+                  "example": {
+                    "data": {
+                      "byok_usage": 17.38,
+                      "byok_usage_daily": 17.38,
+                      "byok_usage_monthly": 17.38,
+                      "byok_usage_weekly": 17.38,
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "disabled": false,
+                      "expires_at": "2027-12-31T23:59:59Z",
+                      "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                      "include_byok_in_limit": false,
+                      "label": "Production API Key",
+                      "limit": 100,
+                      "limit_remaining": 74.5,
+                      "limit_reset": "monthly",
+                      "name": "My Production Key",
+                      "updated_at": "2025-08-24T15:45:00Z",
+                      "usage": 25.5,
+                      "usage_daily": 25.5,
+                      "usage_monthly": 25.5,
+                      "usage_weekly": 25.5
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "The API key information",
+                      "example": {
+                        "byok_usage": 17.38,
+                        "byok_usage_daily": 17.38,
+                        "byok_usage_monthly": 17.38,
+                        "byok_usage_weekly": 17.38,
+                        "created_at": "2025-08-24T10:30:00Z",
+                        "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                        "disabled": false,
+                        "expires_at": "2027-12-31T23:59:59Z",
+                        "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                        "include_byok_in_limit": false,
+                        "label": "sk-or-v1-0e6...1c96",
+                        "limit": 100,
+                        "limit_remaining": 74.5,
+                        "limit_reset": "monthly",
+                        "name": "My Production Key",
+                        "updated_at": "2025-08-24T15:45:00Z",
+                        "usage": 25.5,
+                        "usage_daily": 25.5,
+                        "usage_monthly": 25.5,
+                        "usage_weekly": 25.5
+                      },
+                      "properties": {
+                        "byok_usage": {
+                          "description": "Total external BYOK usage (in USD) for the API key",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_daily": {
+                          "description": "External BYOK usage (in USD) for the current UTC day",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_monthly": {
+                          "description": "External BYOK usage (in USD) for current UTC month",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_weekly": {
+                          "description": "External BYOK usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "created_at": {
+                          "description": "ISO 8601 timestamp of when the API key was created",
+                          "example": "2025-08-24T10:30:00Z",
+                          "type": "string"
+                        },
+                        "creator_user_id": {
+                          "description": "The user ID of the key creator. For organization-owned keys, this is the member who created the key. For individual users, this is the user's own ID.",
+                          "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "disabled": {
+                          "description": "Whether the API key is disabled",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "expires_at": {
+                          "description": "ISO 8601 UTC timestamp when the API key expires, or null if no expiration",
+                          "example": "2027-12-31T23:59:59Z",
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "hash": {
+                          "description": "Unique hash identifier for the API key",
+                          "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                          "type": "string"
+                        },
+                        "include_byok_in_limit": {
+                          "description": "Whether to include external BYOK usage in the credit limit",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "description": "Human-readable label for the API key",
+                          "example": "sk-or-v1-0e6...1c96",
+                          "type": "string"
+                        },
+                        "limit": {
+                          "description": "Spending limit for the API key in USD",
+                          "example": 100,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_remaining": {
+                          "description": "Remaining spending limit in USD",
+                          "example": 74.5,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_reset": {
+                          "description": "Type of limit reset for the API key",
+                          "example": "monthly",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the API key",
+                          "example": "My Production Key",
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "description": "ISO 8601 timestamp of when the API key was last updated",
+                          "example": "2025-08-24T15:45:00Z",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "usage": {
+                          "description": "Total OpenRouter credit usage (in USD) for the API key",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_daily": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC day",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_monthly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC month",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_weekly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "hash",
+                        "name",
+                        "label",
+                        "disabled",
+                        "limit",
+                        "limit_remaining",
+                        "limit_reset",
+                        "include_byok_in_limit",
+                        "usage",
+                        "usage_daily",
+                        "usage_weekly",
+                        "usage_monthly",
+                        "byok_usage",
+                        "byok_usage_daily",
+                        "byok_usage_weekly",
+                        "byok_usage_monthly",
+                        "created_at",
+                        "updated_at",
+                        "creator_user_id"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API key details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get a single API key",
+        "tags": [
+          "API Keys"
+        ],
+        "x-speakeasy-name-override": "get"
+      },
+      "patch": {
+        "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "updateKeys",
+        "parameters": [
+          {
+            "description": "The hash identifier of the API key to update",
+            "in": "path",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "description": "The hash identifier of the API key to update",
+              "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "disabled": false,
+                "include_byok_in_limit": true,
+                "limit": 75,
+                "limit_reset": "daily",
+                "name": "Updated API Key Name"
+              },
+              "schema": {
+                "example": {
+                  "disabled": false,
+                  "include_byok_in_limit": true,
+                  "limit": 75,
+                  "limit_reset": "daily",
+                  "name": "Updated API Key Name"
+                },
+                "properties": {
+                  "disabled": {
+                    "description": "Whether to disable the API key",
+                    "example": false,
+                    "type": "boolean"
+                  },
+                  "include_byok_in_limit": {
+                    "description": "Whether to include BYOK usage in the limit",
+                    "example": true,
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "description": "New spending limit for the API key in USD",
+                    "example": 75,
+                    "format": "double",
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "limit_reset": {
+                    "description": "New limit reset type for the API key (daily, weekly, monthly, or null for no reset). Resets happen automatically at midnight UTC, and weeks are Monday through Sunday.",
+                    "enum": [
+                      "daily",
+                      "weekly",
+                      "monthly",
+                      null
+                    ],
+                    "example": "daily",
+                    "nullable": true,
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "name": {
+                    "description": "New name for the API key",
+                    "example": "Updated API Key Name",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "byok_usage": 17.38,
+                    "byok_usage_daily": 17.38,
+                    "byok_usage_monthly": 17.38,
+                    "byok_usage_weekly": 17.38,
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "disabled": false,
+                    "expires_at": null,
+                    "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                    "include_byok_in_limit": true,
+                    "label": "Updated API Key Name",
+                    "limit": 75,
+                    "limit_remaining": 49.5,
+                    "limit_reset": "daily",
+                    "name": "Updated API Key Name",
+                    "updated_at": "2025-08-24T16:00:00Z",
+                    "usage": 25.5,
+                    "usage_daily": 25.5,
+                    "usage_monthly": 25.5,
+                    "usage_weekly": 25.5
+                  }
+                },
+                "schema": {
+                  "example": {
+                    "data": {
+                      "byok_usage": 17.38,
+                      "byok_usage_daily": 17.38,
+                      "byok_usage_monthly": 17.38,
+                      "byok_usage_weekly": 17.38,
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "disabled": false,
+                      "expires_at": null,
+                      "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                      "include_byok_in_limit": true,
+                      "label": "Updated API Key Name",
+                      "limit": 75,
+                      "limit_remaining": 49.5,
+                      "limit_reset": "daily",
+                      "name": "Updated API Key Name",
+                      "updated_at": "2025-08-24T16:00:00Z",
+                      "usage": 25.5,
+                      "usage_daily": 25.5,
+                      "usage_monthly": 25.5,
+                      "usage_weekly": 25.5
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "description": "The updated API key information",
+                      "example": {
+                        "byok_usage": 17.38,
+                        "byok_usage_daily": 17.38,
+                        "byok_usage_monthly": 17.38,
+                        "byok_usage_weekly": 17.38,
+                        "created_at": "2025-08-24T10:30:00Z",
+                        "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                        "disabled": false,
+                        "expires_at": "2027-12-31T23:59:59Z",
+                        "hash": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                        "include_byok_in_limit": false,
+                        "label": "sk-or-v1-0e6...1c96",
+                        "limit": 100,
+                        "limit_remaining": 74.5,
+                        "limit_reset": "monthly",
+                        "name": "My Production Key",
+                        "updated_at": "2025-08-24T15:45:00Z",
+                        "usage": 25.5,
+                        "usage_daily": 25.5,
+                        "usage_monthly": 25.5,
+                        "usage_weekly": 25.5
+                      },
+                      "properties": {
+                        "byok_usage": {
+                          "description": "Total external BYOK usage (in USD) for the API key",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_daily": {
+                          "description": "External BYOK usage (in USD) for the current UTC day",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_monthly": {
+                          "description": "External BYOK usage (in USD) for current UTC month",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "byok_usage_weekly": {
+                          "description": "External BYOK usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 17.38,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "created_at": {
+                          "description": "ISO 8601 timestamp of when the API key was created",
+                          "example": "2025-08-24T10:30:00Z",
+                          "type": "string"
+                        },
+                        "creator_user_id": {
+                          "description": "The user ID of the key creator. For organization-owned keys, this is the member who created the key. For individual users, this is the user's own ID.",
+                          "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "disabled": {
+                          "description": "Whether the API key is disabled",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "expires_at": {
+                          "description": "ISO 8601 UTC timestamp when the API key expires, or null if no expiration",
+                          "example": "2027-12-31T23:59:59Z",
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "hash": {
+                          "description": "Unique hash identifier for the API key",
+                          "example": "f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943",
+                          "type": "string"
+                        },
+                        "include_byok_in_limit": {
+                          "description": "Whether to include external BYOK usage in the credit limit",
+                          "example": false,
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "description": "Human-readable label for the API key",
+                          "example": "sk-or-v1-0e6...1c96",
+                          "type": "string"
+                        },
+                        "limit": {
+                          "description": "Spending limit for the API key in USD",
+                          "example": 100,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_remaining": {
+                          "description": "Remaining spending limit in USD",
+                          "example": 74.5,
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "limit_reset": {
+                          "description": "Type of limit reset for the API key",
+                          "example": "monthly",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the API key",
+                          "example": "My Production Key",
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "description": "ISO 8601 timestamp of when the API key was last updated",
+                          "example": "2025-08-24T15:45:00Z",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "usage": {
+                          "description": "Total OpenRouter credit usage (in USD) for the API key",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_daily": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC day",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_monthly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC month",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "usage_weekly": {
+                          "description": "OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)",
+                          "example": 25.5,
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "hash",
+                        "name",
+                        "label",
+                        "disabled",
+                        "limit",
+                        "limit_remaining",
+                        "limit_reset",
+                        "include_byok_in_limit",
+                        "usage",
+                        "usage_daily",
+                        "usage_weekly",
+                        "usage_monthly",
+                        "byok_usage",
+                        "byok_usage_daily",
+                        "byok_usage_weekly",
+                        "byok_usage_monthly",
+                        "created_at",
+                        "updated_at",
+                        "creator_user_id"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API key updated successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Update an API key",
+        "tags": [
+          "API Keys"
+        ],
+        "x-speakeasy-name-override": "update"
+      }
+    },
+    "/messages": {
+      "post": {
+        "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
+        "operationId": "createMessages",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "max_tokens": 1024,
+                "messages": [
+                  {
+                    "content": "Hello, how are you?",
+                    "role": "user"
+                  }
+                ],
+                "model": "anthropic/claude-sonnet-4"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/MessagesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "content": [
+                    {
+                      "text": "I'm doing well, thank you for asking! How can I help you today?",
+                      "type": "text"
+                    }
+                  ],
+                  "id": "msg_abc123",
+                  "model": "anthropic/claude-sonnet-4",
+                  "role": "assistant",
+                  "stop_reason": "end_turn",
+                  "type": "message",
+                  "usage": {
+                    "input_tokens": 12,
+                    "output_tokens": 18
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesResult"
+                }
+              },
+              "text/event-stream": {
+                "example": {
+                  "data": {
+                    "delta": {
+                      "text": "Hello",
+                      "type": "text_delta"
+                    },
+                    "index": 0,
+                    "type": "content_block_delta"
+                  },
+                  "event": "content_block_delta"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/MessagesStreamEvents"
+                    },
+                    "event": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "event",
+                    "data"
+                  ],
+                  "type": "object"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Invalid request: messages is required",
+                    "type": "invalid_request_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Invalid API key",
+                    "type": "authentication_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication error"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Permission denied",
+                    "type": "permission_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Model not found",
+                    "type": "not_found_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Not found error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Rate limit exceeded",
+                    "type": "rate_limit_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Internal server error",
+                    "type": "api_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "API error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Service temporarily overloaded",
+                    "type": "overloaded_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Overloaded error"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "message": "Provider is temporarily overloaded",
+                    "type": "overloaded_error"
+                  },
+                  "type": "error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                }
+              }
+            },
+            "description": "Overloaded error"
+          }
+        },
+        "summary": "Create a message",
+        "tags": [
+          "Anthropic Messages"
+        ],
+        "x-speakeasy-ignore": true,
+        "x-speakeasy-name-override": "create",
+        "x-speakeasy-stream-request-field": "stream"
+      }
+    },
+    "/models": {
+      "get": {
+        "operationId": "getModels",
+        "parameters": [
+          {
+            "description": "Filter models by use case category",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "description": "Filter models by use case category",
+              "enum": [
+                "programming",
+                "roleplay",
+                "marketing",
+                "marketing/seo",
+                "technology",
+                "science",
+                "translation",
+                "legal",
+                "finance",
+                "health",
+                "trivia",
+                "academia"
+              ],
+              "example": "programming",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Filter models by supported parameter (comma-separated)",
+            "in": "query",
+            "name": "supported_parameters",
+            "required": false,
+            "schema": {
+              "description": "Filter models by supported parameter (comma-separated)",
+              "example": "temperature",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio, embeddings) or \"all\" to include all models. Defaults to \"text\".",
+            "in": "query",
+            "name": "output_modalities",
+            "required": false,
+            "schema": {
+              "description": "Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio, embeddings) or \"all\" to include all models. Defaults to \"text\".",
+              "example": "text",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "architecture": {
+                        "input_modalities": [
+                          "text"
+                        ],
+                        "instruct_type": "chatml",
+                        "modality": "text->text",
+                        "output_modalities": [
+                          "text"
+                        ],
+                        "tokenizer": "GPT"
+                      },
+                      "canonical_slug": "openai/gpt-4",
+                      "context_length": 8192,
+                      "created": 1692901234,
+                      "default_parameters": null,
+                      "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+                      "expiration_date": null,
+                      "id": "openai/gpt-4",
+                      "knowledge_cutoff": null,
+                      "links": {
+                        "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+                      },
+                      "name": "GPT-4",
+                      "per_request_limits": null,
+                      "pricing": {
+                        "completion": "0.00006",
+                        "image": "0",
+                        "prompt": "0.00003",
+                        "request": "0"
+                      },
+                      "supported_parameters": [
+                        "temperature",
+                        "top_p",
+                        "max_tokens"
+                      ],
+                      "top_provider": {
+                        "context_length": 8192,
+                        "is_moderated": true,
+                        "max_completion_tokens": 4096
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsListResponse"
+                }
+              }
+            },
+            "description": "Returns a list of models or RSS feed"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all models and their properties",
+        "tags": [
+          "Models"
+        ],
+        "x-speakeasy-name-override": "list"
+      }
+    },
+    "/models/count": {
+      "get": {
+        "operationId": "listModelsCount",
+        "parameters": [
+          {
+            "description": "Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio, embeddings) or \"all\" to include all models. Defaults to \"text\".",
+            "in": "query",
+            "name": "output_modalities",
+            "required": false,
+            "schema": {
+              "description": "Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio, embeddings) or \"all\" to include all models. Defaults to \"text\".",
+              "example": "text",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "count": 150
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsCountResponse"
+                }
+              }
+            },
+            "description": "Returns the total count of available models"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get total count of available models",
+        "tags": [
+          "Models"
+        ],
+        "x-speakeasy-name-override": "count"
+      }
+    },
+    "/models/user": {
+      "get": {
+        "description": "List models filtered by user provider preferences, [privacy settings](https://openrouter.ai/docs/guides/privacy/provider-logging), and [guardrails](https://openrouter.ai/docs/guides/features/guardrails). If requesting through `eu.openrouter.ai/api/v1/...` the results will be filtered to models that satisfy [EU in-region routing](https://openrouter.ai/docs/guides/privacy/provider-logging#enterprise-eu-in-region-routing).",
+        "operationId": "listModelsUser",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "architecture": {
+                        "input_modalities": [
+                          "text"
+                        ],
+                        "instruct_type": "chatml",
+                        "modality": "text->text",
+                        "output_modalities": [
+                          "text"
+                        ],
+                        "tokenizer": "GPT"
+                      },
+                      "canonical_slug": "openai/gpt-4",
+                      "context_length": 8192,
+                      "created": 1692901234,
+                      "default_parameters": null,
+                      "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+                      "expiration_date": null,
+                      "id": "openai/gpt-4",
+                      "knowledge_cutoff": null,
+                      "links": {
+                        "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+                      },
+                      "name": "GPT-4",
+                      "per_request_limits": null,
+                      "pricing": {
+                        "completion": "0.00006",
+                        "image": "0",
+                        "prompt": "0.00003",
+                        "request": "0"
+                      },
+                      "supported_parameters": [
+                        "temperature",
+                        "top_p",
+                        "max_tokens"
+                      ],
+                      "top_provider": {
+                        "context_length": 8192,
+                        "is_moderated": true,
+                        "max_completion_tokens": 4096
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsListResponse"
+                }
+              }
+            },
+            "description": "Returns a list of models filtered by user provider preferences"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List models filtered by user provider preferences, privacy settings, and guardrails",
+        "tags": [
+          "Models"
+        ],
+        "x-speakeasy-name-override": "listForUser"
+      }
+    },
+    "/models/{author}/{slug}/endpoints": {
+      "get": {
+        "operationId": "listEndpoints",
+        "parameters": [
+          {
+            "description": "The author/organization of the model",
+            "in": "path",
+            "name": "author",
+            "required": true,
+            "schema": {
+              "description": "The author/organization of the model",
+              "example": "openai",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The model slug",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "The model slug",
+              "example": "gpt-4",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "architecture": {
+                      "input_modalities": [
+                        "text"
+                      ],
+                      "instruct_type": "chatml",
+                      "modality": "text->text",
+                      "output_modalities": [
+                        "text"
+                      ],
+                      "tokenizer": "GPT"
+                    },
+                    "created": 1692901234,
+                    "description": "GPT-4 is a large multimodal model.",
+                    "endpoints": [],
+                    "id": "openai/gpt-4",
+                    "name": "GPT-4"
+                  }
+                },
+                "schema": {
+                  "example": {
+                    "data": {
+                      "architecture": {
+                        "input_modalities": [
+                          "text"
+                        ],
+                        "instruct_type": "chatml",
+                        "modality": "text->text",
+                        "output_modalities": [
+                          "text"
+                        ],
+                        "tokenizer": "GPT"
+                      },
+                      "created": 1692901234,
+                      "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+                      "endpoints": [
+                        {
+                          "context_length": 8192,
+                          "latency_last_30m": {
+                            "p50": 0.25,
+                            "p75": 0.35,
+                            "p90": 0.48,
+                            "p99": 0.85
+                          },
+                          "max_completion_tokens": 4096,
+                          "max_prompt_tokens": 8192,
+                          "model_id": "openai/gpt-4",
+                          "model_name": "GPT-4",
+                          "name": "OpenAI: GPT-4",
+                          "pricing": {
+                            "completion": "0.00006",
+                            "image": "0",
+                            "prompt": "0.00003",
+                            "request": "0"
+                          },
+                          "provider_name": "OpenAI",
+                          "quantization": "fp16",
+                          "status": "default",
+                          "supported_parameters": [
+                            "temperature",
+                            "top_p",
+                            "max_tokens"
+                          ],
+                          "supports_implicit_caching": true,
+                          "tag": "openai",
+                          "throughput_last_30m": {
+                            "p50": 45.2,
+                            "p75": 38.5,
+                            "p90": 28.3,
+                            "p99": 15.1
+                          },
+                          "uptime_last_1d": 99.8,
+                          "uptime_last_30m": 99.5,
+                          "uptime_last_5m": 100
+                        }
+                      ],
+                      "id": "openai/gpt-4",
+                      "name": "GPT-4"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ListEndpointsResponse"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Returns a list of endpoints"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all endpoints for a model",
+        "tags": [
+          "Endpoints"
+        ],
+        "x-speakeasy-name-override": "list"
+      }
+    },
+    "/providers": {
+      "get": {
+        "operationId": "listProviders",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "datacenters": [
+                        "US",
+                        "IE"
+                      ],
+                      "headquarters": "US",
+                      "name": "OpenAI",
+                      "privacy_policy_url": "https://openai.com/privacy",
+                      "slug": "openai",
+                      "status_page_url": "https://status.openai.com",
+                      "terms_of_service_url": "https://openai.com/terms"
+                    }
+                  ]
+                },
+                "schema": {
+                  "example": {
+                    "data": [
+                      {
+                        "datacenters": [
+                          "US",
+                          "IE"
+                        ],
+                        "headquarters": "US",
+                        "name": "OpenAI",
+                        "privacy_policy_url": "https://openai.com/privacy",
+                        "slug": "openai",
+                        "status_page_url": "https://status.openai.com",
+                        "terms_of_service_url": "https://openai.com/terms"
+                      }
+                    ]
+                  },
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "example": {
+                          "datacenters": [
+                            "US",
+                            "IE"
+                          ],
+                          "headquarters": "US",
+                          "name": "OpenAI",
+                          "privacy_policy_url": "https://openai.com/privacy",
+                          "slug": "openai",
+                          "status_page_url": "https://status.openai.com",
+                          "terms_of_service_url": "https://openai.com/terms"
+                        },
+                        "properties": {
+                          "datacenters": {
+                            "description": "ISO 3166-1 Alpha-2 country codes of the provider datacenter locations",
+                            "example": [
+                              "US",
+                              "IE"
+                            ],
+                            "items": {
+                              "enum": [
+                                "AD",
+                                "AE",
+                                "AF",
+                                "AG",
+                                "AI",
+                                "AL",
+                                "AM",
+                                "AO",
+                                "AQ",
+                                "AR",
+                                "AS",
+                                "AT",
+                                "AU",
+                                "AW",
+                                "AX",
+                                "AZ",
+                                "BA",
+                                "BB",
+                                "BD",
+                                "BE",
+                                "BF",
+                                "BG",
+                                "BH",
+                                "BI",
+                                "BJ",
+                                "BL",
+                                "BM",
+                                "BN",
+                                "BO",
+                                "BQ",
+                                "BR",
+                                "BS",
+                                "BT",
+                                "BV",
+                                "BW",
+                                "BY",
+                                "BZ",
+                                "CA",
+                                "CC",
+                                "CD",
+                                "CF",
+                                "CG",
+                                "CH",
+                                "CI",
+                                "CK",
+                                "CL",
+                                "CM",
+                                "CN",
+                                "CO",
+                                "CR",
+                                "CU",
+                                "CV",
+                                "CW",
+                                "CX",
+                                "CY",
+                                "CZ",
+                                "DE",
+                                "DJ",
+                                "DK",
+                                "DM",
+                                "DO",
+                                "DZ",
+                                "EC",
+                                "EE",
+                                "EG",
+                                "EH",
+                                "ER",
+                                "ES",
+                                "ET",
+                                "FI",
+                                "FJ",
+                                "FK",
+                                "FM",
+                                "FO",
+                                "FR",
+                                "GA",
+                                "GB",
+                                "GD",
+                                "GE",
+                                "GF",
+                                "GG",
+                                "GH",
+                                "GI",
+                                "GL",
+                                "GM",
+                                "GN",
+                                "GP",
+                                "GQ",
+                                "GR",
+                                "GS",
+                                "GT",
+                                "GU",
+                                "GW",
+                                "GY",
+                                "HK",
+                                "HM",
+                                "HN",
+                                "HR",
+                                "HT",
+                                "HU",
+                                "ID",
+                                "IE",
+                                "IL",
+                                "IM",
+                                "IN",
+                                "IO",
+                                "IQ",
+                                "IR",
+                                "IS",
+                                "IT",
+                                "JE",
+                                "JM",
+                                "JO",
+                                "JP",
+                                "KE",
+                                "KG",
+                                "KH",
+                                "KI",
+                                "KM",
+                                "KN",
+                                "KP",
+                                "KR",
+                                "KW",
+                                "KY",
+                                "KZ",
+                                "LA",
+                                "LB",
+                                "LC",
+                                "LI",
+                                "LK",
+                                "LR",
+                                "LS",
+                                "LT",
+                                "LU",
+                                "LV",
+                                "LY",
+                                "MA",
+                                "MC",
+                                "MD",
+                                "ME",
+                                "MF",
+                                "MG",
+                                "MH",
+                                "MK",
+                                "ML",
+                                "MM",
+                                "MN",
+                                "MO",
+                                "MP",
+                                "MQ",
+                                "MR",
+                                "MS",
+                                "MT",
+                                "MU",
+                                "MV",
+                                "MW",
+                                "MX",
+                                "MY",
+                                "MZ",
+                                "NA",
+                                "NC",
+                                "NE",
+                                "NF",
+                                "NG",
+                                "NI",
+                                "NL",
+                                "NO",
+                                "NP",
+                                "NR",
+                                "NU",
+                                "NZ",
+                                "OM",
+                                "PA",
+                                "PE",
+                                "PF",
+                                "PG",
+                                "PH",
+                                "PK",
+                                "PL",
+                                "PM",
+                                "PN",
+                                "PR",
+                                "PS",
+                                "PT",
+                                "PW",
+                                "PY",
+                                "QA",
+                                "RE",
+                                "RO",
+                                "RS",
+                                "RU",
+                                "RW",
+                                "SA",
+                                "SB",
+                                "SC",
+                                "SD",
+                                "SE",
+                                "SG",
+                                "SH",
+                                "SI",
+                                "SJ",
+                                "SK",
+                                "SL",
+                                "SM",
+                                "SN",
+                                "SO",
+                                "SR",
+                                "SS",
+                                "ST",
+                                "SV",
+                                "SX",
+                                "SY",
+                                "SZ",
+                                "TC",
+                                "TD",
+                                "TF",
+                                "TG",
+                                "TH",
+                                "TJ",
+                                "TK",
+                                "TL",
+                                "TM",
+                                "TN",
+                                "TO",
+                                "TR",
+                                "TT",
+                                "TV",
+                                "TW",
+                                "TZ",
+                                "UA",
+                                "UG",
+                                "UM",
+                                "US",
+                                "UY",
+                                "UZ",
+                                "VA",
+                                "VC",
+                                "VE",
+                                "VG",
+                                "VI",
+                                "VN",
+                                "VU",
+                                "WF",
+                                "WS",
+                                "YE",
+                                "YT",
+                                "ZA",
+                                "ZM",
+                                "ZW"
+                              ],
+                              "type": "string",
+                              "x-speakeasy-unknown-values": "allow"
+                            },
+                            "nullable": true,
+                            "type": "array"
+                          },
+                          "headquarters": {
+                            "description": "ISO 3166-1 Alpha-2 country code of the provider headquarters",
+                            "enum": [
+                              "AD",
+                              "AE",
+                              "AF",
+                              "AG",
+                              "AI",
+                              "AL",
+                              "AM",
+                              "AO",
+                              "AQ",
+                              "AR",
+                              "AS",
+                              "AT",
+                              "AU",
+                              "AW",
+                              "AX",
+                              "AZ",
+                              "BA",
+                              "BB",
+                              "BD",
+                              "BE",
+                              "BF",
+                              "BG",
+                              "BH",
+                              "BI",
+                              "BJ",
+                              "BL",
+                              "BM",
+                              "BN",
+                              "BO",
+                              "BQ",
+                              "BR",
+                              "BS",
+                              "BT",
+                              "BV",
+                              "BW",
+                              "BY",
+                              "BZ",
+                              "CA",
+                              "CC",
+                              "CD",
+                              "CF",
+                              "CG",
+                              "CH",
+                              "CI",
+                              "CK",
+                              "CL",
+                              "CM",
+                              "CN",
+                              "CO",
+                              "CR",
+                              "CU",
+                              "CV",
+                              "CW",
+                              "CX",
+                              "CY",
+                              "CZ",
+                              "DE",
+                              "DJ",
+                              "DK",
+                              "DM",
+                              "DO",
+                              "DZ",
+                              "EC",
+                              "EE",
+                              "EG",
+                              "EH",
+                              "ER",
+                              "ES",
+                              "ET",
+                              "FI",
+                              "FJ",
+                              "FK",
+                              "FM",
+                              "FO",
+                              "FR",
+                              "GA",
+                              "GB",
+                              "GD",
+                              "GE",
+                              "GF",
+                              "GG",
+                              "GH",
+                              "GI",
+                              "GL",
+                              "GM",
+                              "GN",
+                              "GP",
+                              "GQ",
+                              "GR",
+                              "GS",
+                              "GT",
+                              "GU",
+                              "GW",
+                              "GY",
+                              "HK",
+                              "HM",
+                              "HN",
+                              "HR",
+                              "HT",
+                              "HU",
+                              "ID",
+                              "IE",
+                              "IL",
+                              "IM",
+                              "IN",
+                              "IO",
+                              "IQ",
+                              "IR",
+                              "IS",
+                              "IT",
+                              "JE",
+                              "JM",
+                              "JO",
+                              "JP",
+                              "KE",
+                              "KG",
+                              "KH",
+                              "KI",
+                              "KM",
+                              "KN",
+                              "KP",
+                              "KR",
+                              "KW",
+                              "KY",
+                              "KZ",
+                              "LA",
+                              "LB",
+                              "LC",
+                              "LI",
+                              "LK",
+                              "LR",
+                              "LS",
+                              "LT",
+                              "LU",
+                              "LV",
+                              "LY",
+                              "MA",
+                              "MC",
+                              "MD",
+                              "ME",
+                              "MF",
+                              "MG",
+                              "MH",
+                              "MK",
+                              "ML",
+                              "MM",
+                              "MN",
+                              "MO",
+                              "MP",
+                              "MQ",
+                              "MR",
+                              "MS",
+                              "MT",
+                              "MU",
+                              "MV",
+                              "MW",
+                              "MX",
+                              "MY",
+                              "MZ",
+                              "NA",
+                              "NC",
+                              "NE",
+                              "NF",
+                              "NG",
+                              "NI",
+                              "NL",
+                              "NO",
+                              "NP",
+                              "NR",
+                              "NU",
+                              "NZ",
+                              "OM",
+                              "PA",
+                              "PE",
+                              "PF",
+                              "PG",
+                              "PH",
+                              "PK",
+                              "PL",
+                              "PM",
+                              "PN",
+                              "PR",
+                              "PS",
+                              "PT",
+                              "PW",
+                              "PY",
+                              "QA",
+                              "RE",
+                              "RO",
+                              "RS",
+                              "RU",
+                              "RW",
+                              "SA",
+                              "SB",
+                              "SC",
+                              "SD",
+                              "SE",
+                              "SG",
+                              "SH",
+                              "SI",
+                              "SJ",
+                              "SK",
+                              "SL",
+                              "SM",
+                              "SN",
+                              "SO",
+                              "SR",
+                              "SS",
+                              "ST",
+                              "SV",
+                              "SX",
+                              "SY",
+                              "SZ",
+                              "TC",
+                              "TD",
+                              "TF",
+                              "TG",
+                              "TH",
+                              "TJ",
+                              "TK",
+                              "TL",
+                              "TM",
+                              "TN",
+                              "TO",
+                              "TR",
+                              "TT",
+                              "TV",
+                              "TW",
+                              "TZ",
+                              "UA",
+                              "UG",
+                              "UM",
+                              "US",
+                              "UY",
+                              "UZ",
+                              "VA",
+                              "VC",
+                              "VE",
+                              "VG",
+                              "VI",
+                              "VN",
+                              "VU",
+                              "WF",
+                              "WS",
+                              "YE",
+                              "YT",
+                              "ZA",
+                              "ZM",
+                              "ZW",
+                              null
+                            ],
+                            "example": "US",
+                            "nullable": true,
+                            "type": "string",
+                            "x-speakeasy-unknown-values": "allow"
+                          },
+                          "name": {
+                            "description": "Display name of the provider",
+                            "example": "OpenAI",
+                            "type": "string"
+                          },
+                          "privacy_policy_url": {
+                            "description": "URL to the provider's privacy policy",
+                            "example": "https://openai.com/privacy",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "slug": {
+                            "description": "URL-friendly identifier for the provider",
+                            "example": "openai",
+                            "type": "string"
+                          },
+                          "status_page_url": {
+                            "description": "URL to the provider's status page",
+                            "example": "https://status.openai.com",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "terms_of_service_url": {
+                            "description": "URL to the provider's terms of service",
+                            "example": "https://openai.com/terms",
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "slug",
+                          "privacy_policy_url"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Returns a list of providers"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all providers",
+        "tags": [
+          "Providers"
+        ],
+        "x-speakeasy-name-override": "list"
+      }
+    },
+    "/responses": {
+      "post": {
+        "description": "Creates a streaming or non-streaming response using OpenResponses API format",
+        "operationId": "createResponses",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "input": "Tell me a joke",
+                "model": "openai/gpt-4o"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ResponsesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "created_at": 1700000000,
+                  "id": "resp_abc123",
+                  "model": "openai/gpt-4o",
+                  "object": "response",
+                  "output": [
+                    {
+                      "content": [
+                        {
+                          "text": "Why did the chicken cross the road? To get to the other side!",
+                          "type": "output_text"
+                        }
+                      ],
+                      "role": "assistant",
+                      "type": "message"
+                    }
+                  ],
+                  "status": "completed",
+                  "usage": {
+                    "completion_tokens": 20,
+                    "prompt_tokens": 10,
+                    "total_tokens": 30
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/OpenResponsesResult"
+                }
+              },
+              "text/event-stream": {
+                "example": {
+                  "data": {
+                    "delta": "Hello",
+                    "type": "response.output_text.delta"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/StreamEvents"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 408,
+                    "message": "Operation timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RequestTimeoutResponse"
+                }
+              }
+            },
+            "description": "Request Timeout - Operation exceeded time limit"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 413,
+                    "message": "Request payload too large"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PayloadTooLargeResponse"
+                }
+              }
+            },
+            "description": "Payload Too Large - Request payload exceeds size limits"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 422,
+                    "message": "Invalid argument"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityResponse"
+                }
+              }
+            },
+            "description": "Unprocessable Entity - Semantic validation failure"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Create a response",
+        "tags": [
+          "beta.responses"
+        ],
+        "x-speakeasy-name-override": "send",
+        "x-speakeasy-stream-request-field": "stream"
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Production server",
+      "url": "https://openrouter.ai/api/v1",
+      "x-speakeasy-server-id": "production"
+    }
+  ],
+  "tags": [
+    {
+      "description": "API key management endpoints",
+      "name": "API Keys"
+    },
+    {
+      "description": "Analytics and usage endpoints",
+      "name": "Analytics"
+    },
+    {
+      "description": "Anthropic Messages endpoints",
+      "name": "Anthropic Messages"
+    },
+    {
+      "description": "Chat completion endpoints",
+      "name": "Chat"
+    },
+    {
+      "description": "Credit management endpoints",
+      "name": "Credits"
+    },
+    {
+      "description": "Text embedding endpoints",
+      "name": "Embeddings"
+    },
+    {
+      "description": "Endpoint information",
+      "name": "Endpoints"
+    },
+    {
+      "description": "Generation history endpoints",
+      "name": "Generations"
+    },
+    {
+      "description": "Guardrails endpoints",
+      "name": "Guardrails"
+    },
+    {
+      "description": "Model information endpoints",
+      "name": "Models"
+    },
+    {
+      "description": "OAuth authentication endpoints",
+      "name": "OAuth"
+    },
+    {
+      "description": "Organization endpoints",
+      "name": "Organization"
+    },
+    {
+      "description": "Provider information endpoints",
+      "name": "Providers"
+    },
+    {
+      "description": "Rerank endpoints",
+      "name": "Rerank"
+    },
+    {
+      "description": "Video Generation endpoints",
+      "name": "Video Generation"
+    },
+    {
+      "description": "beta.responses endpoints",
+      "name": "beta.responses"
+    }
+  ]
+}

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -26872,6 +26872,11 @@
       }
     }
   },
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
   "servers": [
     {
       "description": "Production server",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-17T11:37:20+00:00",
+  "captured_at": "2026-04-17T11:44:18+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "22d1aedb07103087",
+      "fingerprint": "a8e8f18928c3c86a",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "eaf0d72807471e20",
+      "fingerprint": "7ba94090fe4a8dfe",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ea35d92c6e907def",
+      "fingerprint": "95f59af93f2a1940",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e10b43ade78233c8",
+      "fingerprint": "97e1f2697bd3066c",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bf4ec48e2e758578",
+      "fingerprint": "0600f3ad77c10704",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "215bf1c5253f6da3",
+      "fingerprint": "50df372af92b0439",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "97b420c303c73d36",
+      "fingerprint": "48ed8bcc9c811a11",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c84f4172e684f9bd",
+      "fingerprint": "fcf564f45586fdb8",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e3e803b9531afd58",
+      "fingerprint": "bdcc5f13eb39b87d",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d3539904724e0153",
+      "fingerprint": "622584d38112ff60",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -161,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "eda1e061818d02ca",
+      "fingerprint": "c73983473e1c0e0e",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -172,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "13c9853a05da61e2",
+      "fingerprint": "db7ebd49d1f65e47",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "18127f043834024a",
+      "fingerprint": "b86d5630a59ac36b",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "136614cae2f70f23",
+      "fingerprint": "e954ef6e86b52be4",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "262fc549b6cad8f6",
+      "fingerprint": "c62675934a04d95e",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b151ca257c76aa63",
+      "fingerprint": "0a831f35217698f2",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "57d547118cea0508",
+      "fingerprint": "6d3ec9bee71dc2ce",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0fbdc84c2d5e2407",
+      "fingerprint": "b91f5f39cec8fec0",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f8e9f4d0943cb4f3",
+      "fingerprint": "48a3cb500e61e8dd",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9d776b9b16b44ad4",
+      "fingerprint": "ce53dfc76885c522",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b985f0ef5cd2a9ce",
+      "fingerprint": "48a58f7ad520ca2e",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4cf37e3514298c1e",
+      "fingerprint": "b4cd1ac5aa0b708f",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "af77e8c907dffe8e",
+      "fingerprint": "dd8e0956b7e1c9ec",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "69a3d30aeb58672b",
+      "fingerprint": "d47c5f120c2fb0b6",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c8ea6e8a471a620a",
+      "fingerprint": "3e6939ae948a68db",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b2dfa714d35acc21",
+      "fingerprint": "258dc171d1242855",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-17T09:25:31+00:00",
+  "captured_at": "2026-04-17T10:57:56+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -18,7 +18,7 @@
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "d3484a7a0fb4f9a7",
+      "fingerprint": "62d6681f3fc2fe20",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b989f1da5ab45daa",
+      "fingerprint": "2a479c2a2828c351",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "472ba7c693ce8503",
+      "fingerprint": "402aca9f89314b49",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8a0f4f70bd09a863",
+      "fingerprint": "05cecac9b09a5e7c",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9052d6b07a853529",
+      "fingerprint": "eaf0d72807471e20",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d1003df9e8071eb3",
+      "fingerprint": "ea35d92c6e907def",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0d89a883fbf084b8",
+      "fingerprint": "e10b43ade78233c8",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ed2d40a8d670846d",
+      "fingerprint": "6f92a5d33c7f972f",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3c0ed0ef06947c89",
+      "fingerprint": "4d19859eff470863",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ed06b4113d099985",
+      "fingerprint": "ccc5b8db50cbce6f",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "622a03090285537f",
+      "fingerprint": "c84f4172e684f9bd",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bcc9ae76e69c3dbc",
+      "fingerprint": "fc3b3a9ea0b3adba",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "543dad11b3c0de50",
+      "fingerprint": "05b0d39c00bf3352",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -161,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0cd366efc1034881",
+      "fingerprint": "eda1e061818d02ca",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -172,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0525540c96eaa9b5",
+      "fingerprint": "13c9853a05da61e2",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "137a01707025b7b0",
+      "fingerprint": "18127f043834024a",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e1bb69144425c619",
+      "fingerprint": "fadc8a1ad75a8722",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a26d23d59c150b3a",
+      "fingerprint": "360a71c424058693",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3de5bddc7b25f821",
+      "fingerprint": "262fc549b6cad8f6",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5045d59c62cd76f1",
+      "fingerprint": "b151ca257c76aa63",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "06f94136625f38c4",
+      "fingerprint": "57d547118cea0508",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e0653fbc8ceec5d6",
+      "fingerprint": "0fbdc84c2d5e2407",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "03fc32ffa7905b33",
+      "fingerprint": "f8e9f4d0943cb4f3",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4f8f938c4f0e76a2",
+      "fingerprint": "350024ac1009cddb",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1cdd29378fd4b1dc",
+      "fingerprint": "9d776b9b16b44ad4",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c9990dc9c0ed8d27",
+      "fingerprint": "b985f0ef5cd2a9ce",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "810eed4e56f10cf6",
+      "fingerprint": "3aae29d559805e6d",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3006e9be0fb90a69",
+      "fingerprint": "4cf37e3514298c1e",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "865711b698747ac4",
+      "fingerprint": "af77e8c907dffe8e",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -337,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6c9fa4efd346e18b",
+      "fingerprint": "cac6ec19bd951299",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -348,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "35fd3681c0ed9d2e",
+      "fingerprint": "fc5f8809122a9fec",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3b008ddef5f8855b",
+      "fingerprint": "a60d54c8a1dd80c0",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4277ede23eb89d2a",
+      "fingerprint": "95cd05e9fbc9490b",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4f5c26d1123be51f",
+      "fingerprint": "69a3d30aeb58672b",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e7771e45f314058e",
+      "fingerprint": "c8ea6e8a471a620a",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "48e21727babf9385",
+      "fingerprint": "b2dfa714d35acc21",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-17T10:57:56+00:00",
+  "captured_at": "2026-04-17T11:37:20+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "402aca9f89314b49",
+      "fingerprint": "22d1aedb07103087",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6f92a5d33c7f972f",
+      "fingerprint": "bf4ec48e2e758578",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4d19859eff470863",
+      "fingerprint": "215bf1c5253f6da3",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ccc5b8db50cbce6f",
+      "fingerprint": "97b420c303c73d36",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fc3b3a9ea0b3adba",
+      "fingerprint": "e3e803b9531afd58",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "05b0d39c00bf3352",
+      "fingerprint": "d3539904724e0153",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fadc8a1ad75a8722",
+      "fingerprint": "136614cae2f70f23",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,0 +1,417 @@
+{
+  "captured_at": "2026-04-17T05:47:58+00:00",
+  "info": {
+    "contact": {
+      "email": "support@openrouter.ai",
+      "name": "OpenRouter Support",
+      "url": "https://openrouter.ai/docs"
+    },
+    "description": "OpenAI-compatible API with additional OpenRouter features",
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "title": "OpenRouter API",
+    "version": "1.0.0"
+  },
+  "operation_count": 36,
+  "operations": [
+    {
+      "deprecated": false,
+      "fingerprint": "d3484a7a0fb4f9a7",
+      "id": "DELETE /guardrails/{id}",
+      "method": "DELETE",
+      "operation_id": "deleteGuardrail",
+      "path": "/guardrails/{id}",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "b989f1da5ab45daa",
+      "id": "DELETE /keys/{hash}",
+      "method": "DELETE",
+      "operation_id": "deleteKeys",
+      "path": "/keys/{hash}",
+      "tags": [
+        "API Keys"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "472ba7c693ce8503",
+      "id": "GET /activity",
+      "method": "GET",
+      "operation_id": "getUserActivity",
+      "path": "/activity",
+      "tags": [
+        "Analytics"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "8a0f4f70bd09a863",
+      "id": "GET /credits",
+      "method": "GET",
+      "operation_id": "getCredits",
+      "path": "/credits",
+      "tags": [
+        "Credits"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "9052d6b07a853529",
+      "id": "GET /embeddings/models",
+      "method": "GET",
+      "operation_id": "listEmbeddingsModels",
+      "path": "/embeddings/models",
+      "tags": [
+        "Embeddings"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "d1003df9e8071eb3",
+      "id": "GET /endpoints/zdr",
+      "method": "GET",
+      "operation_id": "listEndpointsZdr",
+      "path": "/endpoints/zdr",
+      "tags": [
+        "Endpoints"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "0d89a883fbf084b8",
+      "id": "GET /generation",
+      "method": "GET",
+      "operation_id": "getGeneration",
+      "path": "/generation",
+      "tags": [
+        "Generations"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "ed2d40a8d670846d",
+      "id": "GET /guardrails",
+      "method": "GET",
+      "operation_id": "listGuardrails",
+      "path": "/guardrails",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "3c0ed0ef06947c89",
+      "id": "GET /guardrails/assignments/keys",
+      "method": "GET",
+      "operation_id": "listKeyAssignments",
+      "path": "/guardrails/assignments/keys",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "ed06b4113d099985",
+      "id": "GET /guardrails/assignments/members",
+      "method": "GET",
+      "operation_id": "listMemberAssignments",
+      "path": "/guardrails/assignments/members",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "622a03090285537f",
+      "id": "GET /guardrails/{id}",
+      "method": "GET",
+      "operation_id": "getGuardrail",
+      "path": "/guardrails/{id}",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "bcc9ae76e69c3dbc",
+      "id": "GET /guardrails/{id}/assignments/keys",
+      "method": "GET",
+      "operation_id": "listGuardrailKeyAssignments",
+      "path": "/guardrails/{id}/assignments/keys",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "543dad11b3c0de50",
+      "id": "GET /guardrails/{id}/assignments/members",
+      "method": "GET",
+      "operation_id": "listGuardrailMemberAssignments",
+      "path": "/guardrails/{id}/assignments/members",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "0cd366efc1034881",
+      "id": "GET /key",
+      "method": "GET",
+      "operation_id": "getCurrentKey",
+      "path": "/key",
+      "tags": [
+        "API Keys"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "0525540c96eaa9b5",
+      "id": "GET /keys",
+      "method": "GET",
+      "operation_id": "list",
+      "path": "/keys",
+      "tags": [
+        "API Keys"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "137a01707025b7b0",
+      "id": "GET /keys/{hash}",
+      "method": "GET",
+      "operation_id": "getKey",
+      "path": "/keys/{hash}",
+      "tags": [
+        "API Keys"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "e1bb69144425c619",
+      "id": "GET /models",
+      "method": "GET",
+      "operation_id": "getModels",
+      "path": "/models",
+      "tags": [
+        "Models"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "a26d23d59c150b3a",
+      "id": "GET /models/count",
+      "method": "GET",
+      "operation_id": "listModelsCount",
+      "path": "/models/count",
+      "tags": [
+        "Models"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "3de5bddc7b25f821",
+      "id": "GET /models/user",
+      "method": "GET",
+      "operation_id": "listModelsUser",
+      "path": "/models/user",
+      "tags": [
+        "Models"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "5045d59c62cd76f1",
+      "id": "GET /models/{author}/{slug}/endpoints",
+      "method": "GET",
+      "operation_id": "listEndpoints",
+      "path": "/models/{author}/{slug}/endpoints",
+      "tags": [
+        "Endpoints"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "06f94136625f38c4",
+      "id": "GET /providers",
+      "method": "GET",
+      "operation_id": "listProviders",
+      "path": "/providers",
+      "tags": [
+        "Providers"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "e0653fbc8ceec5d6",
+      "id": "PATCH /guardrails/{id}",
+      "method": "PATCH",
+      "operation_id": "updateGuardrail",
+      "path": "/guardrails/{id}",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "03fc32ffa7905b33",
+      "id": "PATCH /keys/{hash}",
+      "method": "PATCH",
+      "operation_id": "updateKeys",
+      "path": "/keys/{hash}",
+      "tags": [
+        "API Keys"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "4f8f938c4f0e76a2",
+      "id": "POST /auth/keys",
+      "method": "POST",
+      "operation_id": "exchangeAuthCodeForAPIKey",
+      "path": "/auth/keys",
+      "tags": [
+        "OAuth"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "1cdd29378fd4b1dc",
+      "id": "POST /auth/keys/code",
+      "method": "POST",
+      "operation_id": "createAuthKeysCode",
+      "path": "/auth/keys/code",
+      "tags": [
+        "OAuth"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "c9990dc9c0ed8d27",
+      "id": "POST /chat/completions",
+      "method": "POST",
+      "operation_id": "sendChatCompletionRequest",
+      "path": "/chat/completions",
+      "tags": [
+        "Chat"
+      ]
+    },
+    {
+      "deprecated": true,
+      "fingerprint": "810eed4e56f10cf6",
+      "id": "POST /credits/coinbase",
+      "method": "POST",
+      "operation_id": "createCoinbaseCharge",
+      "path": "/credits/coinbase",
+      "tags": [
+        "Credits"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "3006e9be0fb90a69",
+      "id": "POST /embeddings",
+      "method": "POST",
+      "operation_id": "createEmbeddings",
+      "path": "/embeddings",
+      "tags": [
+        "Embeddings"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "865711b698747ac4",
+      "id": "POST /guardrails",
+      "method": "POST",
+      "operation_id": "createGuardrail",
+      "path": "/guardrails",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "6c9fa4efd346e18b",
+      "id": "POST /guardrails/{id}/assignments/keys",
+      "method": "POST",
+      "operation_id": "bulkAssignKeysToGuardrail",
+      "path": "/guardrails/{id}/assignments/keys",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "35fd3681c0ed9d2e",
+      "id": "POST /guardrails/{id}/assignments/keys/remove",
+      "method": "POST",
+      "operation_id": "bulkUnassignKeysFromGuardrail",
+      "path": "/guardrails/{id}/assignments/keys/remove",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "3b008ddef5f8855b",
+      "id": "POST /guardrails/{id}/assignments/members",
+      "method": "POST",
+      "operation_id": "bulkAssignMembersToGuardrail",
+      "path": "/guardrails/{id}/assignments/members",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "4277ede23eb89d2a",
+      "id": "POST /guardrails/{id}/assignments/members/remove",
+      "method": "POST",
+      "operation_id": "bulkUnassignMembersFromGuardrail",
+      "path": "/guardrails/{id}/assignments/members/remove",
+      "tags": [
+        "Guardrails"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "4f5c26d1123be51f",
+      "id": "POST /keys",
+      "method": "POST",
+      "operation_id": "createKeys",
+      "path": "/keys",
+      "tags": [
+        "API Keys"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "e7771e45f314058e",
+      "id": "POST /messages",
+      "method": "POST",
+      "operation_id": "createMessages",
+      "path": "/messages",
+      "tags": [
+        "Anthropic Messages"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "48e21727babf9385",
+      "id": "POST /responses",
+      "method": "POST",
+      "operation_id": "createResponses",
+      "path": "/responses",
+      "tags": [
+        "beta.responses"
+      ]
+    }
+  ],
+  "source_url": "https://openrouter.ai/openapi.json"
+}

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-17T05:47:58+00:00",
+  "captured_at": "2026-04-17T09:25:31+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",


### PR DESCRIPTION
## Summary

- add a nightly `openapi-drift` workflow that fetches the latest upstream spec, compares it against a tracked baseline, uploads report artifacts, and opens or refreshes a follow-up issue when drift is detected
- add `scripts/openapi_drift.py` plus `just openapi-drift-check` / `just openapi-refresh-baseline` for local comparison and baseline refresh
- check in an accepted baseline snapshot under `specs/openrouter/` plus docs that explain how the drift workflow relates to the endpoint matrix
- seed the initial baseline from the currently accepted endpoint matrix so newly added upstream operations surface as drift instead of being silently accepted

## Validation

- `python3 -m py_compile scripts/openapi_drift.py`
- `just check-migration-docs`
- `python3 scripts/openapi_drift.py compare --baseline specs/openrouter/openapi-baseline.json --candidate /tmp/openrouter-openapi.latest.json ...`
- `just openapi-drift-check` (expected to exit non-zero when drift is present; currently reports 6 added upstream operations)

## Current Drift Snapshot

With the checked-in baseline, the latest upstream spec currently reports 6 added operations:

- `GET /organization/members`
- `GET /videos/models`
- `GET /videos/{jobId}`
- `GET /videos/{jobId}/content`
- `POST /rerank`
- `POST /videos`

Closes #156