### PR TITLE
refactor: decouple public error types from surf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "dotenvy",
  "dotenvy_macro",
  "futures-util",
+ "http 1.4.0",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ legacy-completions = []
 [dependencies]
 dotenvy_macro = "0.15.7"
 futures-util = "0.3.31"
+http = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 surf = "2.3.2"

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -1,6 +1,6 @@
+use http::StatusCode;
 use serde::Deserialize;
 use serde_json::Value;
-use surf::StatusCode;
 
 use crate::error::{ApiErrorContext, ApiErrorKind, OpenRouterError};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,14 +100,33 @@
 //!
 //! The SDK automatically converts common error types:
 //!
-//! - `surf::Error` → `OpenRouterError::HttpRequest`
+//! - transport client errors → `OpenRouterError::HttpRequest`
 //! - `serde_json::Error` → `OpenRouterError::Serialization`
 //! - `std::io::Error` → `OpenRouterError::Io`
 //! - `derive_builder::UninitializedFieldError` → `OpenRouterError::UninitializedFieldError`
 
+use http::StatusCode;
 use serde_json::Value;
-use surf::StatusCode;
 use thiserror::Error;
+
+/// Stable, backend-neutral request error wrapper used by [`OpenRouterError::HttpRequest`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{message}")]
+pub struct HttpRequestError {
+    message: String,
+}
+
+impl HttpRequestError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
 
 /// Normalized API error category.
 #[derive(Debug, Clone)]
