### PR TITLE
feat: add org member CLI command and smoke coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added typed SDK support for `POST /tts`, including the canonical `client.tts().create(...)` surface, raw audio-byte handling, and a runnable example.
+- Added live smoke coverage for `POST /rerank` and read-only management coverage for `GET /organization/members`.
+- Added `openrouter-cli organization members list` for management-key-backed organization member discovery.
 
 ### Changed
 - Restored the repository snapshot to `43 / 43` official OpenAPI endpoint coverage and aligned the endpoint matrix, README, and docs.rs surface with the newly implemented text-to-speech endpoint.

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -6,7 +6,7 @@ It currently focuses on four areas:
 
 - profile/config resolution
 - model and provider discovery
-- API-key and guardrail management
+- API-key, organization, and guardrail management
 - credits, billing, and usage activity
 
 The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.1.2`.
@@ -54,13 +54,14 @@ keys list|create|get|update|delete
 guardrails list|create|get|update|delete
 guardrails assignments keys list|assign|unassign
 guardrails assignments members list|assign|unassign
+organization members list
 usage activity
 ```
 
 Auth expectations by command group:
 
 - `models`, `providers`, `credits show`, `credits charge`: API key
-- `keys`, `guardrails`, `usage activity`: management key
+- `keys`, `guardrails`, `organization`, `usage activity`: management key
 - `profile`, `config`: no API call required
 
 ## Config And Resolution Order
@@ -207,6 +208,15 @@ openrouter-cli \
 
 Member assignment commands mirror the same shape under `guardrails assignments members ...`.
 
