### PR TITLE
build: scaffold spec snapshot and generated module boundary

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,6 +54,12 @@ check-migration-docs:
 test-migration-smoke:
     cargo test --test migration_smoke --all-features
 
+openapi-refresh-source:
+    curl --fail --show-error -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
+    python3 scripts/openapi_drift.py refresh-source \
+        --source-file /tmp/openrouter-openapi.latest.json \
+        --source-json specs/openrouter/source/openapi.json
+
 openapi-refresh-baseline:
     curl --fail --show-error -L 'https://openrouter.ai/openapi.json' -o /tmp/openrouter-openapi.latest.json
     python3 scripts/openapi_drift.py refresh-baseline \

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -606,6 +606,17 @@ def command_refresh_baseline(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_refresh_source(args: argparse.Namespace) -> int:
+    source_url = args.source_url or UPSTREAM_OPENAPI_URL
+    source_label = str(args.source_file) if args.source_file else source_url
+    raw_spec = read_json(args.source_file) if args.source_file else fetch_spec(source_url)
+    spec = validate_openapi_spec(raw_spec, source_label)
+    write_json(args.source_json, spec)
+    print(f"Refreshed generation source snapshot from {source_url}.")
+    print(f"- source snapshot: {args.source_json}")
+    return 0
+
+
 def command_compare(args: argparse.Namespace) -> int:
     baseline_spec = validate_openapi_spec(read_json(args.baseline), str(args.baseline))
     candidate_label = args.candidate_url or str(args.candidate)
@@ -685,6 +696,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path where the normalized operations snapshot should be written.",
     )
     refresh.set_defaults(func=command_refresh_baseline)
