### PR TITLE
chore: prepare 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-18
+
 ### Added
 - Added an `axum` gateway example and a practical typed-tool agent example so the repository covers copyable Rust application patterns instead of only endpoint-level demos.
 - Added `docs/cli-automation-workflows.md` with JSON-first shell and CI recipes for discovery, usage reporting, and ephemeral key automation.
@@ -15,10 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added runnable examples for rerank requests, video generation submission, and organization-member listing.
 
 ### Changed
+- Completed the SDK HTTP transport migration from `surf -> isahc -> curl` to a Tokio-native `reqwest + rustls` stack while keeping the canonical domain-oriented client surface and SSE semantics intact.
+- Normalized the public HTTP error surface around backend-neutral `HttpRequestError` and `http::StatusCode` so transport details no longer leak through public SDK types.
 - Reorganized the README example/docs surface around application patterns, Tokio streaming, and CLI automation workflows.
 - Aligned OpenAPI drift follow-up docs and issue wording with the new compatibility-update cadence and reporting surfaces.
 - Accepted the 2026-04-18 upstream OpenAPI drift baseline and added typed embedding usage support for `prompt_tokens_details`.
 - Restored the repository snapshot to `42 / 42` official endpoint coverage and aligned the endpoint matrix, README, docs.rs surface, and Awesome OpenRouter submission materials with the newly implemented rerank, videos, and organization-member endpoints.
+
+### Removed
+- Removed `surf` from the SDK dependency graph, including the transitive `curl` chain that came from the legacy transport stack.
+- Removed the public `utils` transport shims `with_bearer_auth`, `with_request_metadata`, `with_client_request_headers`, and `handle_error`. Callers that need custom HTTP glue should keep it in their own application code and treat `openrouter-rs` as the typed domain client layer.
 
 ## [0.7.0] - 2026-03-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file gives repository-specific guidance for coding agents working in `openr
 
 ## Current SDK Shape
 
-The crate is on `0.6.0` and the public documentation treats the domain-oriented surface as canonical:
+The crate is on `0.8.0` and the public documentation treats the domain-oriented surface as canonical:
 
 - `client.chat()`
 - `client.responses()`
@@ -79,13 +79,13 @@ cargo run -p openrouter-cli -- --help
 ## Implementation Notes
 
 - Request and client construction use the builder pattern (`derive_builder`).
-- The crate uses `surf` for HTTP and `tokio` for async runtime.
+- The crate uses `reqwest + rustls` for HTTP and `tokio` for async runtime.
 - Streaming is exposed in three forms:
   - raw endpoint streams
   - `ToolAwareStream` for assembled tool calls
   - `UnifiedStreamEvent` across chat, responses, and messages
 - File/profile config resolution is intentionally scoped to `openrouter-cli`, not the core SDK crate.
-- `legacy-completions` is opt-in in `0.6.x`.
+- `legacy-completions` is opt-in in `0.8.x`.
 
 ## Documentation Expectations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,104 @@
 # Migration Guide: 0.5.x -> 0.6.0
 
