### PR TITLE
feat: add typed text-to-speech support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added typed SDK support for `POST /tts`, including the canonical `client.tts().create(...)` surface, raw audio-byte handling, and a runnable example.
+
+### Changed
+- Restored the repository snapshot to `43 / 43` official OpenAPI endpoint coverage and aligned the endpoint matrix, README, and docs.rs surface with the newly implemented text-to-speech endpoint.
+
 ## [0.8.0] - 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 </div>
 
-`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, text-to-speech, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `42 / 43` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `43 / 43` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
-- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
+- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
 - Typed request/response models with builder-style ergonomics
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
-- Discovery, rerank, video generation, embeddings, API-key management, organization members, guardrails, activity, credits, and generation coverage
+- Discovery, rerank, text-to-speech, video generation, embeddings, API-key management, organization members, guardrails, activity, credits, and generation coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -101,6 +101,7 @@ The canonical public surface in `0.8.x` is domain-oriented:
 | `responses()` | `create`, `stream`, `stream_unified` | `/responses` | API key |
 | `messages()` | `create`, `stream`, `stream_unified` | `/messages` | API key |
 | `rerank()` | `create` | `/rerank` | API key |
+| `tts()` | `create` | `/tts` | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/endpoints/zdr`, `/embeddings*` | API key |
 | `management()` | `create_api_key`, `list_api_keys`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_organization_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/activity`, `/credits*`, `/generation`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
@@ -120,7 +121,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 `openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:
 
 - chat completions, responses, and Anthropic-compatible messages
-- rerank and video generation polling/content retrieval
+- rerank, text-to-speech, and video generation polling/content retrieval
 - unified streaming across chat, responses, and messages
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
@@ -159,6 +160,7 @@ The repo includes runnable examples for the highest-value workflows:
 | [`examples/create_response.rs`](examples/create_response.rs) | `responses()` create |
 | [`examples/create_message.rs`](examples/create_message.rs) | `messages()` create |
 | [`examples/create_rerank.rs`](examples/create_rerank.rs) | `rerank().create(...)` |
+| [`examples/create_tts.rs`](examples/create_tts.rs) | `tts().create(...)` |
 | [`examples/create_video_generation.rs`](examples/create_video_generation.rs) | `videos().create(...)` |
 | [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
 | [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
@@ -217,7 +219,7 @@ Full migration guide: [`MIGRATION.md`](MIGRATION.md)
 - `OpenRouterError::HttpRequest(surf::Error)` -> `OpenRouterError::HttpRequest(HttpRequestError)`
 - `ApiErrorContext.status: surf::StatusCode` -> `ApiErrorContext.status: http::StatusCode`
 - `openrouter_rs::utils::{with_bearer_auth, with_request_metadata, with_client_request_headers, handle_error}` -> caller-owned transport helpers or direct use of the canonical domain clients
-- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `models()`, `management()`, and `legacy()`
+- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and `legacy()`
 
 ### 🔁 0.6 Naming/Pagination Migration
 

--- a/docs/design/generated-core-architecture.md
+++ b/docs/design/generated-core-architecture.md
@@ -21,7 +21,7 @@ If the project wants to stay aligned with a spec-driven SDK direction, it needs 
 
 ## Goals
 
-- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `models()`, `management()`, and `legacy()`
+- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and `legacy()`
 - Introduce a generated low-level layer that can follow the upstream OpenAPI more mechanically
 - Separate drift detection inputs from generation inputs so review workflows stay useful
 - Preserve streaming, typed tools, builder ergonomics, and unified abstractions as handwritten Rust-first surfaces

--- a/docs/design/http-transport-migration.md
+++ b/docs/design/http-transport-migration.md
@@ -30,7 +30,7 @@ The key issue is not that every layer is dead. The issue is that the public SDK 
 
 - Remove the default dependency chain on runtime `libcurl` / `curl`
 - Move the SDK onto a Tokio-native and actively maintained client stack
-- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `models()`, `management()`, and `legacy()`
+- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and `legacy()`
 - Preserve current behavior for JSON requests, auth headers, query encoding, and SSE streaming
 - Reduce coupling between public error types and a specific HTTP client implementation
 - Make the migration reviewable in a small number of focused PRs instead of one rewrite

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -8,7 +8,7 @@ Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 ## Coverage Summary
 
 - Official OpenAPI endpoints: `43` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `42 / 43` (`97.7%`).
+- SDK implementation coverage (`src/api` + domain client): `43 / 43` (`100%`).
 - Live integration coverage (`tests/integration`): `22 / 43` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`
 
@@ -19,7 +19,7 @@ Drift review note:
 Legend:
 
 - `SDK`: endpoint implemented in `openrouter-rs`.
-- Canonical surface note: the `0.7.x` docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
+- Canonical surface note: the `0.7.x` docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
 - `Unit`: unit coverage depth.
   - `Path` = test asserts HTTP method/path (often with header/body checks).
   - `Contract` = serde/request-shape/parser coverage only.
@@ -69,7 +69,7 @@ Legend:
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | No | P1 |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
-| `POST /tts` | Not yet implemented. Tracked in `#182` | No | None | No | P1 |
+| `POST /tts` | `client.tts().create(...)` | Yes | Path | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
 | `GET /videos/models` | `client.videos().list_models()` | Yes | Path | No | P2 |
 | `GET /videos/{jobId}` | `client.videos().get_generation(...)` | Yes | Path | No | P2 |

--- a/examples/create_tts.rs
+++ b/examples/create_tts.rs
@@ -1,0 +1,23 @@
+use openrouter_rs::{
+    OpenRouterClient,
+    api::tts::{TtsRequest, TtsResponseFormat},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello from openrouter-rs")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .build()?;
+
+    let audio = client.tts().create(&request).await?;
+    std::fs::write("tts-output.mp3", &audio)?;
+    println!("wrote {} bytes to tts-output.mp3", audio.len());
+
+    Ok(())
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@
 //! - `client.responses()` -> [`responses`]
 //! - `client.messages()` -> [`messages`]
 //! - `client.rerank()` -> [`rerank`]
+//! - `client.tts()` -> [`tts`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
 //! - `client.management()` -> [`api_keys`], [`auth`], [`credits`], [`generation`], [`guardrails`], [`organization`]
@@ -20,6 +21,7 @@
 //! - Responses API
 //! - Anthropic-compatible Messages API
 //! - rerank
+//! - text-to-speech
 //! - video generation and polling
 //! - model discovery, providers, user model filters, model counts, and ZDR endpoints
 //! - embeddings
@@ -124,6 +126,7 @@ pub mod models;
 pub mod organization;
 pub mod rerank;
 pub mod responses;
+pub mod tts;
 pub mod videos;
 
 #[cfg(feature = "legacy-completions")]

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
+};
+
+/// Supported audio output formats for `POST /tts`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum TtsResponseFormat {
+    Mp3,
+    Pcm,
+}
+
+/// Provider-specific passthrough options for text-to-speech requests.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct TtsProviderOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Request payload for `POST /tts`.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct TtsRequest {
+    #[builder(setter(into))]
+    pub input: String,
+    #[builder(setter(into))]
+    pub model: String,
+    #[builder(setter(into))]
+    pub voice: String,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<TtsProviderOptions>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<TtsResponseFormat>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f64>,
+}
+
+impl TtsRequest {
+    pub fn builder() -> TtsRequestBuilder {
+        TtsRequestBuilder::default()
+    }
+}
+
+/// Submit a text-to-speech request and return raw audio bytes.
+pub async fn create_tts(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &TtsRequest,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_tts_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_tts_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &TtsRequest,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let url = format!("{base_url}/tts");
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+    )?
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        Ok(response.bytes().await?.to_vec())
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use crate::api::legacy::completion;
 use crate::{
     api::{
         api_keys, auth, chat, credits, discovery, embeddings, generation, guardrails, messages,
-        models, organization, rerank, responses, videos,
+        models, organization, rerank, responses, tts, videos,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -133,6 +133,11 @@ impl OpenRouterClient {
     /// Domain client for rerank operations.
     pub fn rerank(&self) -> RerankClient<'_> {
         RerankClient { client: self }
+    }
+
+    /// Domain client for text-to-speech operations.
+    pub fn tts(&self) -> TtsClient<'_> {
+        TtsClient { client: self }
     }
 
     /// Domain client for video generation operations.
@@ -1039,6 +1044,24 @@ impl OpenRouterClient {
         }
     }
 
+    /// Submit a text-to-speech request and return raw audio bytes.
+    pub async fn create_tts(&self, request: &tts::TtsRequest) -> Result<Vec<u8>, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            tts::create_tts_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                &self.x_title,
+                &self.http_referer,
+                &self.app_categories,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Submit a video generation request.
     pub async fn create_video_generation(
         &self,
@@ -1584,6 +1607,19 @@ impl<'a> RerankClient<'a> {
         request: &rerank::RerankRequest,
     ) -> Result<rerank::RerankResponse, OpenRouterError> {
         self.client.create_rerank(request).await
+    }
+}
+
+/// Domain client for text-to-speech endpoints.
+#[derive(Debug, Clone, Copy)]
+pub struct TtsClient<'a> {
+    client: &'a OpenRouterClient,
+}
+
+impl<'a> TtsClient<'a> {
+    /// Create speech audio bytes (`POST /tts`).
+    pub async fn create(&self, request: &tts::TtsRequest) -> Result<Vec<u8>, OpenRouterError> {
+        self.client.create_tts(request).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 //! # OpenRouter Rust SDK
 //!
 //! `openrouter-rs` is a type-safe, async Rust SDK for the [OpenRouter API](https://openrouter.ai/),
-//! providing typed access to chat, responses, messages, rerank, video generation, discovery,
-//! embeddings, and management endpoints.
+//! providing typed access to chat, responses, messages, rerank, text-to-speech, video generation,
+//! discovery, embeddings, and management endpoints.
 //!
 //! ## ✨ Key Features
 //!
 //! - **🔒 Type Safety**: Leverages Rust's type system for compile-time error prevention
 //! - **⚡ Async/Await**: Built on `tokio` for high-performance async operations  
 //! - **🏗️ Builder Pattern**: Ergonomic client and request construction
-//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `models()`, `management()`
+//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`
 //! - **📡 Streaming Support**: Real-time response streaming with `futures`
 //! - **🧩 Unified Streaming Events**: Shared stream event model across chat/responses/messages
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
@@ -145,6 +145,7 @@
 //! | Domain-Oriented Client API | ✅ | [`client::OpenRouterClient`] |
 //! | Chat Completions | ✅ | [`api::chat`] |
 //! | Rerank | ✅ | [`api::rerank`] |
+//! | Text-to-Speech | ✅ | [`api::tts`] |
 //! | Video Generation | ✅ | [`api::videos`] |
 //! | Legacy Text Completions (`legacy-completions`) | ✅ | `api::legacy::completion` |
 //! | Model Information | ✅ | [`api::models`] |

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -8,7 +8,7 @@ use std::{
 
 use openrouter_rs::{
     OpenRouterClient,
-    api::{auth, chat, credits, embeddings, guardrails, messages, rerank, responses, videos},
+    api::{auth, chat, credits, embeddings, guardrails, messages, rerank, responses, tts, videos},
     error::OpenRouterError,
     types::{ModelCategory, PaginationOptions, Role, SupportedParameters},
 };
@@ -98,6 +98,95 @@ fn spawn_json_server(
         stream
             .write_all(response.as_bytes())
             .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+fn spawn_binary_server(
+    response_body: &[u8],
+    content_type: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_vec();
+    let content_type = content_type.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send captured request");
+
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            content_type,
+            body.len()
+        );
+        stream
+            .write_all(header.as_bytes())
+            .expect("server should write response header");
+        stream
+            .write_all(&body)
+            .expect("server should write response body");
     });
 
     (format!("http://{addr}/api/v1"), rx, server)
@@ -277,6 +366,22 @@ async fn test_rerank_domain_requires_api_key() {
         .expect("rerank request should build");
 
     let result = client.rerank().create(&request).await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_tts_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let request = tts::TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("hello")
+        .voice("alloy")
+        .build()
+        .expect("tts request should build");
+
+    let result = client.tts().create(&request).await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
 }
 
@@ -604,6 +709,44 @@ async fn test_rerank_domain_create_delegates_to_api_module() {
         serde_json::from_str(&captured.body_text).expect("body should be valid json");
     assert_eq!(body_json["model"], "cohere/rerank-v3.5");
     assert_eq!(body_json["query"], "capital of France");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_tts_domain_create_delegates_to_api_module() {
+    let (base_url, rx, server) = spawn_binary_server(b"ID3tts-audio", "audio/mpeg");
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .build()
+        .expect("client should build");
+    let request = tts::TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(tts::TtsResponseFormat::Mp3)
+        .build()
+        .expect("tts request should build");
+
+    let response = client
+        .tts()
+        .create(&request)
+        .await
+        .expect("tts should succeed");
+    assert_eq!(response, b"ID3tts-audio");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "POST /api/v1/tts HTTP/1.1");
+
+    let body_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body_json["model"], "elevenlabs/eleven-turbo-v2");
+    assert_eq!(body_json["input"], "Hello world");
+    assert_eq!(body_json["voice"], "alloy");
+    assert_eq!(body_json["response_format"], "mp3");
 
     server.join().expect("server thread should finish");
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -29,5 +29,6 @@ pub mod response_format;
 pub mod responses;
 pub mod stream;
 pub mod tool_builder;
+pub mod tts;
 pub mod unified_stream;
 pub mod videos;

--- a/tests/unit/tts.rs
+++ b/tests/unit/tts.rs
@@ -1,0 +1,180 @@
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::api::tts::{self, TtsProviderOptions, TtsRequest, TtsResponseFormat};
+
+#[test]
+fn test_tts_request_serialization() {
+    let mut provider_options = HashMap::new();
+    provider_options.insert(
+        "openai".to_string(),
+        serde_json::json!({
+            "instructions": "Speak clearly"
+        }),
+    );
+
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .speed(1.1)
+        .provider(TtsProviderOptions {
+            options: Some(provider_options),
+        })
+        .build()
+        .expect("tts request should build");
+
+    let value = serde_json::to_value(&request).expect("tts request should serialize");
+    assert_eq!(value["model"], "elevenlabs/eleven-turbo-v2");
+    assert_eq!(value["input"], "Hello world");
+    assert_eq!(value["voice"], "alloy");
+    assert_eq!(value["response_format"], "mp3");
+    assert_eq!(value["speed"], 1.1);
+    assert_eq!(
+        value["provider"]["options"]["openai"]["instructions"],
+        "Speak clearly"
+    );
+}
+
+#[tokio::test]
+async fn test_create_tts_path_body_headers_and_binary_response() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<(String, String, String)>();
+    let audio_bytes = b"ID3fake-audio-data".to_vec();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send((request_line, request_text, body_text))
+            .expect("server should send captured request");
+
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            audio_bytes.len()
+        );
+        stream
+            .write_all(header.as_bytes())
+            .expect("server should write response header");
+        stream
+            .write_all(&audio_bytes)
+            .expect("server should write binary response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .speed(1.0)
+        .build()
+        .expect("tts request should build");
+
+    let response = tts::create_tts(
+        &base_url,
+        "api-key",
+        &Some("openrouter-rs".to_string()),
+        &Some("https://example.com".to_string()),
+        &Some(vec!["cli-agent".to_string()]),
+        &request,
+    )
+    .await
+    .expect("tts request should succeed");
+    assert_eq!(response, b"ID3fake-audio-data");
+
+    let (request_line, request_text, body_text) = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(request_line, "POST /api/v1/tts HTTP/1.1");
+
+    let body_json: serde_json::Value =
+        serde_json::from_str(&body_text).expect("body should be valid json");
+    assert_eq!(body_json["model"], "elevenlabs/eleven-turbo-v2");
+    assert_eq!(body_json["input"], "Hello world");
+    assert_eq!(body_json["voice"], "alloy");
+    assert_eq!(body_json["response_format"], "mp3");
+    assert_eq!(body_json["speed"], 1.0);
+
+    let request_lower = request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include api key, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("x-title: openrouter-rs")
+            || request_lower.contains("x-title:openrouter-rs"),
+        "x-title header should be present, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("http-referer: https://example.com")
+            || request_lower.contains("http-referer:https://example.com"),
+        "http-referer header should be present, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("x-openrouter-categories: cli-agent")
+            || request_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, request:\n{}",
+        request_text
+    );
+
+    server.join().expect("server thread should finish");
+}


### PR DESCRIPTION
## Summary
- add a typed `api::tts` module for `POST /tts` with builder-based request types and binary audio responses
- expose the canonical `client.tts().create(...)` surface and add a runnable `create_tts` example
- refresh coverage/docs surfaces so the repo snapshot is back to 43/43 accepted OpenAPI endpoints

## Validation
- just quality

Closes #182