### PR TITLE
feat: support app categories request metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .api_key(std::env::var("OPENROUTER_API_KEY")?)
         .http_referer("https://yourapp.example")
         .x_title("my-openrouter-app")
+        .app_categories(["cli-agent"])
         .build()?;
 
     let request = ChatCompletionRequest::builder()
@@ -112,6 +113,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - `management_key`
 - `http_referer`
 - `x_title`
+- `app_categories`
 
 ## Common Workflows
 

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -848,6 +848,7 @@ pub async fn send_chat_completion(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ChatCompletionRequest,
 ) -> Result<CompletionsResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -857,6 +858,7 @@ pub async fn send_chat_completion(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -868,6 +870,7 @@ pub(crate) async fn send_chat_completion_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ChatCompletionRequest,
 ) -> Result<CompletionsResponse, OpenRouterError> {
     let url = format!("{base_url}/chat/completions");
@@ -880,7 +883,8 @@ pub(crate) async fn send_chat_completion_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(&request)
     .send()
     .await?;
@@ -909,6 +913,7 @@ pub async fn stream_chat_completion(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ChatCompletionRequest,
 ) -> Result<BoxStream<'static, Result<CompletionsResponse, OpenRouterError>>, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -918,6 +923,7 @@ pub async fn stream_chat_completion(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -929,6 +935,7 @@ pub(crate) async fn stream_chat_completion_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ChatCompletionRequest,
 ) -> Result<BoxStream<'static, Result<CompletionsResponse, OpenRouterError>>, OpenRouterError> {
     let url = format!("{base_url}/chat/completions");
@@ -941,7 +948,8 @@ pub(crate) async fn stream_chat_completion_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(&request)
     .send()
     .await?;

