### PR TITLE
chore: review latest openapi drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 `openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `42 / 42` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `42 / 43` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,16 +1,20 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-18  
+Snapshot date: 2026-04-20  
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `42` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `42 / 42` (`100%`).
-- Live integration coverage (`tests/integration`): `22 / 42` endpoints currently exercised.
+- Official OpenAPI endpoints: `43` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `42 / 43` (`97.7%`).
+- Live integration coverage (`tests/integration`): `22 / 43` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`
+
+Drift review note:
+
+- Upstream now declares `X-OpenRouter-Categories` on many existing operations. SDK support for that request metadata is tracked in `#183`.
 
 Legend:
 
@@ -65,6 +69,7 @@ Legend:
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | No | P1 |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
+| `POST /tts` | Not yet implemented. Tracked in `#182` | No | None | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
 | `GET /videos/models` | `client.videos().list_models()` | Yes | Path | No | P2 |
 | `GET /videos/{jobId}` | `client.videos().get_generation(...)` | Yes | Path | No | P2 |
@@ -83,7 +88,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity`.
 3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
-4. P1/P2: add low-cost live or smoke coverage for `/rerank`, `/videos*`, and `/organization/members` once stable fixtures and cost controls are defined.
+4. P1/P2: add low-cost live or smoke coverage for `/rerank`, `/tts`, `/videos*`, and `/organization/members` once stable fixtures and cost controls are defined.
 
 ## Reproduce Snapshot
 

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,13 +1,23 @@
 {
   "components": {
     "parameters": {
+      "AppCategories": {
+        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
+        "in": "header",
+        "name": "X-OpenRouter-Categories",
+        "schema": {
+          "type": "string"
+        },
+        "x-speakeasy-name-override": "appCategories"
+      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-Title",
+        "name": "X-OpenRouter-Title",
         "schema": {
           "type": "string"
-        }
+        },
+        "x-speakeasy-name-override": "appTitle"
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -3927,7 +3937,8 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField"
+            "$ref": "#/components/schemas/ResponsesErrorField",
+            "nullable": true
           },
           "frequency_penalty": {
             "format": "double",
@@ -3938,10 +3949,12 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails"
+            "$ref": "#/components/schemas/IncompleteDetails",
+            "nullable": true
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs"
+            "$ref": "#/components/schemas/BaseInputs",
+            "nullable": true
           },
           "max_output_tokens": {
             "nullable": true,
@@ -4022,7 +4035,8 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig"
+            "$ref": "#/components/schemas/BaseReasoningConfig",
+            "nullable": true
           },
           "safety_identifier": {
             "nullable": true,
@@ -4043,7 +4057,8 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig"
+            "$ref": "#/components/schemas/TextConfig",
+            "nullable": true
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -4132,6 +4147,7 @@
             "type": "array"
           },
           "top_logprobs": {
+            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -4140,7 +4156,8 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation"
+            "$ref": "#/components/schemas/Truncation",
+            "nullable": true
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -7067,6 +7084,12 @@
           },
           "reset_interval": {
             "$ref": "#/components/schemas/GuardrailInterval"
+          },
+          "workspace_id": {
+            "description": "The workspace to create the guardrail in. Defaults to the default workspace if not provided.",
+            "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+            "format": "uuid",
+            "type": "string"
           }
         },
         "required": [
@@ -7092,7 +7115,8 @@
             "limit_usd": 50,
             "name": "My New Guardrail",
             "reset_interval": "monthly",
-            "updated_at": null
+            "updated_at": null,
+            "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
           }
         },
         "properties": {
@@ -8163,7 +8187,8 @@
             "limit_usd": 100,
             "name": "Production Guardrail",
             "reset_interval": "monthly",
-            "updated_at": "2025-08-24T15:45:00Z"
+            "updated_at": "2025-08-24T15:45:00Z",
+            "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
           }
         },
         "properties": {
@@ -8249,7 +8274,8 @@
           "limit_usd": 100,
           "name": "Production Guardrail",
           "reset_interval": "monthly",
-          "updated_at": "2025-08-24T15:45:00Z"
+          "updated_at": "2025-08-24T15:45:00Z",
+          "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
         },
         "properties": {
           "allowed_models": {
@@ -8343,12 +8369,18 @@
             "example": "2025-08-24T15:45:00Z",
             "nullable": true,
             "type": "string"
+          },
+          "workspace_id": {
+            "description": "The workspace ID this guardrail belongs to.",
+            "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+            "type": "string"
           }
         },
         "required": [
           "id",
           "name",
-          "created_at"
+          "created_at",
+          "workspace_id"
         ],
         "type": "object"
       },
@@ -9523,7 +9555,8 @@
               "limit_usd": 100,
               "name": "Production Guardrail",
               "reset_interval": "monthly",
-              "updated_at": "2025-08-24T15:45:00Z"
+              "updated_at": "2025-08-24T15:45:00Z",
+              "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
             }
           ],
           "total_count": 1
@@ -14317,7 +14350,9 @@
           "embeddings",
           "audio",
           "video",
-          "rerank"
+          "rerank",
+          "tts",
+          "stt"
         ],
         "example": "text",
         "type": "string",
@@ -18050,7 +18085,8 @@
             "limit_usd": 75,
             "name": "Updated Guardrail Name",
             "reset_interval": "weekly",
-            "updated_at": "2025-08-24T16:00:00Z"
+            "updated_at": "2025-08-24T16:00:00Z",
+            "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
           }
         },
         "properties": {
@@ -19757,9 +19793,31 @@
         "tags": [
           "Analytics"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/auth/keys": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -19902,6 +19960,17 @@
       }
     },
     "/auth/keys/code": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -20131,6 +20200,17 @@
       }
     },
     "/chat/completions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
@@ -20553,9 +20633,31 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/credits/coinbase": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -20592,6 +20694,17 @@
       }
     },
     "/embeddings": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -21193,7 +21306,18 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/endpoints/zdr": {
       "get": {
@@ -21328,7 +21452,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation": {
       "get": {
@@ -21404,6 +21539,8 @@
                             "completions",
                             "embeddings",
                             "rerank",
+                            "tts",
+                            "stt",
                             "video",
                             null
                           ],
@@ -21823,7 +21960,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails": {
       "get": {
@@ -21855,6 +22003,18 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Filter guardrails by workspace ID. By default, guardrails in the default workspace are returned.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Filter guardrails by workspace ID. By default, guardrails in the default workspace are returned.",
+              "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -21879,7 +22039,8 @@
                       "limit_usd": 100,
                       "name": "Production Guardrail",
                       "reset_interval": "monthly",
-                      "updated_at": "2025-08-24T15:45:00Z"
+                      "updated_at": "2025-08-24T15:45:00Z",
+                      "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                     }
                   ],
                   "total_count": 1
@@ -21948,6 +22109,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -21997,7 +22169,8 @@
                     "limit_usd": 50,
                     "name": "My New Guardrail",
                     "reset_interval": "monthly",
-                    "updated_at": null
+                    "updated_at": null,
+                    "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   }
                 },
                 "schema": {
@@ -22038,6 +22211,22 @@
               }
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
           },
           "500": {
             "content": {
@@ -22176,7 +22365,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -22290,7 +22490,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/{id}": {
       "delete": {
@@ -22417,7 +22628,8 @@
                     "limit_usd": 100,
                     "name": "Production Guardrail",
                     "reset_interval": "monthly",
-                    "updated_at": "2025-08-24T15:45:00Z"
+                    "updated_at": "2025-08-24T15:45:00Z",
+                    "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   }
                 },
                 "schema": {
@@ -22482,6 +22694,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
@@ -22534,7 +22757,8 @@
                     "limit_usd": 75,
                     "name": "Updated Guardrail Name",
                     "reset_interval": "weekly",
-                    "updated_at": "2025-08-24T16:00:00Z"
+                    "updated_at": "2025-08-24T16:00:00Z",
+                    "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   }
                 },
                 "schema": {
@@ -22758,6 +22982,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
@@ -22877,6 +23112,17 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -23136,6 +23382,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -23256,6 +23513,17 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -23677,7 +23945,18 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/keys": {
       "get": {
@@ -23708,6 +23987,18 @@
               "nullable": true,
               "type": "integer"
             }
+          },
+          {
+            "description": "Filter API keys by workspace ID. By default, keys in the default workspace are returned.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Filter API keys by workspace ID. By default, keys in the default workspace are returned.",
+              "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -23736,7 +24027,8 @@
                       "usage": 25.5,
                       "usage_daily": 25.5,
                       "usage_monthly": 25.5,
-                      "usage_weekly": 25.5
+                      "usage_weekly": 25.5,
+                      "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                     }
                   ]
                 },
@@ -23763,7 +24055,8 @@
                         "usage": 25.5,
                         "usage_daily": 25.5,
                         "usage_monthly": 25.5,
-                        "usage_weekly": 25.5
+                        "usage_weekly": 25.5,
+                        "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                       }
                     ]
                   },
@@ -23791,7 +24084,8 @@
                           "usage": 25.5,
                           "usage_daily": 25.5,
                           "usage_monthly": 25.5,
-                          "usage_weekly": 25.5
+                          "usage_weekly": 25.5,
+                          "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                         },
                         "properties": {
                           "byok_usage": {
@@ -23910,6 +24204,11 @@
                             "example": 25.5,
                             "format": "double",
                             "type": "number"
+                          },
+                          "workspace_id": {
+                            "description": "The workspace ID this API key belongs to.",
+                            "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -23931,7 +24230,8 @@
                           "byok_usage_monthly",
                           "created_at",
                           "updated_at",
-                          "creator_user_id"
+                          "creator_user_id",
+                          "workspace_id"
                         ],
                         "type": "object"
                       },
@@ -24002,6 +24302,17 @@
         ],
         "x-speakeasy-name-override": "list"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
@@ -24068,6 +24379,12 @@
                     "example": "My New API Key",
                     "minLength": 1,
                     "type": "string"
+                  },
+                  "workspace_id": {
+                    "description": "The workspace to create the API key in. Defaults to the default workspace if not provided.",
+                    "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+                    "format": "uuid",
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -24104,7 +24421,8 @@
                     "usage": 0,
                     "usage_daily": 0,
                     "usage_monthly": 0,
-                    "usage_weekly": 0
+                    "usage_weekly": 0,
+                    "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   },
                   "key": "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"
                 },
@@ -24130,7 +24448,8 @@
                       "usage": 0,
                       "usage_daily": 0,
                       "usage_monthly": 0,
-                      "usage_weekly": 0
+                      "usage_weekly": 0,
+                      "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                     },
                     "key": "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"
                   },
@@ -24157,7 +24476,8 @@
                         "usage": 25.5,
                         "usage_daily": 25.5,
                         "usage_monthly": 25.5,
-                        "usage_weekly": 25.5
+                        "usage_weekly": 25.5,
+                        "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                       },
                       "properties": {
                         "byok_usage": {
@@ -24276,6 +24596,11 @@
                           "example": 25.5,
                           "format": "double",
                           "type": "number"
+                        },
+                        "workspace_id": {
+                          "description": "The workspace ID this API key belongs to.",
+                          "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -24297,7 +24622,8 @@
                         "byok_usage_monthly",
                         "created_at",
                         "updated_at",
-                        "creator_user_id"
+                        "creator_user_id",
+                        "workspace_id"
                       ],
                       "type": "object"
                     },
@@ -24348,6 +24674,22 @@
               }
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
           },
           "429": {
             "content": {
@@ -24546,7 +24888,8 @@
                     "usage": 25.5,
                     "usage_daily": 25.5,
                     "usage_monthly": 25.5,
-                    "usage_weekly": 25.5
+                    "usage_weekly": 25.5,
+                    "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   }
                 },
                 "schema": {
@@ -24571,7 +24914,8 @@
                       "usage": 25.5,
                       "usage_daily": 25.5,
                       "usage_monthly": 25.5,
-                      "usage_weekly": 25.5
+                      "usage_weekly": 25.5,
+                      "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                     }
                   },
                   "properties": {
@@ -24597,7 +24941,8 @@
                         "usage": 25.5,
                         "usage_daily": 25.5,
                         "usage_monthly": 25.5,
-                        "usage_weekly": 25.5
+                        "usage_weekly": 25.5,
+                        "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                       },
                       "properties": {
                         "byok_usage": {
@@ -24716,6 +25061,11 @@
                           "example": 25.5,
                           "format": "double",
                           "type": "number"
+                        },
+                        "workspace_id": {
+                          "description": "The workspace ID this API key belongs to.",
+                          "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -24737,7 +25087,8 @@
                         "byok_usage_monthly",
                         "created_at",
                         "updated_at",
-                        "creator_user_id"
+                        "creator_user_id",
+                        "workspace_id"
                       ],
                       "type": "object"
                     }
@@ -24822,6 +25173,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -24924,7 +25286,8 @@
                     "usage": 25.5,
                     "usage_daily": 25.5,
                     "usage_monthly": 25.5,
-                    "usage_weekly": 25.5
+                    "usage_weekly": 25.5,
+                    "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   }
                 },
                 "schema": {
@@ -24949,7 +25312,8 @@
                       "usage": 25.5,
                       "usage_daily": 25.5,
                       "usage_monthly": 25.5,
-                      "usage_weekly": 25.5
+                      "usage_weekly": 25.5,
+                      "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                     }
                   },
                   "properties": {
@@ -24975,7 +25339,8 @@
                         "usage": 25.5,
                         "usage_daily": 25.5,
                         "usage_monthly": 25.5,
-                        "usage_weekly": 25.5
+                        "usage_weekly": 25.5,
+                        "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                       },
                       "properties": {
                         "byok_usage": {
@@ -25094,6 +25459,11 @@
                           "example": 25.5,
                           "format": "double",
                           "type": "number"
+                        },
+                        "workspace_id": {
+                          "description": "The workspace ID this API key belongs to.",
+                          "example": "0df9e665-d932-5740-b2c7-b52af166bc11",
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -25115,7 +25485,8 @@
                         "byok_usage_monthly",
                         "created_at",
                         "updated_at",
-                        "creator_user_id"
+                        "creator_user_id",
+                        "workspace_id"
                       ],
                       "type": "object"
                     }
@@ -25218,6 +25589,17 @@
       }
     },
     "/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
@@ -25592,7 +25974,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/count": {
       "get": {
@@ -25664,7 +26057,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/user": {
       "get": {
@@ -25786,7 +26190,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -25952,7 +26367,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/organization/members": {
       "get": {
@@ -26140,7 +26566,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/providers": {
       "get": {
@@ -26791,9 +27228,31 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/rerank": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -27170,6 +27629,17 @@
       }
     },
     "/responses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
@@ -27459,7 +27929,926 @@
         "x-speakeasy-stream-request-field": "stream"
       }
     },
+    "/tts": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
+      "post": {
+        "description": "Synthesizes audio from the input text",
+        "operationId": "createTts",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Text-to-speech request input",
+                "example": {
+                  "input": "Hello world",
+                  "model": "elevenlabs/eleven-turbo-v2",
+                  "response_format": "pcm",
+                  "speed": 1,
+                  "voice": "alloy"
+                },
+                "properties": {
+                  "input": {
+                    "description": "Text to synthesize",
+                    "example": "Hello world",
+                    "type": "string"
+                  },
+                  "model": {
+                    "description": "TTS model identifier",
+                    "example": "elevenlabs/eleven-turbo-v2",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "description": "Provider-specific passthrough configuration",
+                    "properties": {
+                      "options": {
+                        "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
+                        "properties": {
+                          "01ai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "ai21": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "aion-labs": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "akashml": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "alibaba": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "amazon-bedrock": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "amazon-nova": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "ambient": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "anthropic": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "anyscale": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "arcee-ai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "atlas-cloud": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "atoma": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "avian": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "azure": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "baidu": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "baseten": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "black-forest-labs": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "byteplus": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "centml": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "cerebras": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "chutes": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "cirrascale": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "clarifai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "cloudflare": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "cohere": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "crofai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "crusoe": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "deepinfra": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "deepseek": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "dekallm": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "enfer": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "fake-provider": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "featherless": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "fireworks": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "friendli": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "gmicloud": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "google-ai-studio": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "google-vertex": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "gopomelo": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "groq": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "huggingface": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "hyperbolic": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "hyperbolic-quantized": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "inception": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "inceptron": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "inference-net": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "infermatic": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "inflection": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "inocloud": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "io-net": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "ionstream": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "klusterai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "lambda": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "lepton": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "liquid": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "lynn": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "lynn-private": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "mancer": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "mancer-old": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "mara": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "meta": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "minimax": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "mistral": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "modal": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "modelrun": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "modular": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "moonshotai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "morph": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "ncompass": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "nebius": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "nextbit": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "nineteen": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "novita": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "nvidia": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "octoai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "open-inference": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "openai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "parasail": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "perplexity": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "phala": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "recraft": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "recursal": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "reflection": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "reka": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "relace": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "replicate": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "sambanova": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "sambanova-cloaked": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "seed": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "sf-compute": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "siliconflow": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "sourceful": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "stealth": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "stepfun": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "streamlake": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "switchpoint": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "targon": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "together": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "together-lite": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "ubicloud": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "upstage": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "venice": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "wandb": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "xai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "xiaomi": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          },
+                          "z-ai": {
+                            "additionalProperties": {
+                              "nullable": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "response_format": {
+                    "default": "pcm",
+                    "description": "Audio output format",
+                    "enum": [
+                      "mp3",
+                      "pcm"
+                    ],
+                    "example": "pcm",
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "speed": {
+                    "description": "Playback speed multiplier. Only used by models that support it (e.g. OpenAI TTS). Ignored by other providers.",
+                    "example": 1,
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "voice": {
+                    "description": "Voice identifier",
+                    "example": "alloy",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "model",
+                  "input",
+                  "voice"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "description": "Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/L16 for pcm).",
+                  "example": "<binary audio data>",
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Audio bytes stream"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Create speech",
+        "tags": [
+          "TTS"
+        ],
+        "x-speakeasy-name-override": "createSpeech"
+      }
+    },
     "/videos": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -27685,7 +29074,18 @@
         "tags": [
           "Video Generation"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}": {
       "get": {
@@ -27780,7 +29180,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -27909,7 +29320,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     }
   },
   "security": [
@@ -27980,6 +29402,10 @@
     {
       "description": "Rerank endpoints",
       "name": "Rerank"
+    },
+    {
+      "description": "Text-to-speech endpoints",
+      "name": "TTS"
     },
     {
       "description": "Video Generation endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-18T06:19:32+00:00",
+  "captured_at": "2026-04-20T11:11:19+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,11 +14,11 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 42,
+  "operation_count": 43,
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "62d6681f3fc2fe20",
+      "fingerprint": "fc9cb5e5f6b4e39c",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2a479c2a2828c351",
+      "fingerprint": "0ff2409f46ebd93d",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a8e8f18928c3c86a",
+      "fingerprint": "d143da7f6f9162c0",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "05cecac9b09a5e7c",
+      "fingerprint": "e87fbb5bb40b4c60",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7ba94090fe4a8dfe",
+      "fingerprint": "15817abb5bf5be68",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "95f59af93f2a1940",
+      "fingerprint": "d94195530e0414a4",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "97e1f2697bd3066c",
+      "fingerprint": "327eccd5c4919e97",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0600f3ad77c10704",
+      "fingerprint": "3d3e8c9561d450c5",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "50df372af92b0439",
+      "fingerprint": "b43f6f0d1e70ec62",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "48ed8bcc9c811a11",
+      "fingerprint": "93d944d97fca595b",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fcf564f45586fdb8",
+      "fingerprint": "6a953189b58fc510",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bdcc5f13eb39b87d",
+      "fingerprint": "34604a16fa41fb79",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "622584d38112ff60",
+      "fingerprint": "6a182854d359c7c1",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -161,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c73983473e1c0e0e",
+      "fingerprint": "6a1d8e77363531a7",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -172,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "db7ebd49d1f65e47",
+      "fingerprint": "73fe6021d5d3877d",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b86d5630a59ac36b",
+      "fingerprint": "fb6bbfd93f43f252",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e954ef6e86b52be4",
+      "fingerprint": "b65369929e313e21",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "360a71c424058693",
+      "fingerprint": "39d755b55859e6de",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c62675934a04d95e",
+      "fingerprint": "2bc0a0465a8d5edb",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0a831f35217698f2",
+      "fingerprint": "87017a6a418ccc83",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "afba5151a3299caf",
+      "fingerprint": "7687a0f00ba6d1b1",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6d3ec9bee71dc2ce",
+      "fingerprint": "db6ea0df829856f4",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "14596fe6b03e4428",
+      "fingerprint": "db1c62dade2d8f06",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0c91e369c0a0d9e1",
+      "fingerprint": "45699b9654b6db62",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f762b88d789b2723",
+      "fingerprint": "81bf8fc0183755b8",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b91f5f39cec8fec0",
+      "fingerprint": "4c0058a2655e0d29",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "48a3cb500e61e8dd",
+      "fingerprint": "4ccab78044c4a13d",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "350024ac1009cddb",
+      "fingerprint": "d5a58f4512027317",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ce53dfc76885c522",
+      "fingerprint": "0781a831d48dec54",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -337,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "48a58f7ad520ca2e",
+      "fingerprint": "ca135372f38e8101",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -348,7 +348,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "3aae29d559805e6d",
+      "fingerprint": "4d49cd207179e897",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "92a8447c3b7e796f",
+      "fingerprint": "0f4fe255c155ded7",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dd8e0956b7e1c9ec",
+      "fingerprint": "2286b192a05d7bfe",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cac6ec19bd951299",
+      "fingerprint": "6b121e68b5bcdb55",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fc5f8809122a9fec",
+      "fingerprint": "8d3111ee0fdd6842",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a60d54c8a1dd80c0",
+      "fingerprint": "04c2e86ce1b63136",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -414,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "95cd05e9fbc9490b",
+      "fingerprint": "76d6bf8fb6c08c1e",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d47c5f120c2fb0b6",
+      "fingerprint": "2384f8263630f7cc",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3e6939ae948a68db",
+      "fingerprint": "f7351c6254fd9718",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -447,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "18f4810d9d6d8bd0",
+      "fingerprint": "38cb2fd0bea5ce96",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -458,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "258dc171d1242855",
+      "fingerprint": "280084097e7625ca",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -469,7 +469,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "624263f08072d641",
+      "fingerprint": "e89c88ef0c59edf6",
+      "id": "POST /tts",
+      "method": "POST",
+      "operation_id": "createTts",
+      "path": "/tts",
+      "tags": [
+        "TTS"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "3dae513ba8623eb6",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",


### PR DESCRIPTION
## Summary
- accept the latest reviewed OpenRouter OpenAPI baseline and refresh the tracked baseline artifacts
- update the endpoint matrix and README to reflect `42 / 43` implemented operations after upstream added `POST /tts`
- record the two implementation follow-ups separately instead of hiding them in the baseline refresh

## Follow-ups
- closes #179
- /tts SDK surface: #182
- X-OpenRouter-Categories request metadata: #183

## Verification
- `just openapi-refresh-baseline`
- `just openapi-drift-check`