+### Organization members
+
+```bash
+# List organization members
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  organization members list --limit 25
+```
+
 ## Credits And Usage
 
 ```bash
@@ -268,7 +278,7 @@ Environment switches:
 Required secrets:
 
 - `OPENROUTER_API_KEY` for read smoke
-- `OPENROUTER_MANAGEMENT_KEY` for usage and write smoke
+- `OPENROUTER_MANAGEMENT_KEY` for usage, organization-members, and write smoke
 
 Examples:
 

--- a/crates/openrouter-cli/src/cli.rs
+++ b/crates/openrouter-cli/src/cli.rs
@@ -86,6 +86,21 @@ pub enum UsageCommands {
     Activity(UsageActivityArgs),
 }
 
+#[derive(Debug, Clone, Subcommand)]
+pub enum OrganizationMemberCommands {
+    /// List organization members.
+    List(PaginationArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum OrganizationCommands {
+    /// Organization member commands.
+    Members {
+        #[command(subcommand)]
+        command: OrganizationMemberCommands,
+    },
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
 pub enum ModelCategoryArg {
     Roleplay,
@@ -503,6 +518,11 @@ pub enum Commands {
     Guardrails {
         #[command(subcommand)]
         command: GuardrailsCommands,
+    },
+    /// Organization management commands.
+    Organization {
+        #[command(subcommand)]
+        command: OrganizationCommands,
     },
     /// Usage commands.
     Usage {

--- a/crates/openrouter-cli/src/main.rs
+++ b/crates/openrouter-cli/src/main.rs
@@ -14,8 +14,9 @@ use crate::{
     cli::{
         Cli, Commands, ConfigCommands, CreditsCommands, GuardrailAssignmentCommands,
         GuardrailKeyAssignmentCommands, GuardrailMemberAssignmentCommands, GuardrailsCommands,
-        KeysCommands, ModelCategoryArg, ModelsCommands, OutputFormat, PaginationArgs,
-        ProfileCommands, ProvidersCommands, SupportedParameterArg, UsageCommands,
+        KeysCommands, ModelCategoryArg, ModelsCommands, OrganizationCommands,
+        OrganizationMemberCommands, OutputFormat, PaginationArgs, ProfileCommands,
+        ProvidersCommands, SupportedParameterArg, UsageCommands,
     },
     config::{Environment, ResolvedProfile, resolve_profile},
 };
@@ -760,6 +761,20 @@ async fn run(cli: Cli) -> Result<()> {
                             print_value(&response, cli.global.output)?;
                         }
                     },
+                },
+            }
+        }
+        Commands::Organization { command } => {
+            let client = build_management_client(&resolved)?;
+            let management = client.management();
+
+            match command {
+                OrganizationCommands::Members { command } => match command {
+                    OrganizationMemberCommands::List(args) => {
+                        let pagination = pagination_from_args(&args);
+                        let response = management.list_organization_members(pagination).await?;
+                        print_value(&response, cli.global.output)?;
+                    }
                 },
             }
         }

--- a/crates/openrouter-cli/tests/help.rs
+++ b/crates/openrouter-cli/tests/help.rs
@@ -9,7 +9,8 @@ fn test_help_starts() {
         .success()
         .stdout(contains("OpenRouter CLI"))
         .stdout(contains("--profile"))
-        .stdout(contains("profile"));
+        .stdout(contains("profile"))
+        .stdout(contains("organization"));
 }
 
 #[test]

--- a/crates/openrouter-cli/tests/live_smoke.rs
+++ b/crates/openrouter-cli/tests/live_smoke.rs
@@ -183,9 +183,30 @@ fn test_live_cli_read_smoke() {
                     .is_some(),
                 "usage activity should include data array",
             )?;
+
+            let organization = run_cli_json(
+                &["organization", "members", "list", "--limit", "5"],
+                Some(&api_key),
+                Some(management_key),
+            )?;
+            ensure_schema(&organization)?;
+            ensure(
+                organization
+                    .pointer("/data/total_count")
+                    .and_then(Value::as_f64)
+                    .is_some(),
+                "organization members should include numeric total_count",
+            )?;
+            ensure(
+                organization
+                    .pointer("/data/data")
+                    .and_then(Value::as_array)
+                    .is_some(),
+                "organization members should include data array",
+            )?;
         } else {
             println!(
-                "Skipping usage activity check in read smoke; OPENROUTER_MANAGEMENT_KEY is not configured"
+                "Skipping usage activity and organization members checks in read smoke; OPENROUTER_MANAGEMENT_KEY is not configured"
             );
         }
 

--- a/crates/openrouter-cli/tests/management_commands.rs
+++ b/crates/openrouter-cli/tests/management_commands.rs
@@ -301,6 +301,52 @@ fn test_guardrail_member_assignment_list_global_happy_path() {
 }
 
 #[test]
+fn test_organization_members_list_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"mem_1","first_name":"Ada","last_name":"Lovelace","email":"ada@example.com","role":"owner"}],"total_count":1}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("organization")
+        .arg("members")
+        .arg("list")
+        .arg("--offset")
+        .arg("2")
+        .arg("--limit")
+        .arg("4");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed
+            .get("data")
+            .and_then(|value| value.get("total_count"))
+            .and_then(Value::as_f64),
+        Some(1.0)
+    );
+    assert_eq!(
+        parsed.pointer("/data/data/0/email").and_then(Value::as_str),
+        Some("ada@example.com")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/organization/members?offset=2&limit=4 HTTP/1.1"
+    );
+    let lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        lower.contains("authorization: bearer mgmt-test-key")
+            || lower.contains("authorization:bearer mgmt-test-key"),
+        "request should include management authorization header: {}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
 fn test_guardrails_update_can_clear_allowlists() {
     let (base_url, rx, server) = spawn_json_server(
         r#"{"data":{"id":"gr_1","name":"Prod","created_at":"2026-03-01T00:00:00.000Z"}}"#,

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-20  
+Snapshot date: 2026-04-21  
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -9,8 +9,8 @@ Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 
 - Official OpenAPI endpoints: `43` method+path entries.
 - SDK implementation coverage (`src/api` + domain client): `43 / 43` (`100%`).
-- Live integration coverage (`tests/integration`): `22 / 43` endpoints currently exercised.
-  - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`
+- Live integration coverage (`tests/integration`): `24 / 43` endpoints currently exercised.
+  - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
 
@@ -64,10 +64,10 @@ Legend:
 | `GET /models/{author}/{slug}/endpoints` | `client.list_model_endpoints(...)` / `client.models().list_endpoints(...)` | Yes | Path | Yes | Keep |
 | `GET /models/count` | `client.count_models()` / `client.models().get_model_count()` | Yes | Contract | Yes | Keep |
 | `GET /models/user` | `client.list_models_for_user()` / `client.models().list_user_models()` | Yes | Path | Yes | Keep |
-| `GET /organization/members` | `client.management().list_organization_members(...)` | Yes | Path | No | P2 |
+| `GET /organization/members` | `client.management().list_organization_members(...)` | Yes | Path | Yes | Keep |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
-| `POST /rerank` | `client.rerank().create(...)` | Yes | Path | No | P1 |
+| `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
 | `POST /tts` | `client.tts().create(...)` | Yes | Path | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
@@ -88,7 +88,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity`.
 3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
-4. P1/P2: add low-cost live or smoke coverage for `/rerank`, `/tts`, `/videos*`, and `/organization/members` once stable fixtures and cost controls are defined.
+4. P1/P2: add low-cost live or smoke coverage for `/tts` and `/videos*` once stable fixtures and cost controls are defined.
 
 ## Reproduce Snapshot
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -18,6 +18,7 @@ The live integration suite resolves models in this order:
 - `OPENROUTER_TEST_CHAT_MODEL`: override the primary chat model
 - `OPENROUTER_TEST_EMBEDDINGS_MODEL`: override the primary embeddings model
 - `OPENROUTER_TEST_MESSAGES_MODEL`: override the primary Messages API model
+- `OPENROUTER_TEST_RERANK_MODEL`: override the primary rerank model
 - `OPENROUTER_TEST_RESPONSES_MODEL`: override the primary Responses API model
 - `OPENROUTER_TEST_REASONING_MODEL`: override the primary reasoning model
 - `OPENROUTER_TEST_STABLE_MODELS`: comma-separated stable regression models
@@ -71,6 +72,10 @@ Management smoke is opt-in and performs cleanup-protected lifecycle checks for:
 
 - `keys`: create -> list/get -> update -> delete
 - `guardrails`: create -> list/get -> update -> delete
+
+When `OPENROUTER_MANAGEMENT_KEY` is configured, the integration suite also runs a read-only
+smoke check for `GET /organization/members` without requiring
+`OPENROUTER_RUN_MANAGEMENT_TESTS=1`.
 
 Example:
 

--- a/tests/integration/contract.rs
+++ b/tests/integration/contract.rs
@@ -6,6 +6,7 @@ use openrouter_rs::{
         chat::{ChatCompletionRequestBuilder, Message},
         embeddings::{EmbeddingRequest, EmbeddingVector},
         messages::{AnthropicMessage, AnthropicMessagesRequest},
+        rerank::RerankRequest,
         responses::ResponsesRequest,
     },
     error::OpenRouterError,
@@ -22,6 +23,7 @@ use super::{
 };
 
 const DEFAULT_RESPONSES_MODEL: &str = "openai/gpt-4o-mini";
+const DEFAULT_RERANK_MODEL: &str = "cohere/rerank-v3.5";
 const MAX_MODEL_ENDPOINT_PROBES: usize = 8;
 const MAX_EMBEDDING_MODEL_PROBES: usize = 8;
 
@@ -39,6 +41,14 @@ fn test_messages_model() -> String {
         .map(|model| model.trim().to_string())
         .filter(|model| !model.is_empty())
         .unwrap_or_else(test_chat_model)
+}
+
+fn test_rerank_model() -> String {
+    env::var("OPENROUTER_TEST_RERANK_MODEL")
+        .ok()
+        .map(|model| model.trim().to_string())
+        .filter(|model| !model.is_empty())
+        .unwrap_or_else(|| DEFAULT_RERANK_MODEL.to_string())
 }
 
 fn configured_embeddings_model() -> Option<String> {
@@ -271,6 +281,48 @@ async fn test_read_only_contract_responses_and_messages_surface() -> Result<(), 
     rate_limit_delay().await;
     let messages_stream = client.messages().stream_unified(&messages_request).await?;
     assert_stream_completes(messages_stream, UnifiedStreamSource::Messages).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_read_only_contract_rerank_surface() -> Result<(), OpenRouterError> {
+    let client = create_test_client()?;
+    let model = test_rerank_model();
+
+    let request = RerankRequest::builder()
+        .model(model.clone())
+        .query("Which city is the capital of France?")
+        .documents(vec![
+            "Berlin is the capital of Germany.".to_string(),
+            "Paris is the capital of France.".to_string(),
+            "Tokyo is the capital of Japan.".to_string(),
+        ])
+        .top_n(2)
+        .build()?;
+
+    rate_limit_delay().await;
+    let response = client.rerank().create(&request).await?;
+    assert!(
+        !response.model.trim().is_empty(),
+        "rerank response model should be present"
+    );
+    assert!(
+        !response.results.is_empty(),
+        "rerank response should include at least one result"
+    );
+    assert!(
+        response.results.len() <= 2,
+        "rerank response should respect top_n"
+    );
+    assert!(
+        response
+            .results
+            .iter()
+            .all(|result| result.index < 3 && result.relevance_score.is_finite()),
+        "rerank results should include valid indices and finite scores"
+    );
 
     Ok(())
 }

--- a/tests/integration/management.rs
+++ b/tests/integration/management.rs
@@ -6,6 +6,7 @@ use std::{
 use openrouter_rs::{
     api::guardrails::{CreateGuardrailRequest, UpdateGuardrailRequest},
     error::OpenRouterError,
+    types::PaginationOptions,
 };
 
 use super::test_utils::{
@@ -232,4 +233,49 @@ async fn test_management_guardrails_smoke_lifecycle() -> Result<(), OpenRouterEr
             "management guardrail lifecycle failed ({primary}); cleanup also failed ({cleanup})"
         ))),
     }
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn test_management_organization_members_read_smoke() -> Result<(), OpenRouterError> {
+    let Some(client) = create_management_test_client()? else {
+        println!(
+            "Skipping organization members smoke test; OPENROUTER_MANAGEMENT_KEY is not configured"
+        );
+        return Ok(());
+    };
+
+    let management = client.management();
+
+    rate_limit_delay().await;
+    let members = management
+        .list_organization_members(Some(PaginationOptions::with_offset_and_limit(0, 25)))
+        .await?;
+
+    smoke_assert(
+        members.total_count as usize >= members.data.len(),
+        "organization members total_count should be >= returned row count",
+    )?;
+
+    if let Some(member) = members.data.first() {
+        smoke_assert(
+            !member.id.trim().is_empty(),
+            "organization member id should not be empty",
+        )?;
+        smoke_assert(
+            !member.email.trim().is_empty(),
+            "organization member email should not be empty",
+        )?;
+        smoke_assert(
+            !member.role.trim().is_empty(),
+            "organization member role should not be empty",
+        )?;
+    }
+
+    println!(
+        "Organization members smoke passed (returned={}, total_count={})",
+        members.data.len(),
+        members.total_count
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add live smoke coverage for `POST /rerank` and read-only management coverage for `GET /organization/members`
- expose `openrouter-cli organization members list` with mock coverage and live-read smoke wiring
- refresh the endpoint matrix, integration docs, CLI docs, and changelog to match the new coverage state

## Validation
- just quality-ci
- cargo test --test integration contract:: -- --nocapture
- cargo test --test integration management:: -- --nocapture

## Notes
- `management::` in this environment skipped the organization-members live call because `OPENROUTER_MANAGEMENT_KEY` was not configured.
- The rerank live contract test executed successfully.

Advances #158