+
+    refresh_source = subparsers.add_parser(
+        "refresh-source",
+        help="Fetch and validate a full accepted source snapshot for future generation work.",
+    )
+    refresh_source_input = refresh_source.add_mutually_exclusive_group()
+    refresh_source_input.add_argument(
+        "--source-url",
+        default=UPSTREAM_OPENAPI_URL,
+        help="OpenAPI URL used to refresh the accepted source snapshot.",
+    )
+    refresh_source_input.add_argument(
+        "--source-file",
+        type=Path,
+        help="Local OpenAPI JSON file used to refresh the accepted source snapshot.",
+    )
+    refresh_source.add_argument(
+        "--source-json",
+        type=Path,
+        required=True,
+        help="Path where the validated full source snapshot should be written.",
+    )
+    refresh_source.set_defaults(func=command_refresh_source)
 
     compare = subparsers.add_parser(
         "compare",

--- a/specs/openrouter/README.md
+++ b/specs/openrouter/README.md
@@ -6,10 +6,23 @@ Files:
 
 - `openapi-baseline.json`: checked-in baseline snapshot used for path+operation drift comparison
 - `openapi-baseline.operations.json`: normalized operation summary derived from the raw baseline
+- `source/openapi.json`: accepted full upstream snapshot reserved for future generation work
+- `overlays/*.yaml`: repo-reviewed generation overlays and naming/auth adjustments
+- `generator/config.yaml`: scaffolded generator input/output configuration
 
 The initial baseline is seeded from the currently accepted endpoint matrix in this repo. That is
 intentional: drift detection should surface newly added upstream operations instead of silently
 accepting them before docs, tests, and implementation are reviewed.
+
+The source snapshot is intentionally separate from the drift baseline. The baseline tracks what the
+repo has accepted for coverage review; the source snapshot is the fuller spec input that future
+generated internal modules can consume.
+
+Refresh the accepted source snapshot locally with:
+
+```bash
+just openapi-refresh-source
+```
 
 Refresh the baseline locally with:
 

--- a/specs/openrouter/generator/README.md
+++ b/specs/openrouter/generator/README.md
@@ -1,0 +1,8 @@
+# Generator Scaffold
+
+This directory holds generator-facing configuration for the internal `src/generated/` boundary.
+
+The current scaffold does not generate code yet. It only defines where generator configuration will
+live once endpoint families start migrating behind the handwritten wrapper layer.
+
+See `config.yaml` for the current reviewed placeholder inputs and outputs.

--- a/specs/openrouter/generator/config.yaml
+++ b/specs/openrouter/generator/config.yaml
@@ -1,0 +1,9 @@
+version: 1
+source_snapshot: ../source/openapi.json
+overlays:
+  - ../overlays/auth.yaml
+  - ../overlays/naming.yaml
+  - ../overlays/rust.yaml
+output:
+  rust_module_dir: ../../../src/generated
+  visibility: internal

--- a/specs/openrouter/overlays/README.md
+++ b/specs/openrouter/overlays/README.md
@@ -1,0 +1,13 @@
+# Generation Overlays
+
+This directory holds repo-reviewed overlays that adjust future generated output without changing the
+public handwritten SDK surface directly.
+
+The first scaffold keeps these overlays intentionally minimal. They exist to define the seam, not
+to start a broad overlay-driven rewrite.
+
+Initial overlay buckets:
+
+- `auth.yaml`: auth-specific adjustments and endpoint-key routing metadata
+- `naming.yaml`: naming overrides when upstream operation names do not fit the Rust wrapper layer
+- `rust.yaml`: Rust-specific generation knobs that should remain reviewable in-repo

--- a/specs/openrouter/overlays/auth.yaml
+++ b/specs/openrouter/overlays/auth.yaml
@@ -1,0 +1,2 @@
+version: 1
+overrides: []

--- a/specs/openrouter/overlays/naming.yaml
+++ b/specs/openrouter/overlays/naming.yaml
@@ -1,0 +1,2 @@
+version: 1
+overrides: []

--- a/specs/openrouter/overlays/rust.yaml
+++ b/specs/openrouter/overlays/rust.yaml
@@ -1,0 +1,2 @@
+version: 1
+overrides: []

--- a/specs/openrouter/source/README.md
+++ b/specs/openrouter/source/README.md
@@ -1,0 +1,17 @@
+# Accepted Source Snapshot
+
+This directory is reserved for the accepted full upstream OpenAPI snapshot that future generated
+internal modules will use as input.
+
+It is intentionally separate from the drift baseline in `../openapi-baseline.json`.
+
+- drift baseline: review-oriented coverage checkpoint
+- source snapshot: fuller accepted generation input
+
+Refresh the tracked source snapshot with:
+
+```bash
+just openapi-refresh-source
+```
+
+The command writes `openapi.json` into this directory.

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -1,0 +1,8 @@
+//! Internal seam for future generated low-level modules.
+//!
+//! This module is intentionally crate-private. The stable public SDK surface continues to live in
+//! `src/client.rs`, `src/api/*.rs`, and `src/types/*.rs`.
+
+pub(crate) mod operations;
+pub(crate) mod schemas;
+pub(crate) mod support;

--- a/src/generated/operations/credits.rs
+++ b/src/generated/operations/credits.rs
@@ -1,0 +1,1 @@
+//! Placeholder for future generated low-level credits operations.

--- a/src/generated/operations/discovery.rs
+++ b/src/generated/operations/discovery.rs
@@ -1,0 +1,1 @@
+//! Placeholder for future generated low-level discovery operations.

--- a/src/generated/operations/generation.rs
+++ b/src/generated/operations/generation.rs
@@ -1,0 +1,1 @@
+//! Placeholder for future generated low-level generation operations.

--- a/src/generated/operations/mod.rs
+++ b/src/generated/operations/mod.rs
@@ -1,0 +1,6 @@
+//! Internal generated operation modules.
+
+pub(crate) mod credits;
+pub(crate) mod discovery;
+pub(crate) mod generation;
+pub(crate) mod models;

--- a/src/generated/operations/models.rs
+++ b/src/generated/operations/models.rs
@@ -1,0 +1,1 @@
+//! Placeholder for future generated low-level model operations.

--- a/src/generated/schemas/mod.rs
+++ b/src/generated/schemas/mod.rs
@@ -1,0 +1,3 @@
+//! Internal generated schema modules.
+
+pub(crate) mod shared;

--- a/src/generated/schemas/shared.rs
+++ b/src/generated/schemas/shared.rs
@@ -1,0 +1,1 @@
+//! Placeholder for future generated shared schema types.

--- a/src/generated/support.rs
+++ b/src/generated/support.rs
@@ -1,0 +1,1 @@
+//! Handwritten support code shared by future generated modules.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@
 pub mod api;
 pub mod client;
 pub mod error;
+mod generated;
 pub mod types;
 pub mod utils;
 


### PR DESCRIPTION
## Summary
- add the repo-local scaffold for accepted source snapshots, overlays, and generator config under `specs/openrouter/`
- add `just openapi-refresh-source` plus a matching `refresh-source` command in `scripts/openapi_drift.py`
- introduce an internal `src/generated/` module seam while keeping the current public client/domain API intact

## Validation
- `cargo check --all-targets`
- `just check-migration-docs`
- `python3 scripts/openapi_drift.py refresh-source --source-file specs/openrouter/openapi-baseline.json --source-json /tmp/openrouter-source.snapshot.json`

Closes #154