### PR TITLE
chore: prepare 0.8.1 and openrouter-cli 0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-04-21
+
 ### Added
 - Added typed SDK support for `POST /tts`, including the canonical `client.tts().create(...)` surface, raw audio-byte handling, and a runnable example.
 - Added live smoke coverage for `POST /rerank` and read-only management coverage for `GET /organization/members`.
 - Added `openrouter-cli organization members list` for management-key-backed organization member discovery.
 
 ### Changed
+- Added `X-OpenRouter-Categories` request metadata support across the existing attribution-enabled SDK request surfaces.
 - Restored the repository snapshot to `43 / 43` official OpenAPI endpoint coverage and aligned the endpoint matrix, README, and docs.rs surface with the newly implemented text-to-speech endpoint.
+
 
 ## [0.8.0] - 2026-04-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openrouter-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The current repo snapshot implements `43 / 43` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.8.0"
+openrouter-rs = "0.8.1"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -45,7 +45,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.8.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.8.1", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -290,7 +290,13 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ## 📈 Release History
 
-### Version 0.8.0 *(Latest)*
+### Version 0.8.1 *(Latest)*
+
+- Added typed `POST /tts` support with the canonical `tts()` client surface and a runnable example.
+- Added live smoke coverage for `POST /rerank` and `GET /organization/members`, and restored the repo snapshot to `43 / 43` accepted OpenAPI endpoints.
+- Added `openrouter-cli organization members list` and aligned the CLI/docs surface with the latest management coverage.
+
+### Version 0.8.0
 
 - Completed the SDK transport migration to `reqwest + rustls` and removed the legacy `surf` / `curl` dependency chain.
 - Made the public HTTP error surface backend-neutral and documented the `0.7.x -> 0.8.0` breaking changes.

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI for OpenRouter account and SDK workflows"
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.8.0", path = "../.." }
+openrouter-rs = { version = "0.8.1", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -9,7 +9,7 @@ It currently focuses on four areas:
 - API-key, organization, and guardrail management
 - credits, billing, and usage activity
 
-The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.1.2`.
+The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.1.3`.
 
 Copyable shell and CI recipes live in [`../../docs/operations/cli-automation-workflows.md`](../../docs/operations/cli-automation-workflows.md).
 
@@ -30,7 +30,7 @@ cargo install --path crates/openrouter-cli --locked
 Prebuilt GitHub release archives follow the `openrouter-cli-v<version>` tag naming:
 
 ```bash
-VERSION=0.1.2
+VERSION=0.1.3
 curl -L -o openrouter-cli.tar.gz \
   "https://github.com/realmorrisliu/openrouter-rs/releases/download/openrouter-cli-v${VERSION}/openrouter-cli-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
 curl -L -o SHA256SUMS \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.8.0"
+//! openrouter-rs = "0.8.1"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- bump `openrouter-rs` to `0.8.1` and `openrouter-cli` to `0.1.3`
- finalize the `0.8.1` changelog entry and refresh the SDK README latest release history
- align the CLI package version, dependency version, and release-install snippets for the upcoming dual release

## Validation
- just quality
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.8.1
- just quality-ci
- cargo package --locked --allow-dirty

## Release sequencing
- Merge this PR to `main`
- Tag and publish SDK first via `v0.8.1`
- After `openrouter-rs 0.8.1` is live on crates.io, rerun `cargo package -p openrouter-cli --locked` and then push `openrouter-cli-v0.1.3`

Advances #158