+This document keeps the historical `0.5.x -> 0.6.0` migration guide intact because the repo still smoke-tests that older domain/naming transition.
+
+> Latest breaking release: `0.7.x -> 0.8.0`.
+> `0.8.0` completes the HTTP transport migration to `reqwest + rustls` and removes the remaining `surf`-shaped public helpers from the SDK surface.
+
+## Latest: 0.7.x -> 0.8.0
+
+If you already use the canonical domain clients (`chat()`, `responses()`, `messages()`, `models()`, `management()`, and opt-in `legacy()`), this upgrade is usually just a version bump plus a recompile. The breaking changes mainly affect callers that coupled themselves to the old transport-facing error and utility surface.
+
+### Quick Checklist For 0.8.0
+
+- Replace `OpenRouterError::HttpRequest(surf::Error)` handling with backend-neutral `OpenRouterError::HttpRequest(HttpRequestError)` handling.
+- Replace `surf::StatusCode` comparisons with `http::StatusCode`.
+- Stop importing `openrouter_rs::utils::{with_bearer_auth, with_request_metadata, with_client_request_headers, handle_error}`.
+- Keep any custom auth/header/request glue in your own application code, or prefer the canonical domain clients directly.
+
+### Breaking-Change Mapping For 0.8.0
+
+| Area | Old Usage (`0.7.x` and earlier) | New Usage (`0.8.0`) |
+| --- | --- | --- |
+| HTTP request errors | `OpenRouterError::HttpRequest(surf::Error)` | `OpenRouterError::HttpRequest(HttpRequestError)` |
+| API status comparisons | `api_error.status == surf::StatusCode::BadRequest` | `api_error.status == http::StatusCode::BAD_REQUEST` |
+| Public transport helpers | `openrouter_rs::utils::with_bearer_auth(...)`, `with_request_metadata(...)`, `with_client_request_headers(...)`, `handle_error(...)` | Use `OpenRouterClient` domain methods or caller-owned transport/header helpers |
+| SDK transport stack | `surf -> isahc -> curl` | `reqwest + rustls` |
+
+### Example: HTTP request error matching
+
+Before:
+
+```rust
+use openrouter_rs::error::OpenRouterError;
+
+fn describe(error: OpenRouterError) {
+    match error {
+        OpenRouterError::HttpRequest(surf_error) => {
+            eprintln!("transport failed: {}", surf_error);
+        }
+        other => eprintln!("{other}"),
+    }
+}
+```
+
+After:
+
+```rust
+use openrouter_rs::error::OpenRouterError;
+
+fn describe(error: OpenRouterError) {
+    match error {
+        OpenRouterError::HttpRequest(request_error) => {
+            eprintln!("transport failed: {}", request_error);
+        }
+        other => eprintln!("{other}"),
+    }
+}
+```
+
+### Example: API status comparisons
+
+Before:
+
+```rust
+if api_error.status == surf::StatusCode::BadRequest {
+    eprintln!("bad request");
+}
+```
+
+After:
+
+```rust
+if api_error.status == http::StatusCode::BAD_REQUEST {
+    eprintln!("bad request");
+}
+```
+
+### Example: removing `utils` transport imports
+
+Before:
+
+```rust
+use openrouter_rs::utils::{
+    handle_error,
+    with_bearer_auth,
+    with_client_request_headers,
+    with_request_metadata,
+};
+```
+
+After:
+
+```rust
+use openrouter_rs::OpenRouterClient;
+
+// Prefer the SDK's domain clients, or keep any custom transport glue local
+// to your application instead of importing transport-specific SDK utilities.
+```
+
+## Historical: 0.5.x -> 0.6.0
+
 This guide is for users upgrading from the `0.5.x` API surface to `0.6.0`.
 All "Before" snippets in this document represent compatibility aliases removed in `0.6.0`.
 
@@ -219,7 +318,7 @@ let guardrails = client
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.6", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.8", features = ["legacy-completions"] }
 ```
 
 ## Validation Tips

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The current repo snapshot implements `42 / 42` official OpenAPI method/path entr
 
 - Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
 - Typed request/response models with builder-style ergonomics
+- Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
 - Discovery, rerank, video generation, embeddings, API-key management, organization members, guardrails, activity, credits, and generation coverage
@@ -36,7 +37,7 @@ The current repo snapshot implements `42 / 42` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.7.0"
+openrouter-rs = "0.8.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -44,7 +45,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.7.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.8.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -91,7 +92,7 @@ The SDK keeps setup intentionally narrow: configure runtime values on `OpenRoute
 
 ## API Surface
 
-The canonical public surface in `0.7.x` is domain-oriented:
+The canonical public surface in `0.8.x` is domain-oriented:
 
 | Domain | Canonical methods | Primary endpoints | Auth note |
 | --- | --- | --- | --- |