--- a/src/api/embeddings.rs
+++ b/src/api/embeddings.rs
@@ -188,6 +188,7 @@ pub async fn create_embedding(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &EmbeddingRequest,
 ) -> Result<EmbeddingResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -197,6 +198,7 @@ pub async fn create_embedding(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -208,6 +210,7 @@ pub(crate) async fn create_embedding_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &EmbeddingRequest,
 ) -> Result<EmbeddingResponse, OpenRouterError> {
     let url = format!("{base_url}/embeddings");
@@ -217,7 +220,8 @@ pub(crate) async fn create_embedding_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(request)
     .send()
     .await?;

--- a/src/api/legacy/completion.rs
+++ b/src/api/legacy/completion.rs
@@ -137,6 +137,7 @@ pub async fn send_completion_request(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &CompletionRequest,
 ) -> Result<CompletionsResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -146,6 +147,7 @@ pub async fn send_completion_request(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -157,6 +159,7 @@ pub(crate) async fn send_completion_request_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &CompletionRequest,
 ) -> Result<CompletionsResponse, OpenRouterError> {
     let url = format!("{base_url}/completions");
@@ -166,7 +169,8 @@ pub(crate) async fn send_completion_request_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(request)
     .send()
     .await?;

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -672,6 +672,7 @@ pub async fn create_message(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &AnthropicMessagesRequest,
 ) -> Result<AnthropicMessagesResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -681,6 +682,7 @@ pub async fn create_message(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -692,6 +694,7 @@ pub(crate) async fn create_message_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &AnthropicMessagesRequest,
 ) -> Result<AnthropicMessagesResponse, OpenRouterError> {
     let url = format!("{base_url}/messages");
@@ -702,7 +705,8 @@ pub(crate) async fn create_message_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(&request)
     .send()
     .await?;
@@ -723,6 +727,7 @@ pub async fn stream_messages(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &AnthropicMessagesRequest,
 ) -> Result<BoxStream<'static, Result<AnthropicMessagesSseEvent, OpenRouterError>>, OpenRouterError>
 {
@@ -733,6 +738,7 @@ pub async fn stream_messages(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -744,6 +750,7 @@ pub(crate) async fn stream_messages_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &AnthropicMessagesRequest,
 ) -> Result<BoxStream<'static, Result<AnthropicMessagesSseEvent, OpenRouterError>>, OpenRouterError>
 {
@@ -755,7 +762,8 @@ pub(crate) async fn stream_messages_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(&request)
     .send()
     .await?;

--- a/src/api/rerank.rs
+++ b/src/api/rerank.rs
@@ -75,6 +75,7 @@ pub async fn create_rerank(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &RerankRequest,
 ) -> Result<RerankResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -84,6 +85,7 @@ pub async fn create_rerank(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -95,6 +97,7 @@ pub(crate) async fn create_rerank_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &RerankRequest,
 ) -> Result<RerankResponse, OpenRouterError> {
     let url = format!("{base_url}/rerank");
@@ -103,7 +106,8 @@ pub(crate) async fn create_rerank_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(request)
     .send()
     .await?;

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -230,6 +230,7 @@ pub async fn create_response(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ResponsesRequest,
 ) -> Result<ResponsesResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -239,6 +240,7 @@ pub async fn create_response(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -250,6 +252,7 @@ pub(crate) async fn create_response_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ResponsesRequest,
 ) -> Result<ResponsesResponse, OpenRouterError> {
     let url = format!("{base_url}/responses");
@@ -260,7 +263,8 @@ pub(crate) async fn create_response_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(&request)
     .send()
     .await?;
@@ -281,6 +285,7 @@ pub async fn stream_response(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ResponsesRequest,
 ) -> Result<BoxStream<'static, Result<ResponsesStreamEvent, OpenRouterError>>, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -290,6 +295,7 @@ pub async fn stream_response(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -301,6 +307,7 @@ pub(crate) async fn stream_response_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &ResponsesRequest,
 ) -> Result<BoxStream<'static, Result<ResponsesStreamEvent, OpenRouterError>>, OpenRouterError> {
     let url = format!("{base_url}/responses");
@@ -311,7 +318,8 @@ pub(crate) async fn stream_response_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(&request)
     .send()
     .await?;

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -164,6 +164,7 @@ pub async fn create_video_generation(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &VideoGenerationRequest,
 ) -> Result<VideoGenerationResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
@@ -173,6 +174,7 @@ pub async fn create_video_generation(
         api_key,
         x_title,
         http_referer,
+        app_categories,
         request,
     )
     .await
@@ -184,6 +186,7 @@ pub(crate) async fn create_video_generation_with_client(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
     request: &VideoGenerationRequest,
 ) -> Result<VideoGenerationResponse, OpenRouterError> {
     let url = format!("{base_url}/videos");
@@ -192,7 +195,8 @@ pub(crate) async fn create_video_generation_with_client(
         api_key,
         x_title,
         http_referer,
-    )
+        app_categories,
+    )?
     .json(request)
     .send()
     .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use crate::{
         models, organization, rerank, responses, videos,
     },
     error::OpenRouterError,
+    strip_option_vec_setter,
     types::{
         ModelCategory, PaginationOptions, SupportedParameters,
         completion::CompletionsResponse,
@@ -38,6 +39,8 @@ pub struct OpenRouterClient {
         default = "Some(String::from(\"openrouter-rs\"))"
     )]
     x_title: Option<String>,
+    #[builder(setter(custom), default)]
+    app_categories: Option<Vec<String>>,
     #[builder(setter(skip), default = "crate::transport::new_client()?")]
     http_client: reqwest::Client,
 }
@@ -156,6 +159,10 @@ impl OpenRouterClient {
     pub(crate) fn http_client(&self) -> &reqwest::Client {
         &self.http_client
     }
+}
+
+impl OpenRouterClientBuilder {
+    strip_option_vec_setter!(app_categories, String);
 }
 
 #[doc(hidden)]
@@ -737,6 +744,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -790,6 +798,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -876,6 +885,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -907,6 +917,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -936,6 +947,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -959,6 +971,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -996,6 +1009,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -1016,6 +1030,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -1036,6 +1051,7 @@ impl OpenRouterClient {
                 api_key,
                 &self.x_title,
                 &self.http_referer,
+                &self.app_categories,
                 request,
             )
             .await
@@ -1952,6 +1968,7 @@ impl<'a> LegacyCompletionsClient<'a> {
                 api_key,
                 &self.client.x_title,
                 &self.client.http_referer,
+                &self.client.app_categories,
                 request,
             )
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //!         .api_key("your_api_key")
 //!         .http_referer("https://yourapp.com")
 //!         .x_title("My App")
+//!         .app_categories(["cli-agent"])
 //!         .build()?;
 //!
 //!     // Build chat request

--- a/src/transport/request.rs
+++ b/src/transport/request.rs
@@ -28,7 +28,8 @@ pub(crate) fn with_request_metadata(
     mut req: RequestBuilder,
     x_title: &Option<String>,
     http_referer: &Option<String>,
-) -> RequestBuilder {
+    app_categories: &Option<Vec<String>>,
+) -> Result<RequestBuilder, crate::error::OpenRouterError> {
     if let Some(x_title) = x_title {
         req = req.header("X-OpenRouter-Title", x_title);
         req = req.header("X-Title", x_title);
@@ -36,8 +37,14 @@ pub(crate) fn with_request_metadata(
     if let Some(http_referer) = http_referer {
         req = req.header("HTTP-Referer", http_referer);
     }
+    if let Some(app_categories) = app_categories {
+        req = req.header(
+            "X-OpenRouter-Categories",
+            serialize_app_categories(app_categories)?,
+        );
+    }
 
-    req
+    Ok(req)
 }
 
 pub(crate) fn with_client_request_headers(
@@ -45,8 +52,55 @@ pub(crate) fn with_client_request_headers(
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
-) -> RequestBuilder {
-    with_request_metadata(with_bearer_auth(req, api_key), x_title, http_referer)
+    app_categories: &Option<Vec<String>>,
+) -> Result<RequestBuilder, crate::error::OpenRouterError> {
+    with_request_metadata(
+        with_bearer_auth(req, api_key),
+        x_title,
+        http_referer,
+        app_categories,
+    )
+}
+
+fn serialize_app_categories(
+    app_categories: &[String],
+) -> Result<String, crate::error::OpenRouterError> {
+    if app_categories.is_empty() {
+        return Err(crate::error::OpenRouterError::ConfigError(
+            "app_categories cannot be empty when provided".to_string(),
+        ));
+    }
+    if app_categories.len() > 2 {
+        return Err(crate::error::OpenRouterError::ConfigError(
+            "app_categories supports at most 2 categories per request".to_string(),
+        ));
+    }
+
+    let mut serialized = Vec::with_capacity(app_categories.len());
+    for category in app_categories {
+        let trimmed = category.trim();
+        if trimmed.is_empty() {
+            return Err(crate::error::OpenRouterError::ConfigError(
+                "app_categories cannot contain empty values".to_string(),
+            ));
+        }
+        if trimmed.len() > 30 {
+            return Err(crate::error::OpenRouterError::ConfigError(format!(
+                "app category `{trimmed}` exceeds the 30 character OpenRouter limit"
+            )));
+        }
+        if !trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        {
+            return Err(crate::error::OpenRouterError::ConfigError(format!(
+                "app category `{trimmed}` must be lowercase and hyphen-separated"
+            )));
+        }
+        serialized.push(trimmed.to_string());
+    }
+
+    Ok(serialized.join(","))
 }
 
 #[cfg(test)]
@@ -63,7 +117,9 @@ mod tests {
             "test-key",
             &Some("openrouter-rs-tests".to_string()),
             &Some("https://example.com".to_string()),
+            &Some(vec!["cli-agent".to_string(), "cloud-agent".to_string()]),
         )
+        .expect("request builder should be created")
         .build()
         .expect("request should build");
 
@@ -94,6 +150,31 @@ mod tests {
                 .get("HTTP-Referer")
                 .expect("http-referer should exist"),
             "https://example.com"
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("X-OpenRouter-Categories")
+                .expect("x-openrouter-categories should exist"),
+            "cli-agent,cloud-agent"
+        );
+    }
+
+    #[test]
+    fn test_with_client_request_headers_rejects_invalid_app_categories() {
+        let client = reqwest::Client::new();
+        let error = with_client_request_headers(
+            post(&client, "http://example.com/test"),
+            "test-key",
+            &Some("openrouter-rs-tests".to_string()),
+            &Some("https://example.com".to_string()),
+            &Some(vec!["CLI-Agent".to_string()]),
+        )
+        .expect_err("invalid categories should fail");
+
+        assert!(
+            matches!(error, crate::error::OpenRouterError::ConfigError(_)),
+            "expected config error, got {error:?}"
         );
     }
 }

--- a/tests/unit/chat_api.rs
+++ b/tests/unit/chat_api.rs
@@ -117,10 +117,18 @@ async fn test_send_chat_completion_sets_stream_false_and_headers() {
         .expect("chat request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
     let http_referer = Some("https://github.com/realmorrisliu/openrouter-rs".to_string());
+    let app_categories = Some(vec!["cli-agent".to_string()]);
 
-    let response = send_chat_completion(&base_url, "api-key", &x_title, &http_referer, &request)
-        .await
-        .expect("send_chat_completion should succeed");
+    let response = send_chat_completion(
+        &base_url,
+        "api-key",
+        &x_title,
+        &http_referer,
+        &app_categories,
+        &request,
+    )
+    .await
+    .expect("send_chat_completion should succeed");
     assert_eq!(response.id, "gen-123");
     assert_eq!(response.choices[0].content(), Some("Hello from mock"));
 
@@ -158,6 +166,12 @@ async fn test_send_chat_completion_sets_stream_false_and_headers() {
         "http-referer header should be present, headers:\n{}",
         captured.header_text
     );
+    assert!(
+        headers_lower.contains("x-openrouter-categories: cli-agent")
+            || headers_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, headers:\n{}",
+        captured.header_text
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
@@ -187,11 +201,18 @@ async fn test_stream_chat_completion_sets_stream_true_and_parses_sse() {
 
     let x_title = Some("openrouter-rs-tests".to_string());
     let http_referer = Some("https://github.com/realmorrisliu/openrouter-rs".to_string());
+    let app_categories = Some(vec!["cli-agent".to_string()]);
 
-    let mut stream =
-        stream_chat_completion(&base_url, "api-key", &x_title, &http_referer, &request)
-            .await
-            .expect("stream_chat_completion should succeed");
+    let mut stream = stream_chat_completion(
+        &base_url,
+        "api-key",
+        &x_title,
+        &http_referer,
+        &app_categories,
+        &request,
+    )
+    .await
+    .expect("stream_chat_completion should succeed");
     let mut chunks = Vec::new();
     while let Some(item) = stream.next().await {
         chunks.push(item.expect("stream chunk should parse"));
@@ -268,7 +289,7 @@ async fn test_stream_chat_completion_parses_multiline_sse_data_frames() {
         .build()
         .expect("chat request should build");
 
-    let mut stream = stream_chat_completion(&base_url, "api-key", &None, &None, &request)
+    let mut stream = stream_chat_completion(&base_url, "api-key", &None, &None, &None, &request)
         .await
         .expect("stream_chat_completion should succeed");
     let mut chunks = Vec::new();
@@ -293,7 +314,7 @@ async fn test_send_chat_completion_returns_contextual_parse_error_on_invalid_jso
         .build()
         .expect("chat request should build");
 
-    let error = send_chat_completion(&base_url, "api-key", &None, &None, &request)
+    let error = send_chat_completion(&base_url, "api-key", &None, &None, &None, &request)
         .await
         .expect_err("invalid JSON should fail");
 
@@ -322,7 +343,7 @@ async fn test_send_chat_completion_treats_error_payload_with_200_status_as_api_e
         .build()
         .expect("chat request should build");
 
-    let error = send_chat_completion(&base_url, "api-key", &None, &None, &request)
+    let error = send_chat_completion(&base_url, "api-key", &None, &None, &None, &request)
         .await
         .expect_err("error payload should fail");
 

--- a/tests/unit/default_headers.rs
+++ b/tests/unit/default_headers.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use futures_util::StreamExt;
-use openrouter_rs::{OpenRouterClient, api::chat, types::Role};
+use openrouter_rs::{OpenRouterClient, api::chat, error::OpenRouterError, types::Role};
 
 struct CapturedRequest {
     request_line: String,
@@ -228,6 +228,59 @@ async fn test_explicit_x_title_overrides_default() {
     );
 
     server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_app_categories_header_is_sent_when_configured() {
+    let (base_url, rx, server) = spawn_json_server(chat_response_json());
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .app_categories(["cli-agent", "cloud-agent"])
+        .build()
+        .expect("client should build");
+
+    let request = build_chat_request();
+    let _response = client
+        .chat()
+        .create(&request)
+        .await
+        .expect("chat request should succeed");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("x-openrouter-categories: cli-agent,cloud-agent")
+            || request_lower.contains("x-openrouter-categories:cli-agent,cloud-agent"),
+        "app categories header should be present, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_invalid_app_categories_fail_request_build_path() {
+    let client = OpenRouterClient::builder()
+        .base_url("http://127.0.0.1:1/api/v1")
+        .api_key("api-key")
+        .app_categories(["CLI-Agent"])
+        .build()
+        .expect("client should build");
+
+    let request = build_chat_request();
+    let error = client
+        .chat()
+        .create(&request)
+        .await
+        .expect_err("invalid categories should fail");
+
+    assert!(
+        matches!(error, OpenRouterError::ConfigError(_)),
+        "expected config error, got {error:?}"
+    );
 }
 
 #[tokio::test]

--- a/tests/unit/embeddings.rs
+++ b/tests/unit/embeddings.rs
@@ -273,10 +273,17 @@ async fn test_create_embedding_path_body_and_headers() {
     let base_url = format!("http://{addr}/api/v1");
     let x_title = Some("openrouter-rs-tests".to_string());
     let http_referer = Some("https://github.com/realmorrisliu/openrouter-rs".to_string());
-    let response =
-        embeddings::create_embedding(&base_url, "api-key", &x_title, &http_referer, &request)
-            .await
-            .expect("create embedding should succeed");
+    let app_categories = Some(vec!["cli-agent".to_string()]);
+    let response = embeddings::create_embedding(
+        &base_url,
+        "api-key",
+        &x_title,
+        &http_referer,
+        &app_categories,
+        &request,
+    )
+    .await
+    .expect("create embedding should succeed");
     assert_eq!(response.object, "list");
     assert_eq!(response.model, "openai/text-embedding-3-large");
     assert_eq!(response.data.len(), 1);
@@ -307,6 +314,11 @@ async fn test_create_embedding_path_body_and_headers() {
             || headers_lower
                 .contains("http-referer:https://github.com/realmorrisliu/openrouter-rs"),
         "http-referer header should be present, headers:\n{header_text}"
+    );
+    assert!(
+        headers_lower.contains("x-openrouter-categories: cli-agent")
+            || headers_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, headers:\n{header_text}"
     );
 
     let request_json: serde_json::Value =

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -254,7 +254,7 @@ async fn test_stream_messages_parses_event_and_data_lines() {
         .expect("messages request should build");
 
     let base_url = format!("http://{addr}/api/v1");
-    let mut stream = stream_messages(&base_url, "test-key", &None, &None, &request)
+    let mut stream = stream_messages(&base_url, "test-key", &None, &None, &None, &request)
         .await
         .expect("stream_messages should succeed");
 
@@ -356,7 +356,7 @@ async fn test_stream_messages_parses_multiline_sse_frames() {
         .expect("messages request should build");
 
     let base_url = format!("http://{addr}/api/v1");
-    let mut stream = stream_messages(&base_url, "test-key", &None, &None, &request)
+    let mut stream = stream_messages(&base_url, "test-key", &None, &None, &None, &request)
         .await
         .expect("stream_messages should succeed");
 
@@ -455,11 +455,19 @@ async fn test_create_message_sets_stream_false_and_headers() {
         .expect("messages request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
     let http_referer = Some("https://github.com/realmorrisliu/openrouter-rs".to_string());
+    let app_categories = Some(vec!["cli-agent".to_string()]);
 
     let base_url = format!("http://{addr}/api/v1");
-    let response = create_message(&base_url, "api-key", &x_title, &http_referer, &request)
-        .await
-        .expect("create_message should succeed");
+    let response = create_message(
+        &base_url,
+        "api-key",
+        &x_title,
+        &http_referer,
+        &app_categories,
+        &request,
+    )
+    .await
+    .expect("create_message should succeed");
     assert_eq!(response.id.as_deref(), Some("msg_1"));
     assert_eq!(response.object_type.as_deref(), Some("message"));
 
@@ -489,6 +497,11 @@ async fn test_create_message_sets_stream_false_and_headers() {
             || headers_lower
                 .contains("http-referer:https://github.com/realmorrisliu/openrouter-rs"),
         "http-referer header should be present, headers:\n{header_text}"
+    );
+    assert!(
+        headers_lower.contains("x-openrouter-categories: cli-agent")
+            || headers_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, headers:\n{header_text}"
     );
 
     let request_json: serde_json::Value =

--- a/tests/unit/rerank.rs
+++ b/tests/unit/rerank.rs
@@ -155,6 +155,7 @@ async fn test_create_rerank_path_body_and_headers() {
         "api-key",
         &Some("openrouter-rs".to_string()),
         &Some("https://example.com".to_string()),
+        &Some(vec!["cli-agent".to_string()]),
         &request,
     )
     .await
@@ -189,6 +190,12 @@ async fn test_create_rerank_path_body_and_headers() {
         request_lower.contains("http-referer: https://example.com")
             || request_lower.contains("http-referer:https://example.com"),
         "http-referer header should be present, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("x-openrouter-categories: cli-agent")
+            || request_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, request:\n{}",
         request_text
     );
 

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -262,10 +262,18 @@ async fn test_create_response_sets_stream_false_and_headers() {
         .expect("responses request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
     let http_referer = Some("https://github.com/realmorrisliu/openrouter-rs".to_string());
+    let app_categories = Some(vec!["cli-agent".to_string()]);
 
-    let response = create_response(&base_url, "api-key", &x_title, &http_referer, &request)
-        .await
-        .expect("create response should succeed");
+    let response = create_response(
+        &base_url,
+        "api-key",
+        &x_title,
+        &http_referer,
+        &app_categories,
+        &request,
+    )
+    .await
+    .expect("create response should succeed");
     assert_eq!(response.id.as_deref(), Some("resp_1"));
     assert_eq!(response.status.as_deref(), Some("completed"));
 
@@ -300,6 +308,12 @@ async fn test_create_response_sets_stream_false_and_headers() {
         "http-referer header should be present, headers:\n{}",
         captured.header_text
     );
+    assert!(
+        headers_lower.contains("x-openrouter-categories: cli-agent")
+            || headers_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, headers:\n{}",
+        captured.header_text
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
@@ -328,10 +342,18 @@ async fn test_stream_response_sets_stream_true_and_parses_sse() {
         .expect("responses request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
     let http_referer = Some("https://github.com/realmorrisliu/openrouter-rs".to_string());
+    let app_categories = Some(vec!["cli-agent".to_string()]);
 
-    let mut stream = stream_response(&base_url, "api-key", &x_title, &http_referer, &request)
-        .await
-        .expect("stream response should succeed");
+    let mut stream = stream_response(
+        &base_url,
+        "api-key",
+        &x_title,
+        &http_referer,
+        &app_categories,
+        &request,
+    )
+    .await
+    .expect("stream response should succeed");
     let mut events = Vec::new();
     while let Some(item) = stream.next().await {
         events.push(item.expect("stream event should parse"));
@@ -379,7 +401,7 @@ async fn test_stream_response_parses_multiline_sse_data_frames() {
         .build()
         .expect("responses request should build");
 
-    let mut stream = stream_response(&base_url, "api-key", &None, &None, &request)
+    let mut stream = stream_response(&base_url, "api-key", &None, &None, &None, &request)
         .await
         .expect("stream response should succeed");
     let mut events = Vec::new();

--- a/tests/unit/videos.rs
+++ b/tests/unit/videos.rs
@@ -198,6 +198,7 @@ async fn test_create_video_generation_path_body_and_headers() {
         "api-key",
         &Some("openrouter-rs".to_string()),
         &Some("https://example.com".to_string()),
+        &Some(vec!["cli-agent".to_string()]),
         &request,
     )
     .await


### PR DESCRIPTION
## Summary
- add `app_categories` to the client builder and serialize it into `X-OpenRouter-Categories`
- thread app categories through request surfaces that already send `X-OpenRouter-Title` and `HTTP-Referer`
- add unit coverage and docs for the new request metadata

## Validation
- just quality

Closes #183