### PR TITLE
docs: establish compatibility update cadence

### DIFF
--- a/.github/ISSUE_TEMPLATE/upstream-compatibility-update.md
+++ b/.github/ISSUE_TEMPLATE/upstream-compatibility-update.md
@@ -1,0 +1,40 @@
+---
+name: Upstream compatibility update
+about: Track an upstream OpenRouter change and the repo follow-up it requires
+title: "compat: review upstream OpenRouter change"
+labels: docs,migration
+---
+
+## Summary
+
+Briefly describe the upstream change and why it matters for `openrouter-rs`.
+
+## Trigger
+
+- [ ] Nightly OpenAPI drift report
+- [ ] Upstream docs or release note
+- [ ] Live contract or integration behavior difference
+- [ ] User report
+- [ ] Other
+
+## Upstream Source
+
+- Link:
+- Date noticed:
+- Affected surface:
+
+## Expected Repo Follow-Up
+
+- [ ] Update `docs/official-endpoint-test-matrix.md`
+- [ ] Update `CHANGELOG.md`
+- [ ] Update `MIGRATION.md`
+- [ ] Refresh the tracked OpenAPI baseline or source snapshot
+- [ ] Link or file implementation issue / PR
+
+## User Impact
+
+Describe what a Rust caller or maintainer should do differently, if anything.
+
+## Notes / Artifacts
+
+Add drift reports, response samples, doc links, or related PRs here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-See `CONTRIBUTING.md` and `docs/maintenance-policy.md` for contributor workflow, release expectations, MSRV policy, and breaking-change guidance.
+See `CONTRIBUTING.md`, `docs/maintenance-policy.md`, and `docs/compatibility-update-policy.md` for contributor workflow, release expectations, compatibility-update cadence, MSRV policy, and breaking-change guidance.
 
 ## Summary
 - What problem does this PR solve?

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -66,17 +66,33 @@ jobs:
             const title = 'chore: review latest OpenRouter OpenAPI drift';
             const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const policyUrl = `${context.serverUrl}/${owner}/${repo}/blob/main/docs/compatibility-update-policy.md`;
             const maxBodyLength = 60000;
+            const truncatedReport = report.length > maxBodyLength
+              ? `${report.slice(0, maxBodyLength)}\n\n... report truncated; see workflow artifact for the full diff ...`
+              : report;
             const body = [
+              '## Summary',
               'Detected upstream OpenAPI drift against the tracked baseline.',
               '',
-              `Workflow run: ${runUrl}`,
+              '## Trigger',
+              '- Source: nightly OpenAPI drift workflow',
+              `- Workflow run: ${runUrl}`,
+              '',
+              '## Expected Repo Follow-Up',
+              '- [ ] Review the drift report and decide whether the change is accepted, deferred, or out of scope',
+              '- [ ] Update `docs/official-endpoint-test-matrix.md` if the reviewed operation surface changed',
+              '- [ ] Update `CHANGELOG.md` if a user-visible repo change lands in response',
+              '- [ ] Update `MIGRATION.md` if canonical usage or compatibility bridges changed',
+              '- [ ] Refresh the tracked baseline with `just openapi-refresh-baseline` if the upstream change is accepted',
+              '',
+              `Policy: ${policyUrl}`,
               '',
               'This issue is maintained automatically by `.github/workflows/openapi-drift.yml`.',
+              'For manual reports that are not driven by spec drift, use `.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`.',
               '',
-              report.length > maxBodyLength
-                ? `${report.slice(0, maxBodyLength)}\n\n... report truncated; see workflow artifact for the full diff ...`
-                : report,
+              '## Drift Report',
+              truncatedReport,
             ].join('\n');
 
             const issues = await github.paginate(
@@ -98,6 +114,7 @@ jobs:
                 repo,
                 issue_number: existing.number,
                 body,
+                labels: ['ci', 'docs', 'migration'],
               });
               return;
             }
@@ -107,5 +124,5 @@ jobs:
               repo,
               title,
               body,
-              labels: ['ci', 'migration'],
+              labels: ['ci', 'docs', 'migration'],
             });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added an `axum` gateway example and a practical typed-tool agent example so the repository covers copyable Rust application patterns instead of only endpoint-level demos.
 - Added `docs/cli-automation-workflows.md` with JSON-first shell and CI recipes for discovery, usage reporting, and ephemeral key automation.