@@ -204,8 +205,17 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 - Canonical docs and examples prefer the domain clients over older flat helpers
 - Full endpoint coverage is tracked against the current OpenAPI snapshot
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
-- Migration guidance for the `0.5.x -> 0.6.x` transition lives in [`MIGRATION.md`](MIGRATION.md)
+- Migration guidance for the `0.7.x -> 0.8.0` transport/error-surface release, plus the archived `0.5.x -> 0.6.x` naming guide, lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
+
+### 🔁 0.8 Transport/Error Migration
+
+Full migration guide: [`MIGRATION.md`](MIGRATION.md)
+
+- `OpenRouterError::HttpRequest(surf::Error)` -> `OpenRouterError::HttpRequest(HttpRequestError)`
+- `ApiErrorContext.status: surf::StatusCode` -> `ApiErrorContext.status: http::StatusCode`
+- `openrouter_rs::utils::{with_bearer_auth, with_request_metadata, with_client_request_headers, handle_error}` -> caller-owned transport helpers or direct use of the canonical domain clients
+- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `models()`, `management()`, and `legacy()`
 
 ### 🔁 0.6 Naming/Pagination Migration
 
@@ -264,7 +274,7 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 ### Design And Roadmap
 
 - [`docs/design/generated-core-architecture.md`](docs/design/generated-core-architecture.md) for the generated-core plus idiomatic-wrapper design baseline
-- [`docs/design/http-transport-migration.md`](docs/design/http-transport-migration.md) for the `surf` to `reqwest + rustls` migration plan
+- [`docs/design/http-transport-migration.md`](docs/design/http-transport-migration.md) for the historical design baseline behind the completed `reqwest + rustls` transport migration
 
 ### Operations, Validation, And Distribution
 
@@ -273,6 +283,20 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 - [`docs/operations/cli-automation-workflows.md`](docs/operations/cli-automation-workflows.md) for JSON-first shell and CI recipes built around `openrouter-cli`
 - [`tests/integration/README.md`](tests/integration/README.md) for live test pools and env switches
 - [`docs/community/awesome-openrouter/README.md`](docs/community/awesome-openrouter/README.md) for the Awesome OpenRouter submission kit and directory-safe assets
+
+## 📈 Release History
+
+### Version 0.8.0 *(Latest)*
+
+- Completed the SDK transport migration to `reqwest + rustls` and removed the legacy `surf` / `curl` dependency chain.
+- Made the public HTTP error surface backend-neutral and documented the `0.7.x -> 0.8.0` breaking changes.
+- Expanded the repo snapshot with rerank, video, and organization-member coverage plus refreshed examples and CLI automation docs.
+
+### Version 0.7.0
+
+- Removed the SDK-level config surface and kept file/profile config out of the core crate.
+- Standardized the canonical domain-oriented client docs around the `0.7.x` API surface.
+- Improved error normalization for `HTTP 200` payloads that actually contain API error bodies.
 
 ## Contributing
 

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.7.0", path = "../.." }
+openrouter-rs = { version = "0.8.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ If you are not sure where to start, use the groups below.
 ## Design Docs
 
 - [`design/generated-core-architecture.md`](design/generated-core-architecture.md) for the generated-core plus idiomatic-wrapper direction
-- [`design/http-transport-migration.md`](design/http-transport-migration.md) for the `surf` to `reqwest + rustls` migration plan
+- [`design/http-transport-migration.md`](design/http-transport-migration.md) for the historical design baseline behind the completed `reqwest + rustls` transport migration
 
 ## Operations And Validation
 

--- a/docs/design/http-transport-migration.md
+++ b/docs/design/http-transport-migration.md
@@ -1,5 +1,8 @@
 # HTTP Transport Migration Plan
 
+> Status: completed in `0.8.0` on `2026-04-18`.
+> This document is retained as the design baseline and validation checklist for the landed migration away from `surf`.
+
 This document defines the recommended path for moving `openrouter-rs` away from the current `surf`-based HTTP stack and toward `reqwest` with `rustls`.
 
 It is a follow-up design baseline for [#158](https://github.com/realmorrisliu/openrouter-rs/issues/158), where transport maintenance risk and runtime `libcurl` dependence were called out explicitly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.7.0"
+//! openrouter-rs = "0.8.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- bump `openrouter-rs` to `0.8.0` and align the workspace CLI dependency on the new SDK version
- document the `0.7.x -> 0.8.0` breaking transport/error-surface migration in `README.md`, `MIGRATION.md`, and `CHANGELOG.md`
- refresh stale internal/docs references now that the `reqwest + rustls` migration has landed

## Testing
- `just quality`
- `bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.8.0`
- `just quality-ci`
- `cargo package --locked --allow-dirty`

Refs #173