### PR TITLE
docs: refresh awesome openrouter submission kit

### DIFF
--- a/docs/community/awesome-openrouter/README.md
+++ b/docs/community/awesome-openrouter/README.md
@@ -37,7 +37,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-openrouter-rs = "0.7.0"
+openrouter-rs = "0.8.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -82,11 +82,12 @@ Useful entrypoints:
 
 ## Traction Snapshot
 
-Use the following reviewer-facing signals in the Awesome OpenRouter PR body. Snapshot date: `2026-04-17`.
+Use the following reviewer-facing signals in the Awesome OpenRouter PR body. Snapshot date: `2026-04-20`.
 
-- GitHub repository: `62` stars and `15` forks
-- `openrouter-rs` crate: `11,900` total downloads and `4,232` recent downloads on crates.io
+- GitHub repository: `63` stars and `15` forks
+- `openrouter-rs` crate: `12,007` total downloads and `4,255` recent downloads on crates.io
 - `openrouter-cli` crate: published companion CLI with `59` downloads across its first three releases
+- Current stable SDK release is `0.8.0`, which ships on `reqwest + rustls` instead of the old `surf -> isahc -> curl` stack
 - Published API docs on docs.rs and runnable examples in-repo
 - Endpoint coverage, live test status, and nightly OpenAPI drift reporting are published in [`docs/operations/official-endpoint-test-matrix.md`](../../operations/official-endpoint-test-matrix.md) and [`docs/operations/openapi-drift-reporting.md`](../../operations/openapi-drift-reporting.md)
 - Contributor, security, support, release, MSRV, and breaking-change policies are public in-repo

--- a/docs/community/awesome-openrouter/app.yaml
+++ b/docs/community/awesome-openrouter/app.yaml
@@ -5,4 +5,4 @@ docs: "https://github.com/realmorrisliu/openrouter-rs/blob/main/docs/community/a
 tags:
   - coding
 open_source: "https://github.com/realmorrisliu/openrouter-rs"
-date_added: "2026-04-17"
+date_added: "2026-04-20"

--- a/docs/community/awesome-openrouter/pr-draft.md
+++ b/docs/community/awesome-openrouter/pr-draft.md
@@ -14,13 +14,14 @@ Add `openrouter-rs` as the default community Rust SDK entry for OpenRouter, with
 - Users bring their own `OPENROUTER_API_KEY`
 - It has a stable public docs/setup page for OpenRouter-specific usage
 - The repo already publishes both a typed SDK and a companion CLI for account and workflow automation
+- The current stable release (`0.8.0`) ships on `reqwest + rustls` rather than the older `surf -> isahc -> curl` dependency chain
 
 ## Traction / Notability
 
-Snapshot date: `2026-04-17`
+Snapshot date: `2026-04-20`
 
-- GitHub: `62` stars, `15` forks
-- `openrouter-rs` on crates.io: `11,900` total downloads, `4,232` recent downloads
+- GitHub: `63` stars, `15` forks
+- `openrouter-rs` on crates.io: `12,007` total downloads, `4,255` recent downloads
 - `openrouter-cli` on crates.io: published companion CLI with `59` downloads across its first three releases
 - docs.rs documentation is live and the repo includes runnable SDK and CLI examples
 - The repository publishes an endpoint matrix for accepted OpenAPI coverage and live-test status, plus nightly in-repo OpenAPI drift reporting


### PR DESCRIPTION
## Summary
- update the Awesome OpenRouter submission kit to reflect the `0.8.0` SDK release
- refresh the reviewer-facing traction snapshot and `date_added`
- note that the stable SDK now ships on `reqwest + rustls`

## Testing
- refreshed GitHub repository metrics via GitHub API
- refreshed crates.io download counts via crates.io API

Refs #167