@@ -141,12 +160,12 @@ impl ApiErrorContext {
     pub fn is_retryable(&self) -> bool {
         matches!(
             self.status,
-            StatusCode::RequestTimeout
-                | StatusCode::TooManyRequests
-                | StatusCode::InternalServerError
-                | StatusCode::BadGateway
-                | StatusCode::ServiceUnavailable
-                | StatusCode::GatewayTimeout
+            StatusCode::REQUEST_TIMEOUT
+                | StatusCode::TOO_MANY_REQUESTS
+                | StatusCode::INTERNAL_SERVER_ERROR
+                | StatusCode::BAD_GATEWAY
+                | StatusCode::SERVICE_UNAVAILABLE
+                | StatusCode::GATEWAY_TIMEOUT
         )
     }
 
@@ -194,7 +213,7 @@ impl std::fmt::Display for ApiErrorContext {
 /// // Pattern matching on specific error types
 /// fn handle_error(error: OpenRouterError) {
 ///     match error {
-///         OpenRouterError::Api(api_error) if api_error.status == surf::StatusCode::Unauthorized => {
+///         OpenRouterError::Api(api_error) if api_error.status == http::StatusCode::UNAUTHORIZED => {
 ///             println!("Check your API key");
 ///         }
 ///         OpenRouterError::Api(api_error) => match &api_error.kind {
@@ -214,7 +233,7 @@ impl std::fmt::Display for ApiErrorContext {
 pub enum OpenRouterError {
     // HTTP request errors
     #[error("HTTP request failed: {0}")]
-    HttpRequest(surf::Error),
+    HttpRequest(HttpRequestError),
 
     // API response errors
     #[error("{0}")]
@@ -245,6 +264,6 @@ pub enum OpenRouterError {
 
 impl From<surf::Error> for OpenRouterError {
     fn from(err: surf::Error) -> Self {
-        OpenRouterError::HttpRequest(err)
+        OpenRouterError::HttpRequest(HttpRequestError::new(err.to_string()))
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -214,7 +214,11 @@ pub(crate) async fn parse_json_response<T: DeserializeOwned>(
         Ok(parsed) => Ok(parsed),
         Err(error) => {
             if body_contains_api_error(&body_text) {
-                Err(parse_api_error(to_http_status(status), request_id, &body_text))
+                Err(parse_api_error(
+                    to_http_status(status),
+                    request_id,
+                    &body_text,
+                ))
             } else {
                 Err(response_deserialization_error(
                     context, status, &error, &body_text,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use futures_util::{Stream, StreamExt, stream, stream::BoxStream};
+use http::StatusCode as HttpStatusCode;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
@@ -164,6 +165,11 @@ fn body_preview(body_text: &str, limit: usize) -> String {
     preview
 }
 
+fn to_http_status(status: StatusCode) -> HttpStatusCode {
+    HttpStatusCode::from_u16(u16::from(status))
+        .expect("surf/http-types status code should map to http::StatusCode")
+}
+
 fn response_request_id(response: &Response) -> Option<String> {
     response
         .header("x-request-id")
@@ -208,7 +214,7 @@ pub(crate) async fn parse_json_response<T: DeserializeOwned>(
         Ok(parsed) => Ok(parsed),
         Err(error) => {
             if body_contains_api_error(&body_text) {
-                Err(parse_api_error(status, request_id, &body_text))
+                Err(parse_api_error(to_http_status(status), request_id, &body_text))
             } else {
                 Err(response_deserialization_error(
                     context, status, &error, &body_text,
@@ -225,12 +231,12 @@ pub async fn handle_error(mut response: Response) -> Result<(), OpenRouterError>
         Ok(text) => text,
         Err(error) => {
             return Err(unreadable_error_response(
-                status,
+                to_http_status(status),
                 request_id,
                 &error.to_string(),
             ));
         }
     };
 
-    Err(parse_api_error(status, request_id, &text))
+    Err(parse_api_error(to_http_status(status), request_id, &text))
 }

--- a/tests/unit/chat_api.rs
+++ b/tests/unit/chat_api.rs
@@ -328,7 +328,7 @@ async fn test_send_chat_completion_treats_error_payload_with_200_status_as_api_e
 
     match error {
         openrouter_rs::error::OpenRouterError::Api(api_error) => {
-            assert_eq!(api_error.status, surf::StatusCode::InternalServerError);
+            assert_eq!(api_error.status, http::StatusCode::INTERNAL_SERVER_ERROR);
             assert_eq!(api_error.api_code, Some(500));
             assert_eq!(api_error.message, "Internal Server Error");
             assert!(api_error.is_retryable());

--- a/tests/unit/error_model.rs
+++ b/tests/unit/error_model.rs
@@ -1,3 +1,4 @@
+use http::StatusCode;
 use std::{
     io::{Read, Write},
     net::TcpListener,
@@ -6,9 +7,8 @@ use std::{
 
 use openrouter_rs::{
     api::models,
-    error::{ApiErrorKind, OpenRouterError},
+    error::{ApiErrorKind, HttpRequestError, OpenRouterError},
 };
-use surf::StatusCode;
 
 fn spawn_error_server(
     status_line: &str,
@@ -70,7 +70,7 @@ async fn test_normalized_generic_api_error_shape() {
     let error = result.expect_err("request should fail");
     match error {
         OpenRouterError::Api(api_error) => {
-            assert_eq!(api_error.status, StatusCode::TooManyRequests);
+            assert_eq!(api_error.status, StatusCode::TOO_MANY_REQUESTS);
             assert_eq!(api_error.api_code, Some(429));
             assert_eq!(api_error.message, "Rate limit exceeded");
             assert_eq!(api_error.request_id.as_deref(), Some("req_123"));
@@ -127,7 +127,7 @@ async fn test_unreadable_error_body_preserves_read_failure_context() {
 
     match error {
         OpenRouterError::Api(api_error) => {
-            assert_eq!(api_error.status, StatusCode::InternalServerError);
+            assert_eq!(api_error.status, StatusCode::INTERNAL_SERVER_ERROR);
             assert_eq!(api_error.request_id.as_deref(), Some("req_truncated"));
             assert!(
                 api_error
@@ -173,7 +173,7 @@ async fn test_normalized_provider_error_shape() {
     let error = result.expect_err("request should fail");
     match error {
         OpenRouterError::Api(api_error) => {
-            assert_eq!(api_error.status, StatusCode::BadGateway);
+            assert_eq!(api_error.status, StatusCode::BAD_GATEWAY);
             assert_eq!(api_error.api_code, Some(502));
             assert_eq!(api_error.request_id.as_deref(), Some("req_provider"));
             assert!(api_error.is_retryable());
@@ -219,7 +219,7 @@ async fn test_normalized_moderation_error_shape() {
     let error = result.expect_err("request should fail");
     match error {
         OpenRouterError::Api(api_error) => {
-            assert_eq!(api_error.status, StatusCode::BadRequest);
+            assert_eq!(api_error.status, StatusCode::BAD_REQUEST);
             assert_eq!(api_error.api_code, Some(400));
             assert_eq!(api_error.request_id.as_deref(), Some("req_mod"));
             assert!(!api_error.is_retryable());
@@ -302,7 +302,7 @@ async fn test_plain_text_error_is_still_normalized() {
     let error = result.expect_err("request should fail");
     match error {
         OpenRouterError::Api(api_error) => {
-            assert_eq!(api_error.status, StatusCode::GatewayTimeout);
+            assert_eq!(api_error.status, StatusCode::GATEWAY_TIMEOUT);
             assert_eq!(api_error.api_code, Some(504));
             assert_eq!(api_error.request_id.as_deref(), Some("req_plain"));
             assert_eq!(api_error.message, "upstream timeout");
@@ -315,4 +315,12 @@ async fn test_plain_text_error_is_still_normalized() {
     server
         .join()
         .expect("server thread should join in reasonable time");
+}
+
+#[test]
+fn test_http_request_error_is_backend_neutral() {
+    let error = HttpRequestError::new("connection refused");
+
+    assert_eq!(error.message(), "connection refused");
+    assert_eq!(error.to_string(), "connection refused");
 }


### PR DESCRIPTION
## Summary
- decouple public error/status types from `surf` by switching to `http::StatusCode`
- introduce a backend-neutral `HttpRequestError` wrapper for transport failures
- add focused unit coverage around the normalized error model and chat error handling

## Why
This is part 1 of the transport migration tracked in #173. The first step is to stop leaking `surf` types through the public error surface so the backend can change without forcing downstream code changes.

## Stack
- base: `main`
- follow-up: #175
- follow-up: #176
- follow-up: #177

## Validation
- `cargo test --test unit error_model`
- `cargo test --test unit chat_api`