+- Added `docs/compatibility-update-policy.md` and a reusable upstream-compatibility issue template so upstream OpenRouter changes can be tracked outside normal release cuts.
 
 ### Changed
 - Reorganized the README example/docs surface around application patterns, Tokio streaming, and CLI automation workflows.
+- Aligned OpenAPI drift follow-up docs and issue wording with the new compatibility-update cadence and reporting surfaces.
 
 ## [0.7.0] - 2026-03-16
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Environment and model-pool details live in [`tests/integration/README.md`](tests
 - [`MIGRATION.md`](MIGRATION.md) for migration guidance
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor workflow and review expectations
 - [`docs/maintenance-policy.md`](docs/maintenance-policy.md) for release, MSRV, and breaking-change policy
+- [`docs/compatibility-update-policy.md`](docs/compatibility-update-policy.md) for upstream compatibility reporting cadence, templates, and update rules
 - [`docs/community/awesome-openrouter/README.md`](docs/community/awesome-openrouter/README.md) for the Awesome OpenRouter submission kit and directory-safe assets
 - [`docs/generated-core-architecture.md`](docs/generated-core-architecture.md) for the generated-core plus idiomatic-wrapper design baseline
 - [`docs/cli-automation-workflows.md`](docs/cli-automation-workflows.md) for JSON-first shell and CI recipes built around `openrouter-cli`

--- a/docs/compatibility-update-policy.md
+++ b/docs/compatibility-update-policy.md
@@ -1,0 +1,92 @@
+# Compatibility Update Policy
+
+This document defines how `openrouter-rs` records upstream OpenRouter compatibility changes between crate releases.
+
+It complements:
+
+- [`docs/maintenance-policy.md`](maintenance-policy.md) for release, MSRV, and breaking-change rules
+- [`docs/openapi-drift-reporting.md`](openapi-drift-reporting.md) for nightly spec-drift detection
+- [`CHANGELOG.md`](../CHANGELOG.md) and [`MIGRATION.md`](../MIGRATION.md) for durable user-facing notes
+
+The goal is to keep upstream-alignment reporting predictable without creating a heavy editorial workflow.
+
+## What Counts As A Compatibility Update
+
+Use a compatibility update when the trigger comes from upstream OpenRouter behavior or from this repo's accepted alignment decision, not just from a normal repository change.
+
+Compatibility updates include:
+
+- OpenAPI method/path additions, removals, or operation-shape drift
+- auth, headers, or endpoint-governance changes introduced upstream
+- upstream behavior changes found in live contract/integration testing, even if they are not visible in the OpenAPI
+- compatibility-bridge decisions, deprecations, or migration guidance updates driven by upstream alignment work
+- changes to the endpoint matrix, support status, or documented "supported vs not-yet-supported" claims
+
+A normal release note is enough when the change is purely repo-local and does not materially change the upstream compatibility story.
+
+Some changes are both:
+
+- repo implements or documents an upstream API change
+- repo removes or narrows a compatibility bridge because upstream alignment changed
+
+In those cases, keep the compatibility update flow and also update the normal release surfaces.
+
+## Reporting Surfaces
+
+Compatibility updates use different surfaces for different jobs:
+
+| Surface | Role | When to update |
+| --- | --- | --- |
+| GitHub issue using [`.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`](../.github/ISSUE_TEMPLATE/upstream-compatibility-update.md) | Active working record for one upstream change or one drift batch | When drift is detected, a non-spec upstream change is noticed, or follow-up work needs coordination |
+| [`CHANGELOG.md`](../CHANGELOG.md) | Durable user-facing summary of accepted compatibility-affecting repo changes | In the same PR that lands a user-visible SDK/docs/test/support change |
+| [`MIGRATION.md`](../MIGRATION.md) | Durable upgrade guidance | When canonical usage, public API names, compatibility bridges, required config, or migration steps changed |
+| [`docs/official-endpoint-test-matrix.md`](official-endpoint-test-matrix.md) | Current implementation and live-test status by operation | When the accepted upstream operation surface changed or support status changed |
+| [`docs/openapi-drift-reporting.md`](openapi-drift-reporting.md) | Detection workflow and baseline refresh rules | When the nightly detection/reporting mechanics change |
+
+This repository does not maintain a separate compatibility newsletter or a second standalone changelog.
+
+The working issue is for triage and coordination. The durable sources of truth remain `CHANGELOG.md`, `MIGRATION.md`, and the endpoint matrix.
+
+## Cadence
+
+The cadence is intentionally small and event-driven:
+
+| Cadence | Trigger | Expected output |
+| --- | --- | --- |
+| Nightly | Upstream OpenAPI drift check | Auto-opened or refreshed drift issue plus report artifact |
+| As needed | Non-spec upstream change noticed by maintainers, tests, or users | Manual compatibility update issue using the reusable template |
+| Same PR as acceptance | Repo accepts the change and updates code/docs/tests/baseline | `CHANGELOG.md`, `MIGRATION.md`, endpoint matrix, or baseline refresh updated in the same PR as needed |
+| Next release cut | A version is published | Release notes summarize already-landed compatibility updates; release notes do not replace the earlier docs updates |
+
+The important rule is: do not wait for a release cut to document a compatibility-relevant change once the repo has accepted it.
+
+## Update Rules
+
+When a compatibility update issue is opened:
+
+1. Record the upstream source and the affected surface.
+2. Decide whether the change is accepted now, deferred, or intentionally out of scope.
+3. Link the follow-up PR or implementation issue.
+
+When a compatibility update is accepted:
+
+- update [`docs/official-endpoint-test-matrix.md`](official-endpoint-test-matrix.md) if the operation surface or support status changed
+- update [`CHANGELOG.md`](../CHANGELOG.md) if a user-visible SDK/docs/test/support change landed
+- update [`MIGRATION.md`](../MIGRATION.md) if callers need a concrete upgrade path or if a compatibility bridge changed
+- refresh the tracked baseline with `just openapi-refresh-baseline` if the upstream OpenAPI change is accepted as the new reviewed baseline
+
+When no migration path is required, do not force `MIGRATION.md` churn. The threshold for touching `MIGRATION.md` is a real caller-facing action item.
+
+## Reusable Template
+
+Use [`.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`](../.github/ISSUE_TEMPLATE/upstream-compatibility-update.md) for manual reports and for follow-up issues derived from the nightly drift workflow.
+
+The template deliberately asks for:
+
+- the trigger source
+- the upstream link or evidence
+- the expected repo follow-up surfaces
+- the user impact
+- linked implementation work
+
+That keeps compatibility updates consistent whether they originate from the nightly drift bot, a live contract failure, or a maintainer noticing an upstream change in docs/releases.

--- a/docs/maintenance-policy.md
+++ b/docs/maintenance-policy.md
@@ -2,6 +2,8 @@
 
 This document describes the repository's contributor-facing maintenance expectations for releases, MSRV, and breaking changes.
 
+Upstream compatibility-update cadence is handled separately in [`docs/compatibility-update-policy.md`](compatibility-update-policy.md) so release policy and upstream-sync policy do not get mixed together.
+
 ## Release Policy
 
 The repository aims to keep `main` in a releasable state.

--- a/docs/openapi-drift-reporting.md
+++ b/docs/openapi-drift-reporting.md
@@ -72,10 +72,14 @@ That updates:
 
 When the nightly workflow reports drift:
 
-1. Review the generated report and candidate operations snapshot artifact.
-2. Update `docs/official-endpoint-test-matrix.md` if the upstream operation surface changed.
-3. Decide whether the SDK, tests, docs, or migration notes need follow-up work.
-4. If the change is accepted as the new baseline, run `just openapi-refresh-baseline` and commit the refreshed artifacts.
+1. Keep the generated issue open as the active compatibility-update record.
+2. Review the generated report and candidate operations snapshot artifact.
+3. Decide whether the drift is accepted now, deferred, or intentionally out of scope.
+4. Update `docs/official-endpoint-test-matrix.md` if the reviewed upstream operation surface changed.
+5. Update `CHANGELOG.md` and `MIGRATION.md` when the accepted change modifies user-visible behavior or migration expectations.
+6. If the change is accepted as the new baseline, run `just openapi-refresh-baseline` and commit the refreshed artifacts.
+
+For the reporting cadence and surface-selection rules behind those steps, see [`docs/compatibility-update-policy.md`](compatibility-update-policy.md).
 
 ## Relationship To The Endpoint Matrix
 


### PR DESCRIPTION
## Summary
- add a dedicated compatibility-update policy that defines when upstream changes become compatibility updates instead of normal release notes
- add a reusable GitHub issue template for upstream compatibility reports and align the drift workflow issue body with the same follow-up surfaces
- link the new cadence from README, maintenance policy, drift-reporting docs, and the PR template

## Validation
- `just quality-ci`

Closes #155