### PR TITLE
docs: reconcile OpenAPI drift issue 166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Reorganized the README example/docs surface around application patterns, Tokio streaming, and CLI automation workflows.
 - Aligned OpenAPI drift follow-up docs and issue wording with the new compatibility-update cadence and reporting surfaces.
+- Accepted the 2026-04-18 upstream OpenAPI drift baseline, tracked newly official `/rerank`, `/videos*`, and `/organization/members` endpoints in the endpoint matrix, and added typed embedding usage support for `prompt_tokens_details`.
 
 ## [0.7.0] - 2026-03-16
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 `openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `36 / 36` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md).
+The current repo snapshot implements `36 / 42` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/official-endpoint-test-matrix.md`](docs/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 

--- a/docs/community/awesome-openrouter/README.md
+++ b/docs/community/awesome-openrouter/README.md
@@ -88,7 +88,7 @@ Use the following reviewer-facing signals in the Awesome OpenRouter PR body. Sna
 - `openrouter-rs` crate: `11,900` total downloads and `4,232` recent downloads on crates.io
 - `openrouter-cli` crate: published companion CLI with `59` downloads across its first three releases
 - Published API docs on docs.rs and runnable examples in-repo
-- Current repo snapshot implements `36 / 36` official OpenAPI method/path entries, with live coverage tracked in [`docs/official-endpoint-test-matrix.md`](../../official-endpoint-test-matrix.md)
+- The repository publishes an endpoint matrix against the current OpenRouter spec and tracks nightly OpenAPI drift in-repo
 - Contributor, security, support, release, MSRV, and breaking-change policies are public in-repo
 
 Refresh the numbers above if submission happens materially later than this snapshot date.

--- a/docs/community/awesome-openrouter/pr-draft.md
+++ b/docs/community/awesome-openrouter/pr-draft.md
@@ -23,7 +23,7 @@ Snapshot date: `2026-04-17`
 - `openrouter-rs` on crates.io: `11,900` total downloads, `4,232` recent downloads
 - `openrouter-cli` on crates.io: published companion CLI with `59` downloads across its first three releases
 - docs.rs documentation is live and the repo includes runnable SDK and CLI examples
-- The repository tracks `36 / 36` official OpenAPI method/path entries against the current OpenRouter spec, with a published endpoint matrix
+- The repository publishes an endpoint matrix against the current OpenRouter spec and tracks nightly OpenAPI drift in-repo
 
 ## Submission Links
 

--- a/docs/official-endpoint-test-matrix.md
+++ b/docs/official-endpoint-test-matrix.md
@@ -1,15 +1,15 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-03-10  
+Snapshot date: 2026-04-18  
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `36` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `36 / 36` (`100%`).
-- Live integration coverage (`tests/integration`): `22 / 36` endpoints currently exercised.
+- Official OpenAPI endpoints: `42` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `36 / 42` (`86%`).
+- Live integration coverage (`tests/integration`): `22 / 42` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`
 
 Legend:
@@ -60,9 +60,15 @@ Legend:
 | `GET /models/{author}/{slug}/endpoints` | `client.list_model_endpoints(...)` / `client.models().list_endpoints(...)` | Yes | Path | Yes | Keep |
 | `GET /models/count` | `client.count_models()` / `client.models().get_model_count()` | Yes | Contract | Yes | Keep |
 | `GET /models/user` | `client.list_models_for_user()` / `client.models().list_user_models()` | Yes | Path | Yes | Keep |
+| `GET /organization/members` | Not implemented yet | No | None | No | P2 |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
+| `POST /rerank` | Not implemented yet | No | None | No | P1 |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
+| `POST /videos` | Not implemented yet | No | None | No | P2 |
+| `GET /videos/models` | Not implemented yet | No | None | No | P2 |
+| `GET /videos/{jobId}` | Not implemented yet | No | None | No | P2 |
+| `GET /videos/{jobId}/content` | Not implemented yet | No | None | No | P2 |
 
 ## Supplemental (Legacy)
 
@@ -77,6 +83,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity`.
 3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
+4. P1/P2: track implementation decisions for the newly official `/rerank`, `/videos*`, and `/organization/members` endpoints in [#168](https://github.com/realmorrisliu/openrouter-rs/issues/168) before claiming full OpenAPI coverage again.
 
 ## Reproduce Snapshot
 

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -20874,6 +20874,30 @@
                           "example": 8,
                           "type": "integer"
                         },
+                        "prompt_tokens_details": {
+                          "description": "Per-modality token breakdown. Only present when the input contains 2+ modalities (e.g. text + image) and the upstream provider returns modality-level usage data. Only non-zero modality counts are included.",
+                          "properties": {
+                            "audio_tokens": {
+                              "description": "Number of audio tokens in the input",
+                              "type": "integer"
+                            },
+                            "image_tokens": {
+                              "description": "Number of image tokens in the input",
+                              "example": 258,
+                              "type": "integer"
+                            },
+                            "text_tokens": {
+                              "description": "Number of text tokens in the input",
+                              "example": 8,
+                              "type": "integer"
+                            },
+                            "video_tokens": {
+                              "description": "Number of video tokens in the input",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        },
                         "total_tokens": {
                           "description": "Total number of tokens used",
                           "example": 8,
@@ -25930,6 +25954,194 @@
         "x-speakeasy-name-override": "list"
       }
     },
+    "/organization/members": {
+      "get": {
+        "description": "List all members of the organization associated with the authenticated management key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listOrganizationMembers",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "email": "jane.doe@example.com",
+                      "first_name": "Jane",
+                      "id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "last_name": "Doe",
+                      "role": "member"
+                    }
+                  ],
+                  "total_count": 25
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "List of organization members",
+                      "items": {
+                        "properties": {
+                          "email": {
+                            "description": "Email address of the member",
+                            "example": "jane.doe@example.com",
+                            "type": "string"
+                          },
+                          "first_name": {
+                            "description": "First name of the member",
+                            "example": "Jane",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "User ID of the organization member",
+                            "example": "user_2dHFtVWx2n56w6HkM0000000000",
+                            "type": "string"
+                          },
+                          "last_name": {
+                            "description": "Last name of the member",
+                            "example": "Doe",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the member in the organization",
+                            "enum": [
+                              "org:admin",
+                              "org:member"
+                            ],
+                            "example": "org:member",
+                            "type": "string",
+                            "x-speakeasy-unknown-values": "allow"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "first_name",
+                          "last_name",
+                          "email",
+                          "role"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_count": {
+                      "description": "Total number of members in the organization",
+                      "example": 25,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "total_count"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "List of organization members"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List organization members",
+        "tags": [
+          "Organization"
+        ],
+        "x-speakeasy-name-override": "listMembers",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      }
+    },
     "/providers": {
       "get": {
         "operationId": "listProviders",
@@ -26581,6 +26793,382 @@
         "x-speakeasy-name-override": "list"
       }
     },
+    "/rerank": {
+      "post": {
+        "description": "Submits a rerank request to the rerank router",
+        "operationId": "createRerank",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Rerank request input",
+                "example": {
+                  "documents": [
+                    "Paris is the capital of France.",
+                    "Berlin is the capital of Germany."
+                  ],
+                  "model": "cohere/rerank-v3.5",
+                  "query": "What is the capital of France?",
+                  "top_n": 3
+                },
+                "properties": {
+                  "documents": {
+                    "description": "The list of documents to rerank",
+                    "example": [
+                      "Paris is the capital of France.",
+                      "Berlin is the capital of Germany."
+                    ],
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "model": {
+                    "description": "The rerank model to use",
+                    "example": "cohere/rerank-v3.5",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/ProviderPreferences"
+                      },
+                      {
+                        "description": "Provider routing preferences for the request."
+                      }
+                    ]
+                  },
+                  "query": {
+                    "description": "The search query to rerank documents against",
+                    "example": "What is the capital of France?",
+                    "type": "string"
+                  },
+                  "top_n": {
+                    "description": "Number of most relevant documents to return",
+                    "example": 3,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "model",
+                  "query",
+                  "documents"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Rerank response containing ranked results",
+                  "example": {
+                    "id": "gen-rerank-1234567890-abc",
+                    "model": "cohere/rerank-v3.5",
+                    "results": [
+                      {
+                        "document": {
+                          "text": "Paris is the capital of France."
+                        },
+                        "index": 0,
+                        "relevance_score": 0.98
+                      }
+                    ],
+                    "usage": {
+                      "search_units": 1,
+                      "total_tokens": 150
+                    }
+                  },
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier for the rerank response (ORID format)",
+                      "example": "gen-rerank-1234567890-abc",
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "The model used for reranking",
+                      "example": "cohere/rerank-v3.5",
+                      "type": "string"
+                    },
+                    "provider": {
+                      "description": "The provider that served the rerank request",
+                      "example": "Cohere",
+                      "type": "string"
+                    },
+                    "results": {
+                      "description": "List of rerank results sorted by relevance",
+                      "example": [
+                        {
+                          "document": {
+                            "text": "Paris is the capital of France."
+                          },
+                          "index": 0,
+                          "relevance_score": 0.98
+                        }
+                      ],
+                      "items": {
+                        "description": "A single rerank result",
+                        "example": {
+                          "document": {
+                            "text": "Paris is the capital of France."
+                          },
+                          "index": 0,
+                          "relevance_score": 0.98
+                        },
+                        "properties": {
+                          "document": {
+                            "description": "The document object containing the original text",
+                            "properties": {
+                              "text": {
+                                "description": "The document text",
+                                "example": "Paris is the capital of France.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "type": "object"
+                          },
+                          "index": {
+                            "description": "Index of the document in the original input list",
+                            "example": 0,
+                            "type": "integer"
+                          },
+                          "relevance_score": {
+                            "description": "Relevance score of the document to the query",
+                            "example": 0.98,
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "relevance_score",
+                          "document"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "usage": {
+                      "description": "Usage statistics",
+                      "example": {
+                        "search_units": 1,
+                        "total_tokens": 150
+                      },
+                      "properties": {
+                        "cost": {
+                          "description": "Cost of the request in credits",
+                          "example": 0.001,
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "search_units": {
+                          "description": "Number of search units consumed (Cohere billing)",
+                          "example": 1,
+                          "type": "integer"
+                        },
+                        "total_tokens": {
+                          "description": "Total number of tokens used",
+                          "example": 150,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "model",
+                    "results"
+                  ],
+                  "type": "object"
+                }
+              },
+              "text/event-stream": {
+                "example": "data: [DONE]",
+                "schema": {
+                  "description": "Not used for rerank - rerank does not support streaming",
+                  "type": "string"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            },
+            "description": "Rerank response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Submit a rerank request",
+        "tags": [
+          "Rerank"
+        ],
+        "x-speakeasy-name-override": "rerank"
+      }
+    },
     "/responses": {
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
@@ -26869,6 +27457,458 @@
         ],
         "x-speakeasy-name-override": "send",
         "x-speakeasy-stream-request-field": "stream"
+      }
+    },
+    "/videos": {
+      "post": {
+        "description": "Submits a video generation request and returns a polling URL to check status",
+        "operationId": "createVideos",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "aspect_ratio": "16:9",
+                "duration": 8,
+                "model": "google/veo-3.1",
+                "prompt": "A serene mountain landscape at sunset",
+                "resolution": "720p"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/VideoGenerationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "generation_id": "gen-xyz789",
+                  "id": "job-abc123",
+                  "polling_url": "/api/v1/videos/job-abc123",
+                  "status": "pending"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/VideoGenerationResponse"
+                }
+              }
+            },
+            "description": "Video generation request accepted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Submit a video generation request",
+        "tags": [
+          "Video Generation"
+        ],
+        "x-speakeasy-name-override": "generate"
+      }
+    },
+    "/videos/models": {
+      "get": {
+        "description": "Returns a list of all available video generation models and their properties",
+        "operationId": "listVideosModels",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "allowed_passthrough_parameters": [],
+                      "canonical_slug": "google/veo-3.1",
+                      "created": 1700000000,
+                      "description": "Google video generation model",
+                      "generate_audio": true,
+                      "id": "google/veo-3.1",
+                      "name": "Veo 3.1",
+                      "pricing_skus": {
+                        "generate": "0.50"
+                      },
+                      "seed": null,
+                      "supported_aspect_ratios": [
+                        "16:9"
+                      ],
+                      "supported_durations": [
+                        5,
+                        8
+                      ],
+                      "supported_frame_images": [
+                        "first_frame",
+                        "last_frame"
+                      ],
+                      "supported_resolutions": [
+                        "720p"
+                      ],
+                      "supported_sizes": null
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/VideoModelsListResponse"
+                }
+              }
+            },
+            "description": "Returns a list of video generation models"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List all video generation models",
+        "tags": [
+          "Video Generation"
+        ]
+      }
+    },
+    "/videos/{jobId}": {
+      "get": {
+        "description": "Returns job status and content URLs when completed",
+        "operationId": "getVideos",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "example": "job-abc123",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "generation_id": "gen-xyz789",
+                  "id": "job-abc123",
+                  "polling_url": "/api/v1/videos/job-abc123",
+                  "status": "complete",
+                  "unsigned_urls": [
+                    "https://storage.example.com/video.mp4"
+                  ],
+                  "usage": {
+                    "cost": 0.5
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/VideoGenerationResponse"
+                }
+              }
+            },
+            "description": "Video generation status"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Poll video generation status",
+        "tags": [
+          "Video Generation"
+        ],
+        "x-speakeasy-name-override": "getGeneration"
+      }
+    },
+    "/videos/{jobId}/content": {
+      "get": {
+        "description": "Streams the generated video content from the upstream provider",
+        "operationId": "listVideosContent",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "example": "job-abc123",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "index",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "example": "<binary video data>",
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Video content stream"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          }
+        },
+        "summary": "Download generated video content",
+        "tags": [
+          "Video Generation"
+        ],
+        "x-speakeasy-name-override": "getVideoContent"
       }
     }
   },

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-17T11:44:18+00:00",
+  "captured_at": "2026-04-18T06:19:32+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,7 +14,7 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 36,
+  "operation_count": 42,
   "operations": [
     {
       "deprecated": false,
@@ -238,6 +238,17 @@
     },
     {
       "deprecated": false,
+      "fingerprint": "afba5151a3299caf",
+      "id": "GET /organization/members",
+      "method": "GET",
+      "operation_id": "listOrganizationMembers",
+      "path": "/organization/members",
+      "tags": [
+        "Organization"
+      ]
+    },
+    {
+      "deprecated": false,
       "fingerprint": "6d3ec9bee71dc2ce",
       "id": "GET /providers",
       "method": "GET",
@@ -245,6 +256,39 @@
       "path": "/providers",
       "tags": [
         "Providers"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "14596fe6b03e4428",
+      "id": "GET /videos/models",
+      "method": "GET",
+      "operation_id": "listVideosModels",
+      "path": "/videos/models",
+      "tags": [
+        "Video Generation"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "0c91e369c0a0d9e1",
+      "id": "GET /videos/{jobId}",
+      "method": "GET",
+      "operation_id": "getVideos",
+      "path": "/videos/{jobId}",
+      "tags": [
+        "Video Generation"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "f762b88d789b2723",
+      "id": "GET /videos/{jobId}/content",
+      "method": "GET",
+      "operation_id": "listVideosContent",
+      "path": "/videos/{jobId}/content",
+      "tags": [
+        "Video Generation"
       ]
     },
     {
@@ -315,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b4cd1ac5aa0b708f",
+      "fingerprint": "92a8447c3b7e796f",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -403,6 +447,17 @@
     },
     {
       "deprecated": false,
+      "fingerprint": "18f4810d9d6d8bd0",
+      "id": "POST /rerank",
+      "method": "POST",
+      "operation_id": "createRerank",
+      "path": "/rerank",
+      "tags": [
+        "Rerank"
+      ]
+    },
+    {
+      "deprecated": false,
       "fingerprint": "258dc171d1242855",
       "id": "POST /responses",
       "method": "POST",
@@ -410,6 +465,17 @@
       "path": "/responses",
       "tags": [
         "beta.responses"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "624263f08072d641",
+      "id": "POST /videos",
+      "method": "POST",
+      "operation_id": "createVideos",
+      "path": "/videos",
+      "tags": [
+        "Video Generation"
       ]
     }
   ],

--- a/src/api/embeddings.rs
+++ b/src/api/embeddings.rs
@@ -145,11 +145,26 @@ pub struct EmbeddingData {
     pub index: Option<u32>,
 }
 
+/// Token breakdown details for embedding requests.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EmbeddingPromptTokensDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video_tokens: Option<u32>,
+}
+
 /// Token/cost usage for embedding request.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EmbeddingUsage {
     pub prompt_tokens: u32,
     pub total_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<EmbeddingPromptTokensDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
 }

--- a/tests/unit/embeddings.rs
+++ b/tests/unit/embeddings.rs
@@ -81,6 +81,37 @@ fn test_embedding_response_float_deserialization() {
 }
 
 #[test]
+fn test_embedding_response_deserializes_prompt_tokens_details() {
+    let raw = r#"{
+        "object": "list",
+        "data": [
+            {"object":"embedding","embedding":[0.1,0.2],"index":0}
+        ],
+        "model": "openai/text-embedding-3-large",
+        "usage": {
+            "prompt_tokens": 8,
+            "total_tokens": 8,
+            "prompt_tokens_details": {
+                "text_tokens": 6,
+                "image_tokens": 2
+            }
+        }
+    }"#;
+
+    let response: EmbeddingResponse =
+        serde_json::from_str(raw).expect("embedding response should deserialize");
+    let usage = response.usage.expect("usage should be present");
+    let details = usage
+        .prompt_tokens_details
+        .expect("prompt token details should deserialize");
+
+    assert_eq!(details.text_tokens, Some(6));
+    assert_eq!(details.image_tokens, Some(2));
+    assert_eq!(details.audio_tokens, None);
+    assert_eq!(details.video_tokens, None);
+}
+
+#[test]
 fn test_embedding_response_base64_deserialization() {
     let raw = r#"{
         "object": "list",


### PR DESCRIPTION
## Summary
- accept the current upstream OpenAPI drift into the tracked baseline and update the endpoint matrix/README counts from 36/36 to 36/42
- add typed support for `prompt_tokens_details` on embedding usage payloads and cover it with a unit test
- keep Awesome OpenRouter submission copy truthful after the drift review and link the remaining implementation gap to #168

## Validation
- `just quality`
- `just openapi-drift-check`

Closes #166
Related to #168