### PR TITLE
refactor: migrate non-streaming endpoints to reqwest

### DIFF
--- a/src/api/api_keys.rs
+++ b/src/api/api_keys.rs
@@ -232,9 +232,9 @@ pub(crate) async fn create_api_key_with_client(
         transport_request::post(http_client, &url),
         management_key,
     )
-        .json(&request)
-        .send()
-        .await?;
+    .json(&request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let api_response: ApiResponse<_> =
@@ -389,9 +389,9 @@ pub(crate) async fn update_api_key_with_client(
         transport_request::patch(http_client, &url),
         management_key,
     )
-        .json(&request)
-        .send()
-        .await?;
+    .json(&request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let api_response: ApiResponse<_> =

--- a/src/api/api_keys.rs
+++ b/src/api/api_keys.rs
@@ -1,9 +1,10 @@
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::{ApiResponse, PaginationOptions},
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -105,15 +106,28 @@ pub async fn get_current_api_key(
     base_url: &str,
     api_key: &str,
 ) -> Result<ApiKeyDetails, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_current_api_key_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn get_current_api_key_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<ApiKeyDetails, OpenRouterError> {
     let url = format!("{base_url}/key");
 
-    let response = with_bearer_auth(surf::get(url), api_key).send().await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
-        let api_response: ApiResponse<_> = parse_json_response(response, "current API key").await?;
+        let api_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "current API key").await?;
         Ok(api_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -136,23 +150,45 @@ pub async fn list_api_keys(
     pagination: Option<PaginationOptions>,
     include_disabled: Option<bool>,
 ) -> Result<Vec<ApiKey>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_api_keys_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        pagination,
+        include_disabled,
+    )
+    .await
+}
+
+pub(crate) async fn list_api_keys_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+    include_disabled: Option<bool>,
+) -> Result<Vec<ApiKey>, OpenRouterError> {
     let url = format!("{base_url}/keys");
     let query = ListApiKeysQuery {
         offset: pagination.and_then(|p| p.offset),
         include_disabled,
     };
-    let req = with_bearer_auth(surf::get(url), management_key);
+    let req = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    );
     let response = if query.offset.is_none() && query.include_disabled.is_none() {
-        req.await?
+        req.send().await?
     } else {
-        req.query(&query)?.await?
+        req.query(&query).send().await?
     };
 
     if response.status().is_success() {
-        let api_response: ApiResponse<_> = parse_json_response(response, "API key list").await?;
+        let api_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "API key list").await?;
         Ok(api_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -175,22 +211,37 @@ pub async fn create_api_key(
     name: &str,
     limit: Option<f64>,
 ) -> Result<ApiKey, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_api_key_with_client(&http_client, base_url, management_key, name, limit).await
+}
+
+pub(crate) async fn create_api_key_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    name: &str,
+    limit: Option<f64>,
+) -> Result<ApiKey, OpenRouterError> {
     let url = format!("{base_url}/keys");
     let request = CreateApiKeyRequest {
         name: name.to_string(),
         limit,
     };
 
-    let response = with_bearer_auth(surf::post(url), management_key)
-        .body_json(&request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+        .json(&request)
+        .send()
         .await?;
 
     if response.status().is_success() {
         let api_response: ApiResponse<_> =
-            parse_json_response(response, "API key creation").await?;
+            transport_response::parse_json_response(response, "API key creation").await?;
         Ok(api_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -211,15 +262,31 @@ pub async fn get_api_key(
     management_key: &str,
     hash: &str,
 ) -> Result<ApiKey, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_api_key_with_client(&http_client, base_url, management_key, hash).await
+}
+
+pub(crate) async fn get_api_key_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    hash: &str,
+) -> Result<ApiKey, OpenRouterError> {
     let url = format!("{base_url}/keys/{hash}");
 
-    let response = with_bearer_auth(surf::get(&url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        let api_response: ApiResponse<_> = parse_json_response(response, "API key").await?;
+        let api_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "API key").await?;
         Ok(api_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -240,14 +307,29 @@ pub async fn delete_api_key(
     management_key: &str,
     hash: &str,
 ) -> Result<bool, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_api_key_with_client(&http_client, base_url, management_key, hash).await
+}
+
+pub(crate) async fn delete_api_key_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    hash: &str,
+) -> Result<bool, OpenRouterError> {
     let url = format!("{base_url}/keys/{hash}");
 
-    let response = with_bearer_auth(surf::delete(&url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::delete(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
         Ok(true)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -274,6 +356,28 @@ pub async fn update_api_key(
     disabled: Option<bool>,
     limit: Option<f64>,
 ) -> Result<ApiKey, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    update_api_key_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        hash,
+        name,
+        disabled,
+        limit,
+    )
+    .await
+}
+
+pub(crate) async fn update_api_key_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    hash: &str,
+    name: Option<String>,
+    disabled: Option<bool>,
+    limit: Option<f64>,
+) -> Result<ApiKey, OpenRouterError> {
     let url = format!("{base_url}/keys/{hash}");
     let request = UpdateApiKeyRequest {
         name,
@@ -281,15 +385,20 @@ pub async fn update_api_key(
         limit,
     };
 
-    let response = with_bearer_auth(surf::patch(&url), management_key)
-        .body_json(&request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::patch(http_client, &url),
+        management_key,
+    )
+        .json(&request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        let api_response: ApiResponse<_> = parse_json_response(response, "API key update").await?;
+        let api_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "API key update").await?;
         Ok(api_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -160,10 +160,11 @@ pub(crate) async fn create_auth_code_with_client(
     request: &CreateAuthCodeRequest,
 ) -> Result<AuthCodeData, OpenRouterError> {
     let url = format!("{base_url}/auth/keys/code");
-    let response = transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
-        .json(request)
-        .send()
-        .await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
+            .json(request)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<AuthCodeData> =

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,10 +1,11 @@
 use derive_builder::Builder;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::ApiResponse,
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -100,6 +101,24 @@ pub async fn exchange_code_for_api_key(
     code_verifier: Option<&str>,
     code_challenge_method: Option<CodeChallengeMethod>,
 ) -> Result<AuthResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    exchange_code_for_api_key_with_client(
+        &http_client,
+        base_url,
+        code,
+        code_verifier,
+        code_challenge_method,
+    )
+    .await
+}
+
+pub(crate) async fn exchange_code_for_api_key_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    code: &str,
+    code_verifier: Option<&str>,
+    code_challenge_method: Option<CodeChallengeMethod>,
+) -> Result<AuthResponse, OpenRouterError> {
     let url = format!("{base_url}/auth/keys");
     let request = AuthRequest {
         code: code.to_string(),
@@ -107,14 +126,17 @@ pub async fn exchange_code_for_api_key(
         code_challenge_method,
     };
 
-    let response = surf::post(url).body_json(&request)?.await?;
+    let response = transport_request::post(http_client, &url)
+        .json(&request)
+        .send()
+        .await?;
 
     if response.status().is_success() {
         let auth_response: AuthResponse =
-            parse_json_response(response, "auth key exchange").await?;
+            transport_response::parse_json_response(response, "auth key exchange").await?;
         Ok(auth_response)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -127,17 +149,28 @@ pub async fn create_auth_code(
     api_key: &str,
     request: &CreateAuthCodeRequest,
 ) -> Result<AuthCodeData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_auth_code_with_client(&http_client, base_url, api_key, request).await
+}
+
+pub(crate) async fn create_auth_code_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    request: &CreateAuthCodeRequest,
+) -> Result<AuthCodeData, OpenRouterError> {
     let url = format!("{base_url}/auth/keys/code");
-    let response = with_bearer_auth(surf::post(url), api_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<AuthCodeData> =
-            parse_json_response(response, "auth code creation").await?;
+            transport_response::parse_json_response(response, "auth code creation").await?;
         Ok(payload.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -2,16 +2,18 @@ use std::collections::HashMap;
 
 use derive_builder::Builder;
 use futures_util::{AsyncBufReadExt, StreamExt, stream::BoxStream};
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
     error::OpenRouterError,
     strip_option_map_setter, strip_option_vec_setter,
+    transport::{request as transport_request, response as transport_response},
     types::{
         ProviderPreferences, ReasoningConfig, ResponseFormat, Role, completion::CompletionsResponse,
     },
-    utils::{handle_error, parse_json_response, parse_sse_frames, with_client_request_headers},
+    utils::{handle_error, parse_sse_frames, with_client_request_headers},
 };
 
 /// Image URL with optional detail level for vision models.
@@ -846,20 +848,45 @@ pub async fn send_chat_completion(
     http_referer: &Option<String>,
     request: &ChatCompletionRequest,
 ) -> Result<CompletionsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    send_chat_completion_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn send_chat_completion_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &ChatCompletionRequest,
+) -> Result<CompletionsResponse, OpenRouterError> {
     let url = format!("{base_url}/chat/completions");
 
     // Ensure that the request is not streaming to get a single response
     let request = request.stream(false);
 
-    let surf_req = with_client_request_headers(surf::post(url), api_key, x_title, http_referer)
-        .body_json(&request)?;
-
-    let response = surf_req.await?;
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+    )
+    .json(&request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "chat completion").await
+        transport_response::parse_json_response(response, "chat completion").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/credits.rs
+++ b/src/api/credits.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::ApiResponse,
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 #[derive(Serialize, Deserialize, Debug, Builder)]
@@ -64,18 +65,29 @@ pub async fn create_coinbase_charge(
     api_key: &str,
     request: &CoinbaseChargeRequest,
 ) -> Result<CoinbaseChargeData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_coinbase_charge_with_client(&http_client, base_url, api_key, request).await
+}
+
+pub(crate) async fn create_coinbase_charge_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    request: &CoinbaseChargeRequest,
+) -> Result<CoinbaseChargeData, OpenRouterError> {
     let url = format!("{base_url}/credits/coinbase");
 
-    let response = with_bearer_auth(surf::post(url), api_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
         let charge_response: ApiResponse<CoinbaseChargeData> =
-            parse_json_response(response, "coinbase charge").await?;
+            transport_response::parse_json_response(response, "coinbase charge").await?;
         Ok(charge_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -91,15 +103,28 @@ pub async fn create_coinbase_charge(
 ///
 /// * `Result<CreditsData, OpenRouterError>` - The response data containing the total credits and usage.
 pub async fn get_credits(base_url: &str, api_key: &str) -> Result<CreditsData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_credits_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn get_credits_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<CreditsData, OpenRouterError> {
     let url = format!("{base_url}/credits");
 
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
-        let credits_response: ApiResponse<_> = parse_json_response(response, "credits").await?;
+        let credits_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "credits").await?;
         Ok(credits_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/credits.rs
+++ b/src/api/credits.rs
@@ -77,10 +77,11 @@ pub(crate) async fn create_coinbase_charge_with_client(
 ) -> Result<CoinbaseChargeData, OpenRouterError> {
     let url = format!("{base_url}/credits/coinbase");
 
-    let response = transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
-        .json(request)
-        .send()
-        .await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
+            .json(request)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let charge_response: ApiResponse<CoinbaseChargeData> =

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::ApiResponse,
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 /// Number-like value used by OpenRouter pricing fields.
@@ -191,15 +192,27 @@ pub async fn list_providers(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<Provider>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_providers_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn list_providers_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<Provider>, OpenRouterError> {
     let url = format!("{base_url}/providers");
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let parsed: ApiResponse<Vec<Provider>> =
-            parse_json_response(response, "provider list").await?;
+            transport_response::parse_json_response(response, "provider list").await?;
         Ok(parsed.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -209,15 +222,27 @@ pub async fn list_models_for_user(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<UserModel>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_models_for_user_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn list_models_for_user_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<UserModel>, OpenRouterError> {
     let url = format!("{base_url}/models/user");
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let parsed: ApiResponse<Vec<UserModel>> =
-            parse_json_response(response, "user model list").await?;
+            transport_response::parse_json_response(response, "user model list").await?;
         Ok(parsed.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -227,15 +252,27 @@ pub async fn count_models(
     base_url: &str,
     api_key: &str,
 ) -> Result<ModelsCountData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    count_models_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn count_models_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<ModelsCountData, OpenRouterError> {
     let url = format!("{base_url}/models/count");
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let parsed: ApiResponse<ModelsCountData> =
-            parse_json_response(response, "model count").await?;
+            transport_response::parse_json_response(response, "model count").await?;
         Ok(parsed.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -245,15 +282,27 @@ pub async fn list_zdr_endpoints(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<PublicEndpoint>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_zdr_endpoints_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn list_zdr_endpoints_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<PublicEndpoint>, OpenRouterError> {
     let url = format!("{base_url}/endpoints/zdr");
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let parsed: ApiResponse<Vec<PublicEndpoint>> =
-            parse_json_response(response, "ZDR endpoint list").await?;
+            transport_response::parse_json_response(response, "ZDR endpoint list").await?;
         Ok(parsed.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -266,20 +315,35 @@ pub async fn get_activity(
     management_key: &str,
     date: Option<&str>,
 ) -> Result<Vec<ActivityItem>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_activity_with_client(&http_client, base_url, management_key, date).await
+}
+
+pub(crate) async fn get_activity_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    date: Option<&str>,
+) -> Result<Vec<ActivityItem>, OpenRouterError> {
     let url = if let Some(date) = date {
         format!("{base_url}/activity?date={}", encode(date))
     } else {
         format!("{base_url}/activity")
     };
 
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let parsed: ApiResponse<Vec<ActivityItem>> =
-            parse_json_response(response, "activity list").await?;
+            transport_response::parse_json_response(response, "activity list").await?;
         Ok(parsed.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/embeddings.rs
+++ b/src/api/embeddings.rs
@@ -1,11 +1,12 @@
 use derive_builder::Builder;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     api::models,
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::{ApiResponse, ProviderPreferences},
-    utils::{handle_error, parse_json_response, with_bearer_auth, with_client_request_headers},
 };
 
 /// Supported embedding encoding formats.
@@ -189,19 +190,44 @@ pub async fn create_embedding(
     http_referer: &Option<String>,
     request: &EmbeddingRequest,
 ) -> Result<EmbeddingResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_embedding_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_embedding_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &EmbeddingRequest,
+) -> Result<EmbeddingResponse, OpenRouterError> {
     let url = format!("{base_url}/embeddings");
 
-    let surf_req = with_client_request_headers(surf::post(url), api_key, x_title, http_referer)
-        .body_json(request)?;
-
-    let response = surf_req.await?;
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+    )
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let embedding_response: EmbeddingResponse =
-            parse_json_response(response, "embedding").await?;
+            transport_response::parse_json_response(response, "embedding").await?;
         Ok(embedding_response)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -211,16 +237,28 @@ pub async fn list_embedding_models(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<models::Model>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_embedding_models_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn list_embedding_models_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<models::Model>, OpenRouterError> {
     let url = format!("{base_url}/embeddings/models");
 
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let models_response: ApiResponse<Vec<models::Model>> =
-            parse_json_response(response, "embedding models").await?;
+            transport_response::parse_json_response(response, "embedding models").await?;
         Ok(models_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -1,9 +1,10 @@
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::ApiResponse,
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -52,17 +53,30 @@ pub async fn get_generation(
     api_key: &str,
     id: impl Into<String>,
 ) -> Result<GenerationData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_generation_with_client(&http_client, base_url, api_key, id).await
+}
+
+pub(crate) async fn get_generation_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    id: impl Into<String>,
+) -> Result<GenerationData, OpenRouterError> {
     let id = id.into();
     let url = format!("{base_url}/generation?id={id}");
 
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let generation_response: ApiResponse<_> =
-            parse_json_response(response, "generation").await?;
+            transport_response::parse_json_response(response, "generation").await?;
         Ok(generation_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -1,12 +1,13 @@
 use derive_builder::Builder;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::{
     error::OpenRouterError,
     strip_option_vec_setter,
+    transport::{request as transport_request, response as transport_response},
     types::{ApiResponse, PaginationOptions},
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 /// Guardrail model.
@@ -213,13 +214,28 @@ pub async fn list_guardrails(
     management_key: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailListResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_guardrails_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_guardrails_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<GuardrailListResponse, OpenRouterError> {
     let url = with_pagination(format!("{base_url}/guardrails"), pagination);
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail list").await
+        transport_response::parse_json_response(response, "guardrail list").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -229,17 +245,31 @@ pub async fn create_guardrail(
     management_key: &str,
     request: &CreateGuardrailRequest,
 ) -> Result<Guardrail, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_guardrail_with_client(&http_client, base_url, management_key, request).await
+}
+
+pub(crate) async fn create_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    request: &CreateGuardrailRequest,
+) -> Result<Guardrail, OpenRouterError> {
     let url = format!("{base_url}/guardrails");
-    let response = with_bearer_auth(surf::post(url), management_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<Guardrail> =
-            parse_json_response(response, "guardrail creation").await?;
+            transport_response::parse_json_response(response, "guardrail creation").await?;
         Ok(payload.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -249,15 +279,30 @@ pub async fn get_guardrail(
     management_key: &str,
     id: &str,
 ) -> Result<Guardrail, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_guardrail_with_client(&http_client, base_url, management_key, id).await
+}
+
+pub(crate) async fn get_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<Guardrail, OpenRouterError> {
     let url = format!("{base_url}/guardrails/{}", encode(id));
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<Guardrail> =
-            parse_json_response(response, "guardrail lookup").await?;
+            transport_response::parse_json_response(response, "guardrail lookup").await?;
         Ok(payload.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -268,17 +313,32 @@ pub async fn update_guardrail(
     id: &str,
     request: &UpdateGuardrailRequest,
 ) -> Result<Guardrail, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    update_guardrail_with_client(&http_client, base_url, management_key, id, request).await
+}
+
+pub(crate) async fn update_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateGuardrailRequest,
+) -> Result<Guardrail, OpenRouterError> {
     let url = format!("{base_url}/guardrails/{}", encode(id));
-    let response = with_bearer_auth(surf::patch(url), management_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::patch(http_client, &url),
+        management_key,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<Guardrail> =
-            parse_json_response(response, "guardrail update").await?;
+            transport_response::parse_json_response(response, "guardrail update").await?;
         Ok(payload.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -288,15 +348,30 @@ pub async fn delete_guardrail(
     management_key: &str,
     id: &str,
 ) -> Result<bool, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_guardrail_with_client(&http_client, base_url, management_key, id).await
+}
+
+pub(crate) async fn delete_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<bool, OpenRouterError> {
     let url = format!("{base_url}/guardrails/{}", encode(id));
-    let response = with_bearer_auth(surf::delete(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::delete(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let payload: DeleteGuardrailResponse =
-            parse_json_response(response, "guardrail deletion").await?;
+            transport_response::parse_json_response(response, "guardrail deletion").await?;
         Ok(payload.deleted)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -307,16 +382,39 @@ pub async fn list_guardrail_key_assignments(
     id: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailKeyAssignmentsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_guardrail_key_assignments_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        pagination,
+    )
+    .await
+}
+
+pub(crate) async fn list_guardrail_key_assignments_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<GuardrailKeyAssignmentsResponse, OpenRouterError> {
     let url = with_pagination(
         format!("{base_url}/guardrails/{}/assignments/keys", encode(id)),
         pagination,
     );
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail key assignments").await
+        transport_response::parse_json_response(response, "guardrail key assignments").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -327,15 +425,31 @@ pub async fn bulk_assign_keys_to_guardrail(
     id: &str,
     request: &BulkKeyAssignmentRequest,
 ) -> Result<AssignedCountResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    bulk_assign_keys_to_guardrail_with_client(&http_client, base_url, management_key, id, request)
+        .await
+}
+
+pub(crate) async fn bulk_assign_keys_to_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkKeyAssignmentRequest,
+) -> Result<AssignedCountResponse, OpenRouterError> {
     let url = format!("{base_url}/guardrails/{}/assignments/keys", encode(id));
-    let response = with_bearer_auth(surf::post(url), management_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail key bulk assignment").await
+        transport_response::parse_json_response(response, "guardrail key bulk assignment").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -346,18 +460,40 @@ pub async fn bulk_unassign_keys_from_guardrail(
     id: &str,
     request: &BulkKeyAssignmentRequest,
 ) -> Result<UnassignedCountResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    bulk_unassign_keys_from_guardrail_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn bulk_unassign_keys_from_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkKeyAssignmentRequest,
+) -> Result<UnassignedCountResponse, OpenRouterError> {
     let url = format!(
         "{base_url}/guardrails/{}/assignments/keys/remove",
         encode(id)
     );
-    let response = with_bearer_auth(surf::post(url), management_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail key bulk removal").await
+        transport_response::parse_json_response(response, "guardrail key bulk removal").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -368,16 +504,39 @@ pub async fn list_guardrail_member_assignments(
     id: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailMemberAssignmentsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_guardrail_member_assignments_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        pagination,
+    )
+    .await
+}
+
+pub(crate) async fn list_guardrail_member_assignments_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<GuardrailMemberAssignmentsResponse, OpenRouterError> {
     let url = with_pagination(
         format!("{base_url}/guardrails/{}/assignments/members", encode(id)),
         pagination,
     );
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail member assignments").await
+        transport_response::parse_json_response(response, "guardrail member assignments").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -388,15 +547,37 @@ pub async fn bulk_assign_members_to_guardrail(
     id: &str,
     request: &BulkMemberAssignmentRequest,
 ) -> Result<AssignedCountResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    bulk_assign_members_to_guardrail_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn bulk_assign_members_to_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkMemberAssignmentRequest,
+) -> Result<AssignedCountResponse, OpenRouterError> {
     let url = format!("{base_url}/guardrails/{}/assignments/members", encode(id));
-    let response = with_bearer_auth(surf::post(url), management_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail member bulk assignment").await
+        transport_response::parse_json_response(response, "guardrail member bulk assignment").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -407,18 +588,40 @@ pub async fn bulk_unassign_members_from_guardrail(
     id: &str,
     request: &BulkMemberAssignmentRequest,
 ) -> Result<UnassignedCountResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    bulk_unassign_members_from_guardrail_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn bulk_unassign_members_from_guardrail_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &BulkMemberAssignmentRequest,
+) -> Result<UnassignedCountResponse, OpenRouterError> {
     let url = format!(
         "{base_url}/guardrails/{}/assignments/members/remove",
         encode(id)
     );
-    let response = with_bearer_auth(surf::post(url), management_key)
-        .body_json(request)?
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "guardrail member bulk removal").await
+        transport_response::parse_json_response(response, "guardrail member bulk removal").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -428,16 +631,31 @@ pub async fn list_key_assignments(
     management_key: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailKeyAssignmentsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_key_assignments_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_key_assignments_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<GuardrailKeyAssignmentsResponse, OpenRouterError> {
     let url = with_pagination(
         format!("{base_url}/guardrails/assignments/keys"),
         pagination,
     );
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "global key assignments").await
+        transport_response::parse_json_response(response, "global key assignments").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -447,16 +665,31 @@ pub async fn list_member_assignments(
     management_key: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailMemberAssignmentsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_member_assignments_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_member_assignments_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<GuardrailMemberAssignmentsResponse, OpenRouterError> {
     let url = with_pagination(
         format!("{base_url}/guardrails/assignments/members"),
         pagination,
     );
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "global member assignments").await
+        transport_response::parse_json_response(response, "global member assignments").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -260,9 +260,9 @@ pub(crate) async fn create_guardrail_with_client(
         transport_request::post(http_client, &url),
         management_key,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<Guardrail> =
@@ -329,9 +329,9 @@ pub(crate) async fn update_guardrail_with_client(
         transport_request::patch(http_client, &url),
         management_key,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let payload: ApiResponse<Guardrail> =
@@ -442,9 +442,9 @@ pub(crate) async fn bulk_assign_keys_to_guardrail_with_client(
         transport_request::post(http_client, &url),
         management_key,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "guardrail key bulk assignment").await
@@ -486,9 +486,9 @@ pub(crate) async fn bulk_unassign_keys_from_guardrail_with_client(
         transport_request::post(http_client, &url),
         management_key,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "guardrail key bulk removal").await
@@ -570,9 +570,9 @@ pub(crate) async fn bulk_assign_members_to_guardrail_with_client(
         transport_request::post(http_client, &url),
         management_key,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "guardrail member bulk assignment").await
@@ -614,9 +614,9 @@ pub(crate) async fn bulk_unassign_members_from_guardrail_with_client(
         transport_request::post(http_client, &url),
         management_key,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "guardrail member bulk removal").await

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use derive_builder::Builder;
 use futures_util::{AsyncBufReadExt, StreamExt, stream::BoxStream};
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -9,8 +10,9 @@ use crate::{
     api::chat::{CacheControl, Plugin, TraceOptions},
     error::OpenRouterError,
     strip_option_vec_setter,
+    transport::{request as transport_request, response as transport_response},
     types::ProviderPreferences,
-    utils::{handle_error, parse_json_response, parse_sse_frames, with_client_request_headers},
+    utils::{handle_error, parse_sse_frames, with_client_request_headers},
 };
 
 /// Role for Anthropic-compatible messages.
@@ -670,20 +672,45 @@ pub async fn create_message(
     http_referer: &Option<String>,
     request: &AnthropicMessagesRequest,
 ) -> Result<AnthropicMessagesResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_message_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_message_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &AnthropicMessagesRequest,
+) -> Result<AnthropicMessagesResponse, OpenRouterError> {
     let url = format!("{base_url}/messages");
     let request = request.stream(false);
 
-    let surf_req = with_client_request_headers(surf::post(url), api_key, x_title, http_referer)
-        .body_json(&request)?;
-
-    let response = surf_req.await?;
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+    )
+    .json(&request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let response_data: AnthropicMessagesResponse =
-            parse_json_response(response, "messages API").await?;
+            transport_response::parse_json_response(response, "messages API").await?;
         Ok(response_data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,10 +1,11 @@
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::{ApiResponse, ModelCategory, SupportedParameters},
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -104,6 +105,24 @@ pub async fn list_models(
     category: Option<ModelCategory>,
     supported_parameters: Option<SupportedParameters>,
 ) -> Result<Vec<Model>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_models_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        category,
+        supported_parameters,
+    )
+    .await
+}
+
+pub(crate) async fn list_models_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    category: Option<ModelCategory>,
+    supported_parameters: Option<SupportedParameters>,
+) -> Result<Vec<Model>, OpenRouterError> {
     #[derive(Serialize)]
     struct ListModelsQuery {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,19 +137,20 @@ pub async fn list_models(
         supported_parameters,
     };
 
-    let req = with_bearer_auth(surf::get(url), api_key);
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
     let response = if query.category.is_none() && query.supported_parameters.is_none() {
-        req.await?
+        req.send().await?
     } else {
-        req.query(&query)?.await?
+        req.query(&query).send().await?
     };
 
     if response.status().is_success() {
         let model_list_response: ApiResponse<_> =
-            parse_json_response(response, "model list").await?;
+            transport_response::parse_json_response(response, "model list").await?;
         Ok(model_list_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -153,18 +173,32 @@ pub async fn list_model_endpoints(
     author: &str,
     slug: &str,
 ) -> Result<EndpointData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_model_endpoints_with_client(&http_client, base_url, api_key, author, slug).await
+}
+
+pub(crate) async fn list_model_endpoints_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    author: &str,
+    slug: &str,
+) -> Result<EndpointData, OpenRouterError> {
     let encoded_author = encode(author);
     let encoded_slug = encode(slug);
     let url = format!("{base_url}/models/{encoded_author}/{encoded_slug}/endpoints");
 
-    let response = with_bearer_auth(surf::get(&url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let endpoint_list_response: ApiResponse<_> =
-            parse_json_response(response, "model endpoint list").await?;
+            transport_response::parse_json_response(response, "model endpoint list").await?;
         Ok(endpoint_list_response.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/organization.rs
+++ b/src/api/organization.rs
@@ -1,9 +1,10 @@
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::PaginationOptions,
-    utils::{handle_error, parse_json_response, with_bearer_auth},
 };
 
 /// One organization member returned by `GET /organization/members`.
@@ -46,13 +47,28 @@ pub async fn list_organization_members(
     management_key: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<OrganizationMembersResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_organization_members_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_organization_members_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<OrganizationMembersResponse, OpenRouterError> {
     let url = with_pagination(format!("{base_url}/organization/members"), pagination);
-    let response = with_bearer_auth(surf::get(url), management_key).await?;
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "organization members").await
+        transport_response::parse_json_response(response, "organization members").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/rerank.rs
+++ b/src/api/rerank.rs
@@ -104,9 +104,9 @@ pub(crate) async fn create_rerank_with_client(
         x_title,
         http_referer,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "rerank").await

--- a/src/api/rerank.rs
+++ b/src/api/rerank.rs
@@ -1,10 +1,11 @@
 use derive_builder::Builder;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
     types::ProviderPreferences,
-    utils::{handle_error, parse_json_response, with_client_request_headers},
 };
 
 /// Request payload for `POST /rerank`.
@@ -76,15 +77,41 @@ pub async fn create_rerank(
     http_referer: &Option<String>,
     request: &RerankRequest,
 ) -> Result<RerankResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_rerank_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_rerank_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &RerankRequest,
+) -> Result<RerankResponse, OpenRouterError> {
     let url = format!("{base_url}/rerank");
-    let response = with_client_request_headers(surf::post(url), api_key, x_title, http_referer)
-        .body_json(request)?
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "rerank").await
+        transport_response::parse_json_response(response, "rerank").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use derive_builder::Builder;
 use futures_util::{AsyncBufReadExt, StreamExt, stream::BoxStream};
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -9,8 +10,9 @@ use crate::{
     api::chat::{Plugin, TraceOptions},
     error::OpenRouterError,
     strip_option_map_setter, strip_option_vec_setter,
+    transport::{request as transport_request, response as transport_response},
     types::ProviderPreferences,
-    utils::{handle_error, parse_json_response, parse_sse_frames, with_client_request_headers},
+    utils::{handle_error, parse_sse_frames, with_client_request_headers},
 };
 
 /// Request body for the OpenRouter Responses API (`POST /responses`).
@@ -228,20 +230,45 @@ pub async fn create_response(
     http_referer: &Option<String>,
     request: &ResponsesRequest,
 ) -> Result<ResponsesResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_response_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_response_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &ResponsesRequest,
+) -> Result<ResponsesResponse, OpenRouterError> {
     let url = format!("{base_url}/responses");
     let request = request.stream(false);
 
-    let surf_req = with_client_request_headers(surf::post(url), api_key, x_title, http_referer)
-        .body_json(&request)?;
-
-    let response = surf_req.await?;
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+    )
+    .json(&request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         let response_data: ResponsesResponse =
-            parse_json_response(response, "responses API").await?;
+            transport_response::parse_json_response(response, "responses API").await?;
         Ok(response_data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::{
     error::OpenRouterError,
-    utils::{handle_error, parse_json_response, with_bearer_auth, with_client_request_headers},
+    transport::{request as transport_request, response as transport_response},
 };
 
 /// One image URL payload used in video generation requests.
@@ -165,15 +166,41 @@ pub async fn create_video_generation(
     http_referer: &Option<String>,
     request: &VideoGenerationRequest,
 ) -> Result<VideoGenerationResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_video_generation_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_video_generation_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    request: &VideoGenerationRequest,
+) -> Result<VideoGenerationResponse, OpenRouterError> {
     let url = format!("{base_url}/videos");
-    let response = with_client_request_headers(surf::post(url), api_key, x_title, http_referer)
-        .body_json(request)?
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+    )
+        .json(request)
+        .send()
         .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "video generation").await
+        transport_response::parse_json_response(response, "video generation").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -183,15 +210,27 @@ pub async fn list_video_models(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<VideoModel>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_video_models_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn list_video_models_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<VideoModel>, OpenRouterError> {
     let url = format!("{base_url}/videos/models");
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
         let payload: crate::types::ApiResponse<Vec<VideoModel>> =
-            parse_json_response(response, "video models").await?;
+            transport_response::parse_json_response(response, "video models").await?;
         Ok(payload.data)
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -202,13 +241,26 @@ pub async fn get_video_generation(
     api_key: &str,
     job_id: &str,
 ) -> Result<VideoGenerationResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_video_generation_with_client(&http_client, base_url, api_key, job_id).await
+}
+
+pub(crate) async fn get_video_generation_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    job_id: &str,
+) -> Result<VideoGenerationResponse, OpenRouterError> {
     let url = format!("{base_url}/videos/{}", encode(job_id));
-    let response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
-        parse_json_response(response, "video generation status").await
+        transport_response::parse_json_response(response, "video generation status").await
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }
@@ -220,17 +272,31 @@ pub async fn get_video_content(
     job_id: &str,
     index: Option<u32>,
 ) -> Result<Vec<u8>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_video_content_with_client(&http_client, base_url, api_key, job_id, index).await
+}
+
+pub(crate) async fn get_video_content_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    job_id: &str,
+    index: Option<u32>,
+) -> Result<Vec<u8>, OpenRouterError> {
     let mut url = format!("{base_url}/videos/{}/content", encode(job_id));
     if let Some(index) = index {
         url = format!("{url}?index={index}");
     }
 
-    let mut response = with_bearer_auth(surf::get(url), api_key).await?;
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
 
     if response.status().is_success() {
-        Ok(response.body_bytes().await?)
+        Ok(response.bytes().await?.to_vec())
     } else {
-        handle_error(response).await?;
+        transport_response::handle_error(response).await?;
         unreachable!()
     }
 }

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -193,9 +193,9 @@ pub(crate) async fn create_video_generation_with_client(
         x_title,
         http_referer,
     )
-        .json(request)
-        .send()
-        .await?;
+    .json(request)
+    .send()
+    .await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "video generation").await

--- a/src/client.rs
+++ b/src/client.rs
@@ -1046,8 +1046,7 @@ impl OpenRouterClient {
     /// List all available video generation models.
     pub async fn list_video_models(&self) -> Result<Vec<videos::VideoModel>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            videos::list_video_models_with_client(self.http_client(), &self.base_url, api_key)
-                .await
+            videos::list_video_models_with_client(self.http_client(), &self.base_url, api_key).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1357,8 +1356,7 @@ impl OpenRouterClient {
     /// for consistency with other client operations.
     pub async fn list_providers(&self) -> Result<Vec<discovery::Provider>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::list_providers_with_client(self.http_client(), &self.base_url, api_key)
-                .await
+            discovery::list_providers_with_client(self.http_client(), &self.base_url, api_key).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1369,12 +1367,8 @@ impl OpenRouterClient {
     /// Equivalent to `GET /models/user`.
     pub async fn list_models_for_user(&self) -> Result<Vec<discovery::UserModel>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::list_models_for_user_with_client(
-                self.http_client(),
-                &self.base_url,
-                api_key,
-            )
-            .await
+            discovery::list_models_for_user_with_client(self.http_client(), &self.base_url, api_key)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1385,8 +1379,7 @@ impl OpenRouterClient {
     /// Equivalent to `GET /models/count`.
     pub async fn count_models(&self) -> Result<discovery::ModelsCountData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::count_models_with_client(self.http_client(), &self.base_url, api_key)
-                .await
+            discovery::count_models_with_client(self.http_client(), &self.base_url, api_key).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1399,12 +1392,8 @@ impl OpenRouterClient {
         &self,
     ) -> Result<Vec<discovery::PublicEndpoint>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::list_zdr_endpoints_with_client(
-                self.http_client(),
-                &self.base_url,
-                api_key,
-            )
-            .await
+            discovery::list_zdr_endpoints_with_client(self.http_client(), &self.base_url, api_key)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -190,7 +190,14 @@ impl OpenRouterClient {
         limit: Option<f64>,
     ) -> Result<api_keys::ApiKey, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            api_keys::create_api_key(&self.base_url, management_key, name, limit).await
+            api_keys::create_api_key_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                name,
+                limit,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -217,7 +224,8 @@ impl OpenRouterClient {
         &self,
     ) -> Result<api_keys::ApiKeyDetails, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            api_keys::get_current_api_key(&self.base_url, api_key).await
+            api_keys::get_current_api_key_with_client(self.http_client(), &self.base_url, api_key)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -246,7 +254,13 @@ impl OpenRouterClient {
     /// ```
     pub async fn delete_api_key(&self, hash: &str) -> Result<bool, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            api_keys::delete_api_key(&self.base_url, management_key, hash).await
+            api_keys::delete_api_key_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                hash,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -284,8 +298,16 @@ impl OpenRouterClient {
         limit: Option<f64>,
     ) -> Result<api_keys::ApiKey, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            api_keys::update_api_key(&self.base_url, management_key, hash, name, disabled, limit)
-                .await
+            api_keys::update_api_key_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                hash,
+                name,
+                disabled,
+                limit,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -297,8 +319,14 @@ impl OpenRouterClient {
         include_disabled: Option<bool>,
     ) -> Result<Vec<api_keys::ApiKey>, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            api_keys::list_api_keys(&self.base_url, management_key, pagination, include_disabled)
-                .await
+            api_keys::list_api_keys_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+                include_disabled,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -327,7 +355,13 @@ impl OpenRouterClient {
     /// ```
     pub async fn get_api_key(&self, hash: &str) -> Result<api_keys::ApiKey, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            api_keys::get_api_key(&self.base_url, management_key, hash).await
+            api_keys::get_api_key_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                hash,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -375,7 +409,8 @@ impl OpenRouterClient {
         request: &auth::CreateAuthCodeRequest,
     ) -> Result<auth::AuthCodeData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            auth::create_auth_code(&self.base_url, api_key, request).await
+            auth::create_auth_code_with_client(self.http_client(), &self.base_url, api_key, request)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -387,7 +422,13 @@ impl OpenRouterClient {
         pagination: Option<PaginationOptions>,
     ) -> Result<guardrails::GuardrailListResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::list_guardrails(&self.base_url, management_key, pagination).await
+            guardrails::list_guardrails_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -399,7 +440,13 @@ impl OpenRouterClient {
         request: &guardrails::CreateGuardrailRequest,
     ) -> Result<guardrails::Guardrail, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::create_guardrail(&self.base_url, management_key, request).await
+            guardrails::create_guardrail_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                request,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -408,7 +455,13 @@ impl OpenRouterClient {
     /// Get a guardrail by ID (`GET /guardrails/{id}`). Requires a management key.
     pub async fn get_guardrail(&self, id: &str) -> Result<guardrails::Guardrail, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::get_guardrail(&self.base_url, management_key, id).await
+            guardrails::get_guardrail_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -421,7 +474,14 @@ impl OpenRouterClient {
         request: &guardrails::UpdateGuardrailRequest,
     ) -> Result<guardrails::Guardrail, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::update_guardrail(&self.base_url, management_key, id, request).await
+            guardrails::update_guardrail_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                request,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -430,7 +490,13 @@ impl OpenRouterClient {
     /// Delete a guardrail (`DELETE /guardrails/{id}`). Requires a management key.
     pub async fn delete_guardrail(&self, id: &str) -> Result<bool, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::delete_guardrail(&self.base_url, management_key, id).await
+            guardrails::delete_guardrail_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -443,7 +509,8 @@ impl OpenRouterClient {
         pagination: Option<PaginationOptions>,
     ) -> Result<guardrails::GuardrailKeyAssignmentsResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::list_guardrail_key_assignments(
+            guardrails::list_guardrail_key_assignments_with_client(
+                self.http_client(),
                 &self.base_url,
                 management_key,
                 id,
@@ -462,8 +529,14 @@ impl OpenRouterClient {
         request: &guardrails::BulkKeyAssignmentRequest,
     ) -> Result<guardrails::AssignedCountResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::bulk_assign_keys_to_guardrail(&self.base_url, management_key, id, request)
-                .await
+            guardrails::bulk_assign_keys_to_guardrail_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                request,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -476,7 +549,8 @@ impl OpenRouterClient {
         request: &guardrails::BulkKeyAssignmentRequest,
     ) -> Result<guardrails::UnassignedCountResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::bulk_unassign_keys_from_guardrail(
+            guardrails::bulk_unassign_keys_from_guardrail_with_client(
+                self.http_client(),
                 &self.base_url,
                 management_key,
                 id,
@@ -495,7 +569,8 @@ impl OpenRouterClient {
         pagination: Option<PaginationOptions>,
     ) -> Result<guardrails::GuardrailMemberAssignmentsResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::list_guardrail_member_assignments(
+            guardrails::list_guardrail_member_assignments_with_client(
+                self.http_client(),
                 &self.base_url,
                 management_key,
                 id,
@@ -514,7 +589,8 @@ impl OpenRouterClient {
         request: &guardrails::BulkMemberAssignmentRequest,
     ) -> Result<guardrails::AssignedCountResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::bulk_assign_members_to_guardrail(
+            guardrails::bulk_assign_members_to_guardrail_with_client(
+                self.http_client(),
                 &self.base_url,
                 management_key,
                 id,
@@ -533,7 +609,8 @@ impl OpenRouterClient {
         request: &guardrails::BulkMemberAssignmentRequest,
     ) -> Result<guardrails::UnassignedCountResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::bulk_unassign_members_from_guardrail(
+            guardrails::bulk_unassign_members_from_guardrail_with_client(
+                self.http_client(),
                 &self.base_url,
                 management_key,
                 id,
@@ -551,7 +628,13 @@ impl OpenRouterClient {
         pagination: Option<PaginationOptions>,
     ) -> Result<guardrails::GuardrailKeyAssignmentsResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::list_key_assignments(&self.base_url, management_key, pagination).await
+            guardrails::list_key_assignments_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -563,7 +646,13 @@ impl OpenRouterClient {
         pagination: Option<PaginationOptions>,
     ) -> Result<guardrails::GuardrailMemberAssignmentsResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            guardrails::list_member_assignments(&self.base_url, management_key, pagination).await
+            guardrails::list_member_assignments_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -602,8 +691,14 @@ impl OpenRouterClient {
         code_verifier: Option<&str>,
         code_challenge_method: Option<auth::CodeChallengeMethod>,
     ) -> Result<auth::AuthResponse, OpenRouterError> {
-        auth::exchange_code_for_api_key(&self.base_url, code, code_verifier, code_challenge_method)
-            .await
+        auth::exchange_code_for_api_key_with_client(
+            self.http_client(),
+            &self.base_url,
+            code,
+            code_verifier,
+            code_challenge_method,
+        )
+        .await
     }
 
     /// Send a chat completion request to a selected model.
@@ -638,7 +733,8 @@ impl OpenRouterClient {
         request: &chat::ChatCompletionRequest,
     ) -> Result<CompletionsResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            chat::send_chat_completion(
+            chat::send_chat_completion_with_client(
+                self.http_client(),
                 &self.base_url,
                 api_key,
                 &self.x_title,
@@ -775,7 +871,8 @@ impl OpenRouterClient {
         request: &responses::ResponsesRequest,
     ) -> Result<responses::ResponsesResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            responses::create_response(
+            responses::create_response_with_client(
+                self.http_client(),
                 &self.base_url,
                 api_key,
                 &self.x_title,
@@ -833,7 +930,8 @@ impl OpenRouterClient {
         request: &messages::AnthropicMessagesRequest,
     ) -> Result<messages::AnthropicMessagesResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            messages::create_message(
+            messages::create_message_with_client(
+                self.http_client(),
                 &self.base_url,
                 api_key,
                 &self.x_title,
@@ -891,7 +989,8 @@ impl OpenRouterClient {
         request: &embeddings::EmbeddingRequest,
     ) -> Result<embeddings::EmbeddingResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            embeddings::create_embedding(
+            embeddings::create_embedding_with_client(
+                self.http_client(),
                 &self.base_url,
                 api_key,
                 &self.x_title,
@@ -910,7 +1009,8 @@ impl OpenRouterClient {
         request: &rerank::RerankRequest,
     ) -> Result<rerank::RerankResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            rerank::create_rerank(
+            rerank::create_rerank_with_client(
+                self.http_client(),
                 &self.base_url,
                 api_key,
                 &self.x_title,
@@ -929,7 +1029,8 @@ impl OpenRouterClient {
         request: &videos::VideoGenerationRequest,
     ) -> Result<videos::VideoGenerationResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            videos::create_video_generation(
+            videos::create_video_generation_with_client(
+                self.http_client(),
                 &self.base_url,
                 api_key,
                 &self.x_title,
@@ -945,7 +1046,8 @@ impl OpenRouterClient {
     /// List all available video generation models.
     pub async fn list_video_models(&self) -> Result<Vec<videos::VideoModel>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            videos::list_video_models(&self.base_url, api_key).await
+            videos::list_video_models_with_client(self.http_client(), &self.base_url, api_key)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -957,7 +1059,13 @@ impl OpenRouterClient {
         job_id: &str,
     ) -> Result<videos::VideoGenerationResponse, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            videos::get_video_generation(&self.base_url, api_key, job_id).await
+            videos::get_video_generation_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                job_id,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -970,7 +1078,14 @@ impl OpenRouterClient {
         index: Option<u32>,
     ) -> Result<Vec<u8>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            videos::get_video_content(&self.base_url, api_key, job_id, index).await
+            videos::get_video_content_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                job_id,
+                index,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -979,7 +1094,12 @@ impl OpenRouterClient {
     /// List all available embeddings models.
     pub async fn list_embedding_models(&self) -> Result<Vec<models::Model>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            embeddings::list_embedding_models(&self.base_url, api_key).await
+            embeddings::list_embedding_models_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1016,7 +1136,13 @@ impl OpenRouterClient {
         request: &credits::CoinbaseChargeRequest,
     ) -> Result<credits::CoinbaseChargeData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            credits::create_coinbase_charge(&self.base_url, api_key, request).await
+            credits::create_coinbase_charge_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                request,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1041,7 +1167,7 @@ impl OpenRouterClient {
     /// ```
     pub async fn get_credits(&self) -> Result<credits::CreditsData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            credits::get_credits(&self.base_url, api_key).await
+            credits::get_credits_with_client(self.http_client(), &self.base_url, api_key).await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1073,7 +1199,8 @@ impl OpenRouterClient {
         id: impl Into<String>,
     ) -> Result<generation::GenerationData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            generation::get_generation(&self.base_url, api_key, id).await
+            generation::get_generation_with_client(self.http_client(), &self.base_url, api_key, id)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1098,7 +1225,8 @@ impl OpenRouterClient {
     /// ```
     pub async fn list_models(&self) -> Result<Vec<models::Model>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            models::list_models(&self.base_url, api_key, None, None).await
+            models::list_models_with_client(self.http_client(), &self.base_url, api_key, None, None)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1130,7 +1258,14 @@ impl OpenRouterClient {
         category: ModelCategory,
     ) -> Result<Vec<models::Model>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            models::list_models(&self.base_url, api_key, Some(category), None).await
+            models::list_models_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                Some(category),
+                None,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1162,7 +1297,14 @@ impl OpenRouterClient {
         supported_parameters: SupportedParameters,
     ) -> Result<Vec<models::Model>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            models::list_models(&self.base_url, api_key, None, Some(supported_parameters)).await
+            models::list_models_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                None,
+                Some(supported_parameters),
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1196,7 +1338,14 @@ impl OpenRouterClient {
         slug: &str,
     ) -> Result<models::EndpointData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            models::list_model_endpoints(&self.base_url, api_key, author, slug).await
+            models::list_model_endpoints_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                author,
+                slug,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1208,7 +1357,8 @@ impl OpenRouterClient {
     /// for consistency with other client operations.
     pub async fn list_providers(&self) -> Result<Vec<discovery::Provider>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::list_providers(&self.base_url, api_key).await
+            discovery::list_providers_with_client(self.http_client(), &self.base_url, api_key)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1219,7 +1369,12 @@ impl OpenRouterClient {
     /// Equivalent to `GET /models/user`.
     pub async fn list_models_for_user(&self) -> Result<Vec<discovery::UserModel>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::list_models_for_user(&self.base_url, api_key).await
+            discovery::list_models_for_user_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1230,7 +1385,8 @@ impl OpenRouterClient {
     /// Equivalent to `GET /models/count`.
     pub async fn count_models(&self) -> Result<discovery::ModelsCountData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::count_models(&self.base_url, api_key).await
+            discovery::count_models_with_client(self.http_client(), &self.base_url, api_key)
+                .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1243,7 +1399,12 @@ impl OpenRouterClient {
         &self,
     ) -> Result<Vec<discovery::PublicEndpoint>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            discovery::list_zdr_endpoints(&self.base_url, api_key).await
+            discovery::list_zdr_endpoints_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1262,7 +1423,13 @@ impl OpenRouterClient {
         date: Option<&str>,
     ) -> Result<Vec<discovery::ActivityItem>, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            discovery::get_activity(&self.base_url, management_key, date).await
+            discovery::get_activity_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                date,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1274,8 +1441,13 @@ impl OpenRouterClient {
         pagination: Option<PaginationOptions>,
     ) -> Result<organization::OrganizationMembersResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
-            organization::list_organization_members(&self.base_url, management_key, pagination)
-                .await
+            organization::list_organization_members_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -146,6 +146,7 @@ where
     .boxed()
 }
 
+#[allow(dead_code)]
 fn body_preview(body_text: &str, limit: usize) -> String {
     let normalized = body_text.replace('\r', "\\r").replace('\n', "\\n");
     let mut preview = String::new();
@@ -183,6 +184,7 @@ fn response_request_id(response: &Response) -> Option<String> {
         })
 }
 
+#[allow(dead_code)]
 fn body_contains_api_error(body_text: &str) -> bool {
     serde_json::from_str::<Value>(body_text)
         .ok()
@@ -190,6 +192,7 @@ fn body_contains_api_error(body_text: &str) -> bool {
         .is_some()
 }
 
+#[allow(dead_code)]
 pub(crate) fn response_deserialization_error(
     context: &str,
     status: StatusCode,
@@ -202,6 +205,7 @@ pub(crate) fn response_deserialization_error(
     ))
 }
 
+#[allow(dead_code)]
 pub(crate) async fn parse_json_response<T: DeserializeOwned>(
     mut response: Response,
     context: &str,


### PR DESCRIPTION
## Summary
- migrate non-streaming API modules onto the private reqwest transport helpers
- route hidden `OpenRouterClient` methods through the shared internal client
- keep the public endpoint module signatures stable by adding internal `*_with_client` helpers

## Why
This is part 3 of #173. With the private reqwest transport in place, this PR moves the non-streaming request paths first so the final surf removal can be isolated to streaming and legacy cleanup.

## Stack
- base: #175
- next: #177

## Validation
- `cargo test --test unit`
