### PR TITLE
docs: expand Rust distribution workflow examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added an `axum` gateway example and a practical typed-tool agent example so the repository covers copyable Rust application patterns instead of only endpoint-level demos.
+- Added `docs/cli-automation-workflows.md` with JSON-first shell and CI recipes for discovery, usage reporting, and ephemeral key automation.
+
+### Changed
+- Reorganized the README example/docs surface around application patterns, Tokio streaming, and CLI automation workflows.
+
 ## [0.7.0] - 2026-03-16
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes 1.11.1",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes 1.11.1",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1040,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes 1.11.1",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes 1.11.1",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes 1.11.1",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-client"
 version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1106,53 @@ dependencies = [
  "serde_qs",
  "serde_urlencoded",
  "url",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.11.1",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes 1.11.1",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1218,7 +1350,7 @@ dependencies = [
  "curl-sys",
  "flume",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.12",
  "log",
  "once_cell",
  "slab",
@@ -1326,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1567,7 @@ dependencies = [
 name = "openrouter-rs"
 version = "0.7.0"
 dependencies = [
+ "axum",
  "derive_builder",
  "dotenvy",
  "dotenvy_macro",
@@ -1816,7 +1955,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1894,18 +2033,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1933,6 +2082,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2177,6 +2337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,7 +2363,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2336,6 +2502,34 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,5 @@ name = "send_completion_request"
 required-features = ["legacy-completions"]
 
 [dev-dependencies]
+axum = "0.8"
 dotenvy = "0.15.7"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 [examples](https://github.com/realmorrisliu/openrouter-rs/tree/main/examples) |
 [crate](https://crates.io/crates/openrouter-rs) |
 [openrouter-cli](https://github.com/realmorrisliu/openrouter-rs/tree/main/crates/openrouter-cli) |
+[cli automation](docs/cli-automation-workflows.md) |
 [contributing](CONTRIBUTING.md) |
 [endpoint matrix](docs/official-endpoint-test-matrix.md) |
 [awesome-openrouter kit](docs/community/awesome-openrouter/README.md) |
@@ -128,17 +129,31 @@ For deeper examples, prefer the runnable examples in [`examples/`](examples) ove
 
 The repo includes runnable examples for the highest-value workflows:
 
+### Application Patterns
+
 | Example | Focus |
 | --- | --- |
-| [`examples/domain_chat_completion.rs`](examples/domain_chat_completion.rs) | Canonical `chat()` usage |
-| [`examples/stream_chat_completion.rs`](examples/stream_chat_completion.rs) | Raw chat streaming |
-| [`examples/stream_chat_with_tools.rs`](examples/stream_chat_with_tools.rs) | Tool-aware streaming aggregation |
+| [`examples/axum_chat_gateway.rs`](examples/axum_chat_gateway.rs) | Minimal `axum` server that proxies prompts through `OpenRouterClient` |
+| [`examples/typed_tool_agent.rs`](examples/typed_tool_agent.rs) | Practical typed-tool agent loop with explicit tool dispatch |
+| [`examples/domain_chat_completion.rs`](examples/domain_chat_completion.rs) | Canonical `chat()` request with the domain-oriented client |
+
+### Tokio Streaming
+
+| Example | Focus |
+| --- | --- |
+| [`examples/stream_chat_completion.rs`](examples/stream_chat_completion.rs) | Stream chat deltas into a Tokio task/stdout |
+| [`examples/stream_chat_with_tools.rs`](examples/stream_chat_with_tools.rs) | Tool-aware streaming aggregation plus a second round after execution |
+| [`examples/stream_response.rs`](examples/stream_response.rs) | `responses()` streaming |
+| [`examples/stream_messages.rs`](examples/stream_messages.rs) | `messages()` streaming |
+
+### API Surface Demos
+
+| Example | Focus |
+| --- | --- |
 | [`examples/basic_tool_calling.rs`](examples/basic_tool_calling.rs) | Manual tool-calling loop |
 | [`examples/typed_tool_calling.rs`](examples/typed_tool_calling.rs) | Typed tools with generated schema |
 | [`examples/create_response.rs`](examples/create_response.rs) | `responses()` create |
-| [`examples/stream_response.rs`](examples/stream_response.rs) | `responses()` streaming |
 | [`examples/create_message.rs`](examples/create_message.rs) | `messages()` create |
-| [`examples/stream_messages.rs`](examples/stream_messages.rs) | `messages()` streaming |
 | [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
 | [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
 | [`examples/exchange_code_for_api_key.rs`](examples/exchange_code_for_api_key.rs) | PKCE/auth-code flow |
@@ -149,13 +164,17 @@ Typical local usage:
 ```bash
 export OPENROUTER_API_KEY=sk-or-v1-...
 
+cargo run --example axum_chat_gateway
 cargo run --example domain_chat_completion
 cargo run --example stream_chat_completion
+cargo run --example typed_tool_agent
 cargo run --example typed_tool_calling
 cargo run --example create_response
 cargo run --example create_message
 cargo run --example create_embedding
 ```
+
+For shell and CI automation recipes built around the companion CLI, see [`docs/cli-automation-workflows.md`](docs/cli-automation-workflows.md).
 
 ## CLI Companion
 
@@ -172,6 +191,7 @@ cargo run -p openrouter-cli -- usage activity --date 2026-03-01
 ```
 
 See [`crates/openrouter-cli/README.md`](crates/openrouter-cli/README.md) for the full command surface and config/auth precedence rules.
+For copy-paste shell/CI recipes, see [`docs/cli-automation-workflows.md`](docs/cli-automation-workflows.md).
 
 ## Project Status
 
@@ -225,6 +245,7 @@ Environment and model-pool details live in [`tests/integration/README.md`](tests
 - [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for release, MSRV, and breaking-change policy
 - [`docs/community/awesome-openrouter/README.md`](docs/community/awesome-openrouter/README.md) for the Awesome OpenRouter submission kit and directory-safe assets
 - [`docs/generated-core-architecture.md`](docs/generated-core-architecture.md) for the generated-core plus idiomatic-wrapper design baseline
+- [`docs/cli-automation-workflows.md`](docs/cli-automation-workflows.md) for JSON-first shell and CI recipes built around `openrouter-cli`
 - [`docs/openapi-drift-reporting.md`](docs/openapi-drift-reporting.md) for nightly upstream-spec drift detection and baseline refresh workflow
 - [`SECURITY.md`](SECURITY.md) for vulnerability reporting
 - [`SUPPORT.md`](SUPPORT.md) for support boundaries and issue-reporting guidance

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -11,6 +11,8 @@ It currently focuses on four areas:
 
 The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.1.2`.
 
+Copyable shell and CI recipes live in [`../../docs/cli-automation-workflows.md`](../../docs/cli-automation-workflows.md).
+
 ## Install
 
 From crates.io:

--- a/docs/cli-automation-workflows.md
+++ b/docs/cli-automation-workflows.md
@@ -1,0 +1,100 @@
+# CLI Automation Workflows
+
+`openrouter-cli` is most useful in automation when you treat it as a JSON-emitting boundary around the SDK.
+
+All examples below assume:
+
+- `jq` is available
+- `--output json` is set explicitly
+- JSON responses use the versioned `{ "schema_version": "0.1", "data": ... }` envelope
+
+## Verify Profile Resolution In CI
+
+This is a cheap preflight before any real API call:
+
+```bash
+openrouter-cli --output json profile show \
+  | jq '.data | {profile, base_url, api_key_present, management_key_present}'
+```
+
+Use it when you want CI logs to show which profile/base URL won without exposing secrets.
+
+## Export Tool-Capable Models For Agent Jobs
+
+This turns discovery output into a tab-separated inventory that can feed a matrix job or a generated config file:
+
+```bash
+openrouter-cli \
+  --api-key "$OPENROUTER_API_KEY" \
+  --output json \
+  models list \
+  --supported-parameter tools \
+  | jq -r '.data[] | [.id, .context_length, .pricing.prompt] | @tsv'
+```
+
+If you only want the IDs:
+
+```bash
+openrouter-cli \
+  --api-key "$OPENROUTER_API_KEY" \
+  --output json \
+  models list \
+  --supported-parameter tools \
+  | jq -r '.data[].id'
+```
+
+## Build A Daily Usage Rollup
+
+This example aggregates per-model usage for a given UTC day and sorts the result by spend:
+
+```bash
+day="${1:-$(date -u +%F)}"
+
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  --output json \
+  usage activity \
+  --date "$day" \
+  | jq '
+      .data
+      | group_by(.model)
+      | map({
+          model: .[0].model,
+          requests: (map(.requests) | add),
+          usage: (map(.usage) | add),
+          prompt_tokens: (map(.prompt_tokens) | add),
+          completion_tokens: (map(.completion_tokens) | add)
+        })
+      | sort_by(-.usage)
+    '
+```
+
+That output is stable enough to upload as a CI artifact or feed into a scheduled reporting job.
+
+## Create And Revoke An Ephemeral CI Key
+
+Use a management key to mint a short-lived API key with a hard budget cap, then revoke it after the job:
+
+```bash
+key_json="$(
+  openrouter-cli \
+    --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+    --output json \
+    keys create \
+    --name "ci-${GITHUB_RUN_ID:-local}" \
+    --limit 5
+)"
+
+export OPENROUTER_API_KEY="$(jq -r '.data.key' <<<"$key_json")"
+export OPENROUTER_KEY_HASH="$(jq -r '.data.hash' <<<"$key_json")"
+
+cargo run --example domain_chat_completion
+
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  --output json \
+  keys delete "$OPENROUTER_KEY_HASH" \
+  --yes
+```
+
+`data.key` is only returned on creation, so capture it immediately if the automation needs the raw token.

--- a/examples/axum_chat_gateway.rs
+++ b/examples/axum_chat_gateway.rs
@@ -1,0 +1,174 @@
+//! # Axum Chat Gateway
+//!
+//! A minimal server-side integration example that keeps `OpenRouterClient`
+//! in application state and exposes one HTTP endpoint for chat completions.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! export OPENROUTER_API_KEY=sk-or-v1-...
+//! cargo run --example axum_chat_gateway
+//!
+//! curl -s http://127.0.0.1:3000/chat \
+//!   -H 'content-type: application/json' \
+//!   -d '{"prompt":"Summarize why Rust is a good fit for network services."}' | jq
+//! ```
+
+use std::{env, error::Error};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+};
+use openrouter_rs::{
+    OpenRouterClient,
+    api::chat::{ChatCompletionRequest, Message},
+    error::OpenRouterError,
+    types::Role,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct AppState {
+    client: OpenRouterClient,
+    default_model: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatGatewayRequest {
+    prompt: String,
+    #[serde(default)]
+    system: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default = "default_max_tokens")]
+    max_tokens: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatGatewayResponse {
+    model: String,
+    content: String,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HealthcheckResponse {
+    ok: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+fn default_max_tokens() -> u32 {
+    512
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let api_key =
+        env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY environment variable not set");
+    let bind_addr =
+        env::var("OPENROUTER_AXUM_BIND").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let default_model =
+        env::var("OPENROUTER_MODEL").unwrap_or_else(|_| "openai/gpt-4o-mini".to_string());
+
+    let client = OpenRouterClient::builder()
+        .api_key(api_key)
+        .http_referer("https://github.com/realmorrisliu/openrouter-rs")
+        .x_title("openrouter-rs axum gateway example")
+        .build()?;
+
+    let state = AppState {
+        client,
+        default_model,
+    };
+
+    let app = Router::new()
+        .route("/healthz", get(healthcheck))
+        .route("/chat", post(chat_completion))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+    println!("listening on http://{bind_addr}");
+    println!("GET  /healthz");
+    println!("POST /chat");
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn healthcheck() -> Json<HealthcheckResponse> {
+    Json(HealthcheckResponse { ok: true })
+}
+
+async fn chat_completion(
+    State(state): State<AppState>,
+    Json(payload): Json<ChatGatewayRequest>,
+) -> Result<Json<ChatGatewayResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let mut messages = Vec::new();
+    if let Some(system) = payload.system {
+        messages.push(Message::new(Role::System, system));
+    }
+    messages.push(Message::new(Role::User, payload.prompt));
+
+    let model = payload.model.unwrap_or_else(|| state.default_model.clone());
+    let request = ChatCompletionRequest::builder()
+        .model(model)
+        .messages(messages)
+        .max_tokens(payload.max_tokens)
+        .build()
+        .map_err(map_sdk_error)?;
+
+    let response = state
+        .client
+        .chat()
+        .create(&request)
+        .await
+        .map_err(map_sdk_error)?;
+
+    let choice = response
+        .choices
+        .first()
+        .ok_or_else(|| error_response(StatusCode::BAD_GATEWAY, "OpenRouter returned no choices"))?;
+
+    Ok(Json(ChatGatewayResponse {
+        model: response.model,
+        content: choice.content().unwrap_or("").to_string(),
+        finish_reason: choice.finish_reason().map(|reason| format!("{reason:?}")),
+    }))
+}
+
+fn map_sdk_error(error: OpenRouterError) -> (StatusCode, Json<ErrorResponse>) {
+    match error {
+        OpenRouterError::KeyNotConfigured | OpenRouterError::ConfigError(_) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+        }
+        OpenRouterError::Api(_) => error_response(StatusCode::BAD_GATEWAY, error.to_string()),
+        OpenRouterError::HttpRequest(_) => {
+            error_response(StatusCode::BAD_GATEWAY, error.to_string())
+        }
+        OpenRouterError::UninitializedFieldError(_)
+        | OpenRouterError::Serialization(_)
+        | OpenRouterError::Io(_)
+        | OpenRouterError::Unknown(_) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+        }
+    }
+}
+
+fn error_response(
+    status: StatusCode,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}

--- a/examples/typed_tool_agent.rs
+++ b/examples/typed_tool_agent.rs
@@ -1,0 +1,180 @@
+//! # Typed Tool Agent
+//!
+//! A practical tool-calling agent loop built with `typed_tool::<T>()`,
+//! typed argument parsing, and explicit tool execution.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! export OPENROUTER_API_KEY=sk-or-v1-...
+//! cargo run --example typed_tool_agent
+//! ```
+
+use std::{env, error::Error};
+
+use openrouter_rs::{
+    OpenRouterClient,
+    api::chat::{ChatCompletionRequest, Message},
+    types::{
+        Role, ToolCall,
+        typed_tool::{TypedTool, TypedToolParams},
+    },
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+const MAX_AGENT_STEPS: usize = 4;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum Environment {
+    Production,
+    Staging,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct DeploymentStatusParams {
+    service: String,
+    environment: Environment,
+}
+
+impl TypedTool for DeploymentStatusParams {
+    fn name() -> &'static str {
+        "get_deployment_status"
+    }
+
+    fn description() -> &'static str {
+        "Look up the current deployment status for a service and environment"
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct RunbookLookupParams {
+    service: String,
+    symptom: String,
+}
+
+impl TypedTool for RunbookLookupParams {
+    fn name() -> &'static str {
+        "lookup_runbook"
+    }
+
+    fn description() -> &'static str {
+        "Fetch the most relevant incident runbook for a service symptom"
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let api_key =
+        env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY environment variable not set");
+    let model = env::var("OPENROUTER_MODEL").unwrap_or_else(|_| "openai/gpt-4o-mini".to_string());
+
+    let client = OpenRouterClient::builder()
+        .api_key(api_key)
+        .http_referer("https://github.com/realmorrisliu/openrouter-rs")
+        .x_title("openrouter-rs typed tool agent example")
+        .build()?;
+
+    let mut messages = vec![
+        Message::new(
+            Role::System,
+            "You are an operations agent for a Rust service team. Use tools before giving guidance when deployment state or runbook context is missing.",
+        ),
+        Message::new(
+            Role::User,
+            "Checkout is showing elevated 5xx errors in production. Check deployment status, pull the most relevant runbook, then tell me the next action.",
+        ),
+    ];
+
+    for step in 1..=MAX_AGENT_STEPS {
+        let request = ChatCompletionRequest::builder()
+            .model(model.clone())
+            .messages(messages.clone())
+            .typed_tool::<DeploymentStatusParams>()
+            .typed_tool::<RunbookLookupParams>()
+            .tool_choice_auto()
+            .parallel_tool_calls(false)
+            .max_tokens(700)
+            .build()?;
+
+        let response = client.chat().create(&request).await?;
+        let Some(choice) = response.choices.first() else {
+            println!("OpenRouter returned no choices");
+            return Ok(());
+        };
+
+        if let Some(tool_calls) = choice.tool_calls() {
+            println!("step {step}: executing {} tool call(s)", tool_calls.len());
+            messages.push(Message::assistant_with_tool_calls(
+                choice.content().unwrap_or(""),
+                tool_calls.to_vec(),
+            ));
+
+            for tool_call in tool_calls {
+                let tool_result = execute_tool_call(tool_call)?;
+                println!("  {} -> {}", tool_call.name(), tool_result);
+                messages.push(Message::tool_response_named(
+                    tool_call.id(),
+                    tool_call.name(),
+                    tool_result,
+                ));
+            }
+
+            continue;
+        }
+
+        println!("final answer:\n");
+        println!("{}", choice.content().unwrap_or("(empty response)"));
+        return Ok(());
+    }
+
+    println!("agent stopped after reaching the configured step limit");
+    Ok(())
+}
+
+fn execute_tool_call(tool_call: &ToolCall) -> Result<String, Box<dyn Error>> {
+    if tool_call.is_tool::<DeploymentStatusParams>() {
+        let params = DeploymentStatusParams::from_json_value(serde_json::from_str(
+            tool_call.arguments_json(),
+        )?)?;
+
+        let status = json!({
+            "service": params.service,
+            "environment": params.environment,
+            "latest_release": "checkout-2026-04-17.2",
+            "rolled_out_by": "deploy-bot",
+            "health": "degraded",
+            "notes": [
+                "error rate increased 6 minutes after the latest rollout",
+                "one canary node is above the 5xx alert threshold"
+            ]
+        });
+
+        return Ok(serde_json::to_string_pretty(&status)?);
+    }
+
+    if tool_call.is_tool::<RunbookLookupParams>() {
+        let params = tool_call.parse_params::<RunbookLookupParams>()?;
+
+        let runbook = json!({
+            "service": params.service,
+            "symptom": params.symptom,
+            "runbook_id": "rb-checkout-rollback",
+            "summary": "If 5xx rate spikes immediately after a rollout, stop further rollout, compare config drift, and prepare rollback.",
+            "first_steps": [
+                "pause the current deployment wave",
+                "compare environment variables and feature flags against the last healthy release",
+                "rollback if the error rate keeps climbing for more than 5 minutes"
+            ]
+        });
+
+        return Ok(serde_json::to_string_pretty(&runbook)?);
+    }
+
+    Ok(format!(
+        "{{\"warning\":\"unhandled tool: {}\"}}",
+        tool_call.name()
+    ))
+}


### PR DESCRIPTION
## Summary
- add a copyable axum chat gateway example for server-side Rust integrations
- add a practical typed-tool agent example that shows explicit tool dispatch and multi-step looping
- add CLI automation workflow docs and reorganize the README examples/docs surface around application patterns and Tokio streaming

## Validation
- cargo check --all-targets
- just quality

Closes #153