### PR TITLE
chore: review latest openapi drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
+
+### Changed
+- `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` when the newer route is unavailable.
+- Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and recorded workspace-management follow-up work in `#190`.
+
 ## [0.8.1] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 `openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, text-to-speech, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `43 / 43` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `44 / 51` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md). Newly official workspace management endpoints are tracked separately in [#190](https://github.com/realmorrisliu/openrouter-rs/issues/190).
 
 ## Why `openrouter-rs`
 
@@ -30,7 +30,7 @@ The current repo snapshot implements `43 / 43` official OpenAPI method/path entr
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
-- Discovery, rerank, text-to-speech, video generation, embeddings, API-key management, organization members, guardrails, activity, credits, and generation coverage
+- Discovery, rerank, text-to-speech, video generation, embeddings, API-key management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -101,10 +101,10 @@ The canonical public surface in `0.8.x` is domain-oriented:
 | `responses()` | `create`, `stream`, `stream_unified` | `/responses` | API key |
 | `messages()` | `create`, `stream`, `stream_unified` | `/messages` | API key |
 | `rerank()` | `create` | `/rerank` | API key |
-| `tts()` | `create` | `/tts` | API key |
+| `tts()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/endpoints/zdr`, `/embeddings*` | API key |
-| `management()` | `create_api_key`, `list_api_keys`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_organization_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/activity`, `/credits*`, `/generation`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
+| `management()` | `create_api_key`, `list_api_keys`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_organization_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
 At runtime, the builder/client exposes the values the SDK directly consumes:
@@ -126,7 +126,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, embeddings, and ZDR endpoints
-- management-key workflows for keys, auth codes, organization members, guardrails, and activity, plus API-key-authenticated credits and generation endpoints
+- management-key workflows for keys, auth codes, organization members, guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 
@@ -207,7 +207,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Full endpoint coverage is tracked against the current OpenAPI snapshot
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, with the current workspace-management gap tracked in [#190](https://github.com/realmorrisliu/openrouter-rs/issues/190)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.7.x -> 0.8.0` transport/error-surface release, plus the archived `0.5.x -> 0.6.x` naming guide, lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -7,14 +7,16 @@ Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `43` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `43 / 43` (`100%`).
-- Live integration coverage (`tests/integration`): `24 / 43` endpoints currently exercised.
+- Official OpenAPI endpoints: `51` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `44 / 51` (`86.3%`).
+- Live integration coverage (`tests/integration`): `24 / 51` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
 
-- Upstream now declares `X-OpenRouter-Categories` on many existing operations. SDK support for that request metadata is tracked in `#183`.
+- Official text-to-speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.tts().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
+- Upstream added `GET /generation/content`, now exposed as `client.get_generation_content(...)` / `client.management().get_generation_content(...)`.
+- Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK follow-up is tracked in `#190`.
 
 Legend:
 
@@ -41,6 +43,7 @@ Legend:
 | `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | Path | Yes | Keep |
 | `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | Yes | Keep |
 | `GET /generation` | `client.get_generation(...)` / `client.management().get_generation(...)` | Yes | Path | No | P2 |
+| `GET /generation/content` | `client.get_generation_content(...)` / `client.management().get_generation_content(...)` | Yes | Path | No | P2 |
 | `GET /guardrails` | `client.management().list_guardrails(...)` | Yes | Path | Yes | Keep |
 | `POST /guardrails` | `client.management().create_guardrail(...)` | Yes | Contract | Yes | Keep |
 | `GET /guardrails/{id}` | `client.management().get_guardrail(...)` | Yes | Contract | Yes | Keep |
@@ -66,14 +69,21 @@ Legend:
 | `GET /models/user` | `client.list_models_for_user()` / `client.models().list_user_models()` | Yes | Path | Yes | Keep |
 | `GET /organization/members` | `client.management().list_organization_members(...)` | Yes | Path | Yes | Keep |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
+| `GET /workspaces` | Tracked in `#190` | No | None | No | P1 |
+| `GET /workspaces/{id}` | Tracked in `#190` | No | None | No | P1 |
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
-| `POST /tts` | `client.tts().create(...)` | Yes | Path | No | P1 |
+| `POST /audio/speech` | `client.tts().create(...)` | Yes | Path | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
+| `POST /workspaces` | Tracked in `#190` | No | None | No | P1 |
+| `POST /workspaces/{id}/members/add` | Tracked in `#190` | No | None | No | P1 |
+| `POST /workspaces/{id}/members/remove` | Tracked in `#190` | No | None | No | P1 |
 | `GET /videos/models` | `client.videos().list_models()` | Yes | Path | No | P2 |
 | `GET /videos/{jobId}` | `client.videos().get_generation(...)` | Yes | Path | No | P2 |
 | `GET /videos/{jobId}/content` | `client.videos().get_content(...)` | Yes | Path | No | P2 |
+| `PATCH /workspaces/{id}` | Tracked in `#190` | No | None | No | P1 |
+| `DELETE /workspaces/{id}` | Tracked in `#190` | No | None | No | P1 |
 
 ## Supplemental (Legacy)
 
@@ -82,13 +92,15 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 | Endpoint | SDK surface | Notes |
 | --- | --- | --- |
 | `POST /completions` | `client.legacy().completions().create(...)` (feature `legacy-completions`) | Migration-only surface toward `chat`/`responses` |
+| `POST /tts` | `client.tts().create(...)` | Compatibility fallback while upstream rolls out `POST /audio/speech` everywhere |
 
 ## Incremental Test Plan
 
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity`.
-3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
-4. P1/P2: add low-cost live or smoke coverage for `/tts` and `/videos*` once stable fixtures and cost controls are defined.
+3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
+4. P1/P2: add low-cost live or smoke coverage for `/audio/speech` and `/videos*` once stable fixtures and cost controls are defined.
+5. P1: add typed workspace management support and then cover `/workspaces*` in unit and live management-key validation (`#190`).
 
 ## Reproduce Snapshot
 

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,23 +1,13 @@
 {
   "components": {
     "parameters": {
-      "AppCategories": {
-        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
-        "in": "header",
-        "name": "X-OpenRouter-Categories",
-        "schema": {
-          "type": "string"
-        },
-        "x-speakeasy-name-override": "appCategories"
-      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-OpenRouter-Title",
+        "name": "X-Title",
         "schema": {
           "type": "string"
-        },
-        "x-speakeasy-name-override": "appTitle"
+        }
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -3937,8 +3927,7 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField",
-            "nullable": true
+            "$ref": "#/components/schemas/ResponsesErrorField"
           },
           "frequency_penalty": {
             "format": "double",
@@ -3949,12 +3938,10 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails",
-            "nullable": true
+            "$ref": "#/components/schemas/IncompleteDetails"
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs",
-            "nullable": true
+            "$ref": "#/components/schemas/BaseInputs"
           },
           "max_output_tokens": {
             "nullable": true,
@@ -4035,8 +4022,7 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig",
-            "nullable": true
+            "$ref": "#/components/schemas/BaseReasoningConfig"
           },
           "safety_identifier": {
             "nullable": true,
@@ -4057,8 +4043,7 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig",
-            "nullable": true
+            "$ref": "#/components/schemas/TextConfig"
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -4147,7 +4132,6 @@
             "type": "array"
           },
           "top_logprobs": {
-            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -4156,8 +4140,7 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation",
-            "nullable": true
+            "$ref": "#/components/schemas/Truncation"
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -4296,6 +4279,66 @@
         "example": 1000,
         "type": "string"
       },
+      "BulkAddWorkspaceMembersRequest": {
+        "example": {
+          "user_ids": [
+            "user_abc123",
+            "user_def456"
+          ]
+        },
+        "properties": {
+          "user_ids": {
+            "description": "List of user IDs to add to the workspace. Members are assigned the same role they hold in the organization.",
+            "example": [
+              "user_abc123",
+              "user_def456"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "user_ids"
+        ],
+        "type": "object"
+      },
+      "BulkAddWorkspaceMembersResponse": {
+        "example": {
+          "added_count": 1,
+          "data": [
+            {
+              "created_at": "2025-08-24T10:30:00Z",
+              "id": "660e8400-e29b-41d4-a716-446655440000",
+              "role": "member",
+              "user_id": "user_abc123",
+              "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          ]
+        },
+        "properties": {
+          "added_count": {
+            "description": "Number of workspace memberships created or updated",
+            "example": 2,
+            "type": "integer"
+          },
+          "data": {
+            "description": "List of added workspace memberships",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceMember"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "added_count"
+        ],
+        "type": "object"
+      },
       "BulkAssignKeysRequest": {
         "example": {
           "key_hashes": [
@@ -4377,6 +4420,49 @@
         },
         "required": [
           "assigned_count"
+        ],
+        "type": "object"
+      },
+      "BulkRemoveWorkspaceMembersRequest": {
+        "example": {
+          "user_ids": [
+            "user_abc123",
+            "user_def456"
+          ]
+        },
+        "properties": {
+          "user_ids": {
+            "description": "List of user IDs to remove from the workspace",
+            "example": [
+              "user_abc123",
+              "user_def456"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "user_ids"
+        ],
+        "type": "object"
+      },
+      "BulkRemoveWorkspaceMembersResponse": {
+        "example": {
+          "removed_count": 2
+        },
+        "properties": {
+          "removed_count": {
+            "description": "Number of members removed",
+            "example": 2,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "removed_count"
         ],
         "type": "object"
       },
@@ -5466,6 +5552,7 @@
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
                   "moderation": "#/components/schemas/ModerationPlugin",
+                  "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
                   "web": "#/components/schemas/WebSearchPlugin"
                 },
@@ -5489,6 +5576,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ContextCompressionPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ParetoRouterPlugin"
                 }
               ]
             },
@@ -7136,6 +7226,113 @@
         ],
         "type": "object"
       },
+      "CreateWorkspaceRequest": {
+        "example": {
+          "default_image_model": "openai/dall-e-3",
+          "default_provider_sort": "price",
+          "default_text_model": "openai/gpt-4o",
+          "description": "Production environment workspace",
+          "name": "Production",
+          "slug": "production"
+        },
+        "properties": {
+          "default_image_model": {
+            "description": "Default image model for this workspace",
+            "example": "openai/dall-e-3",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_provider_sort": {
+            "description": "Default provider sort preference (price, throughput, latency, exacto)",
+            "example": "price",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_text_model": {
+            "description": "Default text model for this workspace",
+            "example": "openai/gpt-4o",
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the workspace",
+            "example": "Production environment workspace",
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "is_data_discount_logging_enabled": {
+            "description": "Whether data discount logging is enabled",
+            "example": true,
+            "type": "boolean"
+          },
+          "is_observability_broadcast_enabled": {
+            "description": "Whether broadcast is enabled",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_observability_io_logging_enabled": {
+            "description": "Whether private logging is enabled",
+            "example": false,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Name for the new workspace",
+            "example": "Production",
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "slug": {
+            "description": "URL-friendly slug (lowercase alphanumeric and hyphens only)",
+            "example": "production",
+            "maxLength": 50,
+            "minLength": 1,
+            "pattern": "^[a-z0-9-]+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "slug"
+        ],
+        "type": "object"
+      },
+      "CreateWorkspaceResponse": {
+        "example": {
+          "data": {
+            "created_at": "2025-08-24T10:30:00Z",
+            "created_by": "user_abc123",
+            "default_image_model": "openai/dall-e-3",
+            "default_provider_sort": "price",
+            "default_text_model": "openai/gpt-4o",
+            "description": "Production environment workspace",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "is_data_discount_logging_enabled": true,
+            "is_observability_broadcast_enabled": false,
+            "is_observability_io_logging_enabled": false,
+            "name": "Production",
+            "slug": "production",
+            "updated_at": null
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Workspace"
+              },
+              {
+                "description": "The created workspace"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "CreatedEvent": {
         "description": "Event emitted when a response is created",
         "example": {
@@ -7343,6 +7540,23 @@
           "deleted": {
             "const": true,
             "description": "Confirmation that the guardrail was deleted",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "DeleteWorkspaceResponse": {
+        "example": {
+          "deleted": true
+        },
+        "properties": {
+          "deleted": {
+            "const": true,
+            "description": "Confirmation that the workspace was deleted",
             "example": true,
             "type": "boolean"
           }
@@ -8169,6 +8383,454 @@
         ],
         "type": "object"
       },
+      "GenerationContentData": {
+        "description": "Stored prompt and completion content",
+        "example": {
+          "input": {
+            "messages": [
+              {
+                "content": "What is the meaning of life?",
+                "role": "user"
+              }
+            ]
+          },
+          "output": {
+            "completion": "The meaning of life is a philosophical question...",
+            "reasoning": null
+          }
+        },
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "properties": {
+                  "prompt": {
+                    "example": "What is the meaning of life?",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "messages": {
+                    "example": [
+                      {
+                        "content": "What is the meaning of life?",
+                        "role": "user"
+                      }
+                    ],
+                    "items": {
+                      "nullable": true
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "messages"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "The input to the generation \u2014 either a prompt string or an array of messages"
+          },
+          "output": {
+            "description": "The output from the generation",
+            "properties": {
+              "completion": {
+                "description": "The completion output",
+                "example": "The meaning of life is a philosophical question...",
+                "nullable": true,
+                "type": "string"
+              },
+              "reasoning": {
+                "description": "Reasoning/thinking output, if any",
+                "example": null,
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "reasoning",
+              "completion"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "input",
+          "output"
+        ],
+        "type": "object"
+      },
+      "GenerationContentResponse": {
+        "description": "Stored prompt and completion content for a generation",
+        "example": {
+          "data": {
+            "input": {
+              "messages": [
+                {
+                  "content": "What is the meaning of life?",
+                  "role": "user"
+                }
+              ]
+            },
+            "output": {
+              "completion": "The meaning of life is a philosophical question...",
+              "reasoning": null
+            }
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/GenerationContentData"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GenerationResponse": {
+        "description": "Generation response",
+        "example": {
+          "data": {
+            "api_type": "completions",
+            "app_id": 12345,
+            "cache_discount": null,
+            "cancelled": false,
+            "created_at": "2024-07-15T23:33:19.433273+00:00",
+            "external_user": "user-123",
+            "finish_reason": "stop",
+            "generation_time": 1200,
+            "http_referer": "https://openrouter.ai/",
+            "id": "gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG",
+            "is_byok": false,
+            "latency": 1250,
+            "model": "sao10k/l3-stheno-8b",
+            "moderation_latency": 50,
+            "native_finish_reason": "stop",
+            "native_tokens_cached": 3,
+            "native_tokens_completion": 25,
+            "native_tokens_completion_images": 0,
+            "native_tokens_prompt": 10,
+            "native_tokens_reasoning": 5,
+            "num_input_audio_prompt": 0,
+            "num_media_completion": 0,
+            "num_media_prompt": 1,
+            "num_search_results": 5,
+            "origin": "https://openrouter.ai/",
+            "provider_name": "Infermatic",
+            "provider_responses": null,
+            "request_id": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
+            "router": "openrouter/auto",
+            "session_id": null,
+            "streamed": true,
+            "tokens_completion": 25,
+            "tokens_prompt": 10,
+            "total_cost": 0.0015,
+            "upstream_id": "chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946",
+            "upstream_inference_cost": 0.0012,
+            "usage": 0.0015,
+            "user_agent": "Mozilla/5.0"
+          }
+        },
+        "properties": {
+          "data": {
+            "description": "Generation data",
+            "properties": {
+              "api_type": {
+                "description": "Type of API used for the generation",
+                "enum": [
+                  "completions",
+                  "embeddings",
+                  "rerank",
+                  "tts",
+                  "video",
+                  null
+                ],
+                "nullable": true,
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              },
+              "app_id": {
+                "description": "ID of the app that made the request",
+                "example": 12345,
+                "nullable": true,
+                "type": "integer"
+              },
+              "cache_discount": {
+                "description": "Discount applied due to caching",
+                "example": 0.0002,
+                "format": "double",
+                "nullable": true,
+                "type": "number"
+              },
+              "cancelled": {
+                "description": "Whether the generation was cancelled",
+                "example": false,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "created_at": {
+                "description": "ISO 8601 timestamp of when the generation was created",
+                "example": "2024-07-15T23:33:19.433273+00:00",
+                "type": "string"
+              },
+              "external_user": {
+                "description": "External user identifier",
+                "example": "user-123",
+                "nullable": true,
+                "type": "string"
+              },
+              "finish_reason": {
+                "description": "Reason the generation finished",
+                "example": "stop",
+                "nullable": true,
+                "type": "string"
+              },
+              "generation_time": {
+                "description": "Time taken for generation in milliseconds",
+                "example": 1200,
+                "format": "double",
+                "nullable": true,
+                "type": "number"
+              },
+              "http_referer": {
+                "description": "Referer header from the request",
+                "nullable": true,
+                "type": "string"
+              },
+              "id": {
+                "description": "Unique identifier for the generation",
+                "example": "gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG",
+                "type": "string"
+              },
+              "is_byok": {
+                "description": "Whether this used bring-your-own-key",
+                "example": false,
+                "type": "boolean"
+              },
+              "latency": {
+                "description": "Total latency in milliseconds",
+                "example": 1250,
+                "format": "double",
+                "nullable": true,
+                "type": "number"
+              },
+              "model": {
+                "description": "Model used for the generation",
+                "example": "sao10k/l3-stheno-8b",
+                "type": "string"
+              },
+              "moderation_latency": {
+                "description": "Moderation latency in milliseconds",
+                "example": 50,
+                "format": "double",
+                "nullable": true,
+                "type": "number"
+              },
+              "native_finish_reason": {
+                "description": "Native finish reason as reported by provider",
+                "example": "stop",
+                "nullable": true,
+                "type": "string"
+              },
+              "native_tokens_cached": {
+                "description": "Native cached tokens as reported by provider",
+                "example": 3,
+                "nullable": true,
+                "type": "integer"
+              },
+              "native_tokens_completion": {
+                "description": "Native completion tokens as reported by provider",
+                "example": 25,
+                "nullable": true,
+                "type": "integer"
+              },
+              "native_tokens_completion_images": {
+                "description": "Native completion image tokens as reported by provider",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "native_tokens_prompt": {
+                "description": "Native prompt tokens as reported by provider",
+                "example": 10,
+                "nullable": true,
+                "type": "integer"
+              },
+              "native_tokens_reasoning": {
+                "description": "Native reasoning tokens as reported by provider",
+                "example": 5,
+                "nullable": true,
+                "type": "integer"
+              },
+              "num_input_audio_prompt": {
+                "description": "Number of audio inputs in the prompt",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "num_media_completion": {
+                "description": "Number of media items in the completion",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "num_media_prompt": {
+                "description": "Number of media items in the prompt",
+                "example": 1,
+                "nullable": true,
+                "type": "integer"
+              },
+              "num_search_results": {
+                "description": "Number of search results included",
+                "example": 5,
+                "nullable": true,
+                "type": "integer"
+              },
+              "origin": {
+                "description": "Origin URL of the request",
+                "example": "https://openrouter.ai/",
+                "type": "string"
+              },
+              "provider_name": {
+                "description": "Name of the provider that served the request",
+                "example": "Infermatic",
+                "nullable": true,
+                "type": "string"
+              },
+              "provider_responses": {
+                "description": "List of provider responses for this generation, including fallback attempts",
+                "items": {
+                  "$ref": "#/components/schemas/ProviderResponse"
+                },
+                "nullable": true,
+                "type": "array"
+              },
+              "request_id": {
+                "description": "Unique identifier grouping all generations from a single API request",
+                "example": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
+                "nullable": true,
+                "type": "string"
+              },
+              "router": {
+                "description": "Router used for the request (e.g., openrouter/auto)",
+                "example": "openrouter/auto",
+                "nullable": true,
+                "type": "string"
+              },
+              "session_id": {
+                "description": "Session identifier grouping multiple generations in the same session",
+                "nullable": true,
+                "type": "string"
+              },
+              "streamed": {
+                "description": "Whether the response was streamed",
+                "example": true,
+                "nullable": true,
+                "type": "boolean"
+              },
+              "tokens_completion": {
+                "description": "Number of tokens in the completion",
+                "example": 25,
+                "nullable": true,
+                "type": "integer"
+              },
+              "tokens_prompt": {
+                "description": "Number of tokens in the prompt",
+                "example": 10,
+                "nullable": true,
+                "type": "integer"
+              },
+              "total_cost": {
+                "description": "Total cost of the generation in USD",
+                "example": 0.0015,
+                "format": "double",
+                "type": "number"
+              },
+              "upstream_id": {
+                "description": "Upstream provider's identifier for this generation",
+                "example": "chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946",
+                "nullable": true,
+                "type": "string"
+              },
+              "upstream_inference_cost": {
+                "description": "Cost charged by the upstream provider",
+                "example": 0.0012,
+                "format": "double",
+                "nullable": true,
+                "type": "number"
+              },
+              "usage": {
+                "description": "Usage amount in USD",
+                "example": 0.0015,
+                "format": "double",
+                "type": "number"
+              },
+              "user_agent": {
+                "description": "User-Agent header from the request",
+                "nullable": true,
+                "type": "string"
+              },
+              "web_search_engine": {
+                "description": "The resolved web search engine used for this generation (e.g. exa, firecrawl, parallel)",
+                "example": "exa",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "upstream_id",
+              "total_cost",
+              "cache_discount",
+              "upstream_inference_cost",
+              "created_at",
+              "model",
+              "app_id",
+              "streamed",
+              "cancelled",
+              "provider_name",
+              "latency",
+              "moderation_latency",
+              "generation_time",
+              "finish_reason",
+              "tokens_prompt",
+              "tokens_completion",
+              "native_tokens_prompt",
+              "native_tokens_completion",
+              "native_tokens_completion_images",
+              "native_tokens_reasoning",
+              "native_tokens_cached",
+              "num_media_prompt",
+              "num_input_audio_prompt",
+              "num_media_completion",
+              "num_search_results",
+              "web_search_engine",
+              "origin",
+              "usage",
+              "is_byok",
+              "native_finish_reason",
+              "external_user",
+              "api_type",
+              "router",
+              "provider_responses",
+              "user_agent",
+              "http_referer"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "GetGuardrailResponse": {
         "example": {
           "data": {
@@ -8199,6 +8861,41 @@
               },
               {
                 "description": "The guardrail"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetWorkspaceResponse": {
+        "example": {
+          "data": {
+            "created_at": "2025-08-24T10:30:00Z",
+            "created_by": "user_abc123",
+            "default_image_model": "openai/dall-e-3",
+            "default_provider_sort": "price",
+            "default_text_model": "openai/gpt-4o",
+            "description": "Production environment workspace",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "is_data_discount_logging_enabled": true,
+            "is_observability_broadcast_enabled": false,
+            "is_observability_io_logging_enabled": false,
+            "name": "Production",
+            "slug": "production",
+            "updated_at": "2025-08-24T15:45:00Z"
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Workspace"
+              },
+              {
+                "description": "The workspace"
               }
             ]
           }
@@ -9650,6 +10347,47 @@
         ],
         "type": "object"
       },
+      "ListWorkspacesResponse": {
+        "example": {
+          "data": [
+            {
+              "created_at": "2025-08-24T10:30:00Z",
+              "created_by": "user_abc123",
+              "default_image_model": "openai/dall-e-3",
+              "default_provider_sort": "price",
+              "default_text_model": "openai/gpt-4o",
+              "description": "Production environment workspace",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "is_data_discount_logging_enabled": true,
+              "is_observability_broadcast_enabled": false,
+              "is_observability_io_logging_enabled": false,
+              "name": "Production",
+              "slug": "production",
+              "updated_at": "2025-08-24T15:45:00Z"
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "description": "List of workspaces",
+            "items": {
+              "$ref": "#/components/schemas/Workspace"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "Total number of workspaces",
+            "example": 5,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
       "McpServerTool": {
         "description": "MCP (Model Context Protocol) tool configuration",
         "example": {
@@ -10889,6 +11627,7 @@
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
                   "moderation": "#/components/schemas/ModerationPlugin",
+                  "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
                   "web": "#/components/schemas/WebSearchPlugin"
                 },
@@ -10912,6 +11651,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ContextCompressionPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ParetoRouterPlugin"
                 }
               ]
             },
@@ -14351,8 +15093,7 @@
           "audio",
           "video",
           "rerank",
-          "tts",
-          "stt"
+          "tts"
         ],
         "example": "text",
         "type": "string",
@@ -14669,6 +15410,37 @@
         "example": "temperature",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "ParetoRouterPlugin": {
+        "example": {
+          "enabled": true,
+          "id": "pareto-router",
+          "min_coding_score": 0.8
+        },
+        "properties": {
+          "enabled": {
+            "description": "Set to false to disable the pareto-router plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "id": {
+            "enum": [
+              "pareto-router"
+            ],
+            "type": "string"
+          },
+          "min_coding_score": {
+            "description": "Minimum desired coding score between 0 and 1, where 1 is best. Higher values select from stronger coding models (sourced from Artificial Analysis coding percentiles). Maps internally to one of three tiers (low, medium, high). Omit to use the router default tier.",
+            "example": 0.8,
+            "format": "double",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
       },
       "PayloadTooLargeResponse": {
         "description": "Payload Too Large - Request payload exceeds size limits",
@@ -16795,6 +17567,7 @@
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
                   "moderation": "#/components/schemas/ModerationPlugin",
+                  "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
                   "web": "#/components/schemas/WebSearchPlugin"
                 },
@@ -16818,6 +17591,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ContextCompressionPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/ParetoRouterPlugin"
                 }
               ]
             },
@@ -17126,6 +17902,710 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechRequest": {
+        "description": "Text-to-speech request input",
+        "example": {
+          "input": "Hello world",
+          "model": "elevenlabs/eleven-turbo-v2",
+          "response_format": "pcm",
+          "speed": 1,
+          "voice": "alloy"
+        },
+        "properties": {
+          "input": {
+            "description": "Text to synthesize",
+            "example": "Hello world",
+            "type": "string"
+          },
+          "model": {
+            "description": "TTS model identifier",
+            "example": "elevenlabs/eleven-turbo-v2",
+            "type": "string"
+          },
+          "provider": {
+            "description": "Provider-specific passthrough configuration",
+            "properties": {
+              "options": {
+                "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
+                "properties": {
+                  "01ai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ai21": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "aion-labs": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "akashml": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "alibaba": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "amazon-bedrock": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "amazon-nova": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ambient": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "anthropic": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "anyscale": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "arcee-ai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "atlas-cloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "atoma": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "avian": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "azure": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "baidu": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "baseten": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "black-forest-labs": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "byteplus": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "centml": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cerebras": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "chutes": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cirrascale": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "clarifai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cloudflare": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "cohere": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "crofai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "crusoe": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "deepinfra": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "deepseek": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "dekallm": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "enfer": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "fake-provider": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "featherless": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "fireworks": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "friendli": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "gmicloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "google-ai-studio": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "google-vertex": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "gopomelo": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "groq": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "huggingface": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "hyperbolic": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "hyperbolic-quantized": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inception": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inceptron": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inference-net": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "infermatic": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inflection": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "inocloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "io-net": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ionstream": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "klusterai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lambda": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lepton": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "liquid": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lynn": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "lynn-private": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mancer": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mancer-old": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mara": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "meta": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "minimax": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "mistral": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "modal": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "modelrun": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "modular": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "moonshotai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "morph": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ncompass": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nebius": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nextbit": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nineteen": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "novita": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nvidia": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "octoai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "open-inference": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "openai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "parasail": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "perplexity": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "phala": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "recraft": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "recursal": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "reflection": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "reka": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "relace": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "replicate": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sambanova": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sambanova-cloaked": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "seed": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sf-compute": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "siliconflow": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "sourceful": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "stealth": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "stepfun": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "streamlake": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "switchpoint": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "targon": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "together": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "together-lite": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "ubicloud": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "upstage": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "venice": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "wandb": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "xai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "xiaomi": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "z-ai": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "response_format": {
+            "default": "pcm",
+            "description": "Audio output format",
+            "enum": [
+              "mp3",
+              "pcm"
+            ],
+            "example": "pcm",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "speed": {
+            "description": "Playback speed multiplier. Only used by models that support it (e.g. OpenAI TTS). Ignored by other providers.",
+            "example": 1,
+            "format": "double",
+            "type": "number"
+          },
+          "voice": {
+            "description": "Voice identifier (provider-specific).",
+            "example": "alloy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "input",
+          "voice"
         ],
         "type": "object"
       },
@@ -18097,6 +19577,105 @@
               },
               {
                 "description": "The updated guardrail"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "UpdateWorkspaceRequest": {
+        "example": {
+          "name": "Updated Workspace",
+          "slug": "updated-workspace"
+        },
+        "properties": {
+          "default_image_model": {
+            "description": "Default image model for this workspace",
+            "example": "openai/dall-e-3",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_provider_sort": {
+            "description": "Default provider sort preference (price, throughput, latency, exacto)",
+            "example": "price",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_text_model": {
+            "description": "Default text model for this workspace",
+            "example": "openai/gpt-4o",
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "description": "New description for the workspace",
+            "example": "Updated description",
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "is_data_discount_logging_enabled": {
+            "description": "Whether data discount logging is enabled",
+            "example": true,
+            "type": "boolean"
+          },
+          "is_observability_broadcast_enabled": {
+            "description": "Whether broadcast is enabled",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_observability_io_logging_enabled": {
+            "description": "Whether private logging is enabled",
+            "example": false,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "New name for the workspace",
+            "example": "Updated Workspace",
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "slug": {
+            "description": "New URL-friendly slug",
+            "example": "updated-workspace",
+            "maxLength": 50,
+            "minLength": 1,
+            "pattern": "^[a-z0-9-]+$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateWorkspaceResponse": {
+        "example": {
+          "data": {
+            "created_at": "2025-08-24T10:30:00Z",
+            "created_by": "user_abc123",
+            "default_image_model": "openai/dall-e-3",
+            "default_provider_sort": "price",
+            "default_text_model": "openai/gpt-4o",
+            "description": "Production environment workspace",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "is_data_discount_logging_enabled": true,
+            "is_observability_broadcast_enabled": false,
+            "is_observability_io_logging_enabled": false,
+            "name": "Updated Workspace",
+            "slug": "updated-workspace",
+            "updated_at": "2025-08-25T10:00:00Z"
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Workspace"
+              },
+              {
+                "description": "The updated workspace"
               }
             ]
           }
@@ -19610,6 +21189,164 @@
           }
         },
         "type": "object"
+      },
+      "Workspace": {
+        "example": {
+          "created_at": "2025-08-24T10:30:00Z",
+          "created_by": "user_abc123",
+          "default_image_model": "openai/dall-e-3",
+          "default_provider_sort": "price",
+          "default_text_model": "openai/gpt-4o",
+          "description": "Production environment workspace",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "is_data_discount_logging_enabled": true,
+          "is_observability_broadcast_enabled": false,
+          "is_observability_io_logging_enabled": false,
+          "name": "Production",
+          "slug": "production",
+          "updated_at": "2025-08-24T15:45:00Z"
+        },
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 timestamp of when the workspace was created",
+            "example": "2025-08-24T10:30:00Z",
+            "type": "string"
+          },
+          "created_by": {
+            "description": "User ID of the workspace creator",
+            "example": "user_abc123",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_image_model": {
+            "description": "Default image model for this workspace",
+            "example": "openai/dall-e-3",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_provider_sort": {
+            "description": "Default provider sort preference (price, throughput, latency, exacto)",
+            "example": "price",
+            "nullable": true,
+            "type": "string"
+          },
+          "default_text_model": {
+            "description": "Default text model for this workspace",
+            "example": "openai/gpt-4o",
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the workspace",
+            "example": "Production environment workspace",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the workspace",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "is_data_discount_logging_enabled": {
+            "description": "Whether data discount logging is enabled for this workspace",
+            "example": true,
+            "type": "boolean"
+          },
+          "is_observability_broadcast_enabled": {
+            "description": "Whether broadcast is enabled for this workspace",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_observability_io_logging_enabled": {
+            "description": "Whether private logging is enabled for this workspace",
+            "example": false,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Name of the workspace",
+            "example": "Production",
+            "type": "string"
+          },
+          "slug": {
+            "description": "URL-friendly slug for the workspace",
+            "example": "production",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 timestamp of when the workspace was last updated",
+            "example": "2025-08-24T15:45:00Z",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "description",
+          "default_text_model",
+          "default_image_model",
+          "default_provider_sort",
+          "is_observability_io_logging_enabled",
+          "is_observability_broadcast_enabled",
+          "is_data_discount_logging_enabled",
+          "created_at",
+          "updated_at",
+          "created_by"
+        ],
+        "type": "object"
+      },
+      "WorkspaceMember": {
+        "example": {
+          "created_at": "2025-08-24T10:30:00Z",
+          "id": "660e8400-e29b-41d4-a716-446655440000",
+          "role": "member",
+          "user_id": "user_abc123",
+          "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+        },
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 timestamp of when the membership was created",
+            "example": "2025-08-24T10:30:00Z",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the workspace membership",
+            "example": "660e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "role": {
+            "description": "Role of the member in the workspace",
+            "enum": [
+              "admin",
+              "member"
+            ],
+            "example": "member",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "user_id": {
+            "description": "Clerk user ID of the member",
+            "example": "user_abc123",
+            "type": "string"
+          },
+          "workspace_id": {
+            "description": "ID of the workspace",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "user_id",
+          "role",
+          "created_at"
+        ],
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -19793,31 +21530,212 @@
         "tags": [
           "Analytics"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
+      }
+    },
+    "/audio/speech": {
+      "post": {
+        "description": "Synthesizes audio from the input text",
+        "operationId": "createAudioSpeech",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "input": "Hello world",
+                "model": "elevenlabs/eleven-turbo-v2",
+                "response_format": "pcm",
+                "speed": 1,
+                "voice": "alloy"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SpeechRequest"
+              }
+            }
+          },
+          "required": true
         },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
+        "responses": {
+          "200": {
+            "content": {
+              "audio/*": {
+                "schema": {
+                  "description": "Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/L16 for pcm).",
+                  "example": "<binary audio data>",
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Audio bytes stream"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
         },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+        "summary": "Create speech",
+        "tags": [
+          "TTS"
+        ],
+        "x-speakeasy-name-override": "createSpeech"
+      }
     },
     "/auth/keys": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -19960,17 +21878,6 @@
       }
     },
     "/auth/keys/code": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -20200,17 +22107,6 @@
       }
     },
     "/chat/completions": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
@@ -20633,31 +22529,9 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/credits/coinbase": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -20694,17 +22568,6 @@
       }
     },
     "/embeddings": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -21306,18 +23169,7 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/endpoints/zdr": {
       "get": {
@@ -21452,18 +23304,7 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/generation": {
       "get": {
@@ -21488,15 +23329,15 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "api_type": null,
+                    "api_type": "completions",
                     "app_id": 12345,
-                    "cache_discount": 0.0002,
+                    "cache_discount": null,
                     "cancelled": false,
                     "created_at": "2024-07-15T23:33:19.433273+00:00",
                     "external_user": "user-123",
                     "finish_reason": "stop",
                     "generation_time": 1200,
-                    "http_referer": null,
+                    "http_referer": "https://openrouter.ai/",
                     "id": "gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG",
                     "is_byok": false,
                     "latency": 1250,
@@ -21516,7 +23357,8 @@
                     "provider_name": "Infermatic",
                     "provider_responses": null,
                     "request_id": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
-                    "router": null,
+                    "router": "openrouter/auto",
+                    "session_id": null,
                     "streamed": true,
                     "tokens_completion": 25,
                     "tokens_prompt": 10,
@@ -21524,304 +23366,11 @@
                     "upstream_id": "chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946",
                     "upstream_inference_cost": 0.0012,
                     "usage": 0.0015,
-                    "user_agent": null
+                    "user_agent": "Mozilla/5.0"
                   }
                 },
                 "schema": {
-                  "description": "Generation response",
-                  "properties": {
-                    "data": {
-                      "description": "Generation data",
-                      "properties": {
-                        "api_type": {
-                          "description": "Type of API used for the generation",
-                          "enum": [
-                            "completions",
-                            "embeddings",
-                            "rerank",
-                            "tts",
-                            "stt",
-                            "video",
-                            null
-                          ],
-                          "nullable": true,
-                          "type": "string",
-                          "x-speakeasy-unknown-values": "allow"
-                        },
-                        "app_id": {
-                          "description": "ID of the app that made the request",
-                          "example": 12345,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "cache_discount": {
-                          "description": "Discount applied due to caching",
-                          "example": 0.0002,
-                          "format": "double",
-                          "nullable": true,
-                          "type": "number"
-                        },
-                        "cancelled": {
-                          "description": "Whether the generation was cancelled",
-                          "example": false,
-                          "nullable": true,
-                          "type": "boolean"
-                        },
-                        "created_at": {
-                          "description": "ISO 8601 timestamp of when the generation was created",
-                          "example": "2024-07-15T23:33:19.433273+00:00",
-                          "type": "string"
-                        },
-                        "external_user": {
-                          "description": "External user identifier",
-                          "example": "user-123",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "finish_reason": {
-                          "description": "Reason the generation finished",
-                          "example": "stop",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "generation_time": {
-                          "description": "Time taken for generation in milliseconds",
-                          "example": 1200,
-                          "format": "double",
-                          "nullable": true,
-                          "type": "number"
-                        },
-                        "http_referer": {
-                          "description": "Referer header from the request",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "id": {
-                          "description": "Unique identifier for the generation",
-                          "example": "gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG",
-                          "type": "string"
-                        },
-                        "is_byok": {
-                          "description": "Whether this used bring-your-own-key",
-                          "example": false,
-                          "type": "boolean"
-                        },
-                        "latency": {
-                          "description": "Total latency in milliseconds",
-                          "example": 1250,
-                          "format": "double",
-                          "nullable": true,
-                          "type": "number"
-                        },
-                        "model": {
-                          "description": "Model used for the generation",
-                          "example": "sao10k/l3-stheno-8b",
-                          "type": "string"
-                        },
-                        "moderation_latency": {
-                          "description": "Moderation latency in milliseconds",
-                          "example": 50,
-                          "format": "double",
-                          "nullable": true,
-                          "type": "number"
-                        },
-                        "native_finish_reason": {
-                          "description": "Native finish reason as reported by provider",
-                          "example": "stop",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "native_tokens_cached": {
-                          "description": "Native cached tokens as reported by provider",
-                          "example": 3,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "native_tokens_completion": {
-                          "description": "Native completion tokens as reported by provider",
-                          "example": 25,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "native_tokens_completion_images": {
-                          "description": "Native completion image tokens as reported by provider",
-                          "example": 0,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "native_tokens_prompt": {
-                          "description": "Native prompt tokens as reported by provider",
-                          "example": 10,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "native_tokens_reasoning": {
-                          "description": "Native reasoning tokens as reported by provider",
-                          "example": 5,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "num_input_audio_prompt": {
-                          "description": "Number of audio inputs in the prompt",
-                          "example": 0,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "num_media_completion": {
-                          "description": "Number of media items in the completion",
-                          "example": 0,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "num_media_prompt": {
-                          "description": "Number of media items in the prompt",
-                          "example": 1,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "num_search_results": {
-                          "description": "Number of search results included",
-                          "example": 5,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "origin": {
-                          "description": "Origin URL of the request",
-                          "example": "https://openrouter.ai/",
-                          "type": "string"
-                        },
-                        "provider_name": {
-                          "description": "Name of the provider that served the request",
-                          "example": "Infermatic",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "provider_responses": {
-                          "description": "List of provider responses for this generation, including fallback attempts",
-                          "items": {
-                            "$ref": "#/components/schemas/ProviderResponse"
-                          },
-                          "nullable": true,
-                          "type": "array"
-                        },
-                        "request_id": {
-                          "description": "Unique identifier grouping all generations from a single API request",
-                          "example": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "router": {
-                          "description": "Router used for the request (e.g., openrouter/auto)",
-                          "example": "openrouter/auto",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "session_id": {
-                          "description": "Session identifier grouping multiple generations in the same session",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "streamed": {
-                          "description": "Whether the response was streamed",
-                          "example": true,
-                          "nullable": true,
-                          "type": "boolean"
-                        },
-                        "tokens_completion": {
-                          "description": "Number of tokens in the completion",
-                          "example": 25,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "tokens_prompt": {
-                          "description": "Number of tokens in the prompt",
-                          "example": 10,
-                          "nullable": true,
-                          "type": "integer"
-                        },
-                        "total_cost": {
-                          "description": "Total cost of the generation in USD",
-                          "example": 0.0015,
-                          "format": "double",
-                          "type": "number"
-                        },
-                        "upstream_id": {
-                          "description": "Upstream provider's identifier for this generation",
-                          "example": "chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "upstream_inference_cost": {
-                          "description": "Cost charged by the upstream provider",
-                          "example": 0.0012,
-                          "format": "double",
-                          "nullable": true,
-                          "type": "number"
-                        },
-                        "usage": {
-                          "description": "Usage amount in USD",
-                          "example": 0.0015,
-                          "format": "double",
-                          "type": "number"
-                        },
-                        "user_agent": {
-                          "description": "User-Agent header from the request",
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "web_search_engine": {
-                          "description": "The resolved web search engine used for this generation (e.g. exa, firecrawl, parallel)",
-                          "example": "exa",
-                          "nullable": true,
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "upstream_id",
-                        "total_cost",
-                        "cache_discount",
-                        "upstream_inference_cost",
-                        "created_at",
-                        "model",
-                        "app_id",
-                        "streamed",
-                        "cancelled",
-                        "provider_name",
-                        "latency",
-                        "moderation_latency",
-                        "generation_time",
-                        "finish_reason",
-                        "tokens_prompt",
-                        "tokens_completion",
-                        "native_tokens_prompt",
-                        "native_tokens_completion",
-                        "native_tokens_completion_images",
-                        "native_tokens_reasoning",
-                        "native_tokens_cached",
-                        "num_media_prompt",
-                        "num_input_audio_prompt",
-                        "num_media_completion",
-                        "num_search_results",
-                        "web_search_engine",
-                        "origin",
-                        "usage",
-                        "is_byok",
-                        "native_finish_reason",
-                        "external_user",
-                        "api_type",
-                        "router",
-                        "provider_responses",
-                        "user_agent",
-                        "http_referer"
-                      ],
-                      "type": "object"
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/GenerationResponse"
                 }
               }
             },
@@ -21960,18 +23509,186 @@
         "tags": [
           "Generations"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
+      }
+    },
+    "/generation/content": {
+      "get": {
+        "operationId": "listGenerationContent",
+        "parameters": [
+          {
+            "description": "The generation ID",
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The generation ID",
+              "example": "gen-1234567890",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "input": {
+                      "messages": [
+                        {
+                          "content": "What is the meaning of life?",
+                          "role": "user"
+                        }
+                      ]
+                    },
+                    "output": {
+                      "completion": "The meaning of life is a philosophical question...",
+                      "reasoning": null
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GenerationContentResponse"
+                }
+              }
+            },
+            "description": "Returns the stored prompt and completion content"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
         },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+        "summary": "Get stored prompt and completion content for a generation",
+        "tags": [
+          "Generations"
+        ]
+      }
     },
     "/guardrails": {
       "get": {
@@ -22109,17 +23826,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -22365,18 +24071,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -22490,18 +24185,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails/{id}": {
       "delete": {
@@ -22694,17 +24378,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
@@ -22982,17 +24655,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
@@ -23112,17 +24774,6 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -23382,17 +25033,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -23513,17 +25153,6 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -23945,18 +25574,7 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/keys": {
       "get": {
@@ -24302,17 +25920,6 @@
         ],
         "x-speakeasy-name-override": "list"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
@@ -25173,17 +26780,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -25589,17 +27185,6 @@
       }
     },
     "/messages": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
@@ -25974,18 +27559,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/count": {
       "get": {
@@ -26057,18 +27631,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/user": {
       "get": {
@@ -26190,18 +27753,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -26367,18 +27919,7 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/organization/members": {
       "get": {
@@ -26566,18 +28107,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/providers": {
       "get": {
@@ -27228,31 +28758,9 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/rerank": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -27629,17 +29137,6 @@
       }
     },
     "/responses": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
@@ -27929,926 +29426,7 @@
         "x-speakeasy-stream-request-field": "stream"
       }
     },
-    "/tts": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
-      "post": {
-        "description": "Synthesizes audio from the input text",
-        "operationId": "createTts",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Text-to-speech request input",
-                "example": {
-                  "input": "Hello world",
-                  "model": "elevenlabs/eleven-turbo-v2",
-                  "response_format": "pcm",
-                  "speed": 1,
-                  "voice": "alloy"
-                },
-                "properties": {
-                  "input": {
-                    "description": "Text to synthesize",
-                    "example": "Hello world",
-                    "type": "string"
-                  },
-                  "model": {
-                    "description": "TTS model identifier",
-                    "example": "elevenlabs/eleven-turbo-v2",
-                    "type": "string"
-                  },
-                  "provider": {
-                    "description": "Provider-specific passthrough configuration",
-                    "properties": {
-                      "options": {
-                        "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
-                        "properties": {
-                          "01ai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "ai21": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "aion-labs": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "akashml": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "alibaba": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "amazon-bedrock": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "amazon-nova": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "ambient": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "anthropic": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "anyscale": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "arcee-ai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "atlas-cloud": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "atoma": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "avian": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "azure": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "baidu": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "baseten": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "black-forest-labs": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "byteplus": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "centml": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "cerebras": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "chutes": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "cirrascale": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "clarifai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "cloudflare": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "cohere": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "crofai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "crusoe": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "deepinfra": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "deepseek": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "dekallm": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "enfer": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "fake-provider": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "featherless": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "fireworks": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "friendli": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "gmicloud": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "google-ai-studio": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "google-vertex": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "gopomelo": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "groq": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "huggingface": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "hyperbolic": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "hyperbolic-quantized": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "inception": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "inceptron": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "inference-net": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "infermatic": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "inflection": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "inocloud": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "io-net": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "ionstream": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "klusterai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "lambda": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "lepton": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "liquid": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "lynn": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "lynn-private": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "mancer": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "mancer-old": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "mara": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "meta": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "minimax": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "mistral": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "modal": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "modelrun": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "modular": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "moonshotai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "morph": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "ncompass": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "nebius": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "nextbit": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "nineteen": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "novita": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "nvidia": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "octoai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "open-inference": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "openai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "parasail": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "perplexity": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "phala": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "recraft": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "recursal": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "reflection": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "reka": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "relace": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "replicate": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "sambanova": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "sambanova-cloaked": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "seed": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "sf-compute": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "siliconflow": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "sourceful": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "stealth": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "stepfun": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "streamlake": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "switchpoint": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "targon": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "together": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "together-lite": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "ubicloud": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "upstage": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "venice": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "wandb": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "xai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "xiaomi": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          },
-                          "z-ai": {
-                            "additionalProperties": {
-                              "nullable": true
-                            },
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "response_format": {
-                    "default": "pcm",
-                    "description": "Audio output format",
-                    "enum": [
-                      "mp3",
-                      "pcm"
-                    ],
-                    "example": "pcm",
-                    "type": "string",
-                    "x-speakeasy-unknown-values": "allow"
-                  },
-                  "speed": {
-                    "description": "Playback speed multiplier. Only used by models that support it (e.g. OpenAI TTS). Ignored by other providers.",
-                    "example": 1,
-                    "format": "double",
-                    "type": "number"
-                  },
-                  "voice": {
-                    "description": "Voice identifier",
-                    "example": "alloy",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "model",
-                  "input",
-                  "voice"
-                ],
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "description": "Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/L16 for pcm).",
-                  "example": "<binary audio data>",
-                  "format": "binary",
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Audio bytes stream"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 400,
-                    "message": "Invalid request parameters"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestResponse"
-                }
-              }
-            },
-            "description": "Bad Request - Invalid request parameters or malformed input"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 401,
-                    "message": "Missing Authentication header"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedResponse"
-                }
-              }
-            },
-            "description": "Unauthorized - Authentication required or invalid credentials"
-          },
-          "402": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 402,
-                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentRequiredResponse"
-                }
-              }
-            },
-            "description": "Payment Required - Insufficient credits or quota to complete request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 404,
-                    "message": "Resource not found"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResponse"
-                }
-              }
-            },
-            "description": "Not Found - Resource does not exist"
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 429,
-                    "message": "Rate limit exceeded"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/TooManyRequestsResponse"
-                }
-              }
-            },
-            "description": "Too Many Requests - Rate limit exceeded"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 500,
-                    "message": "Internal Server Error"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error - Unexpected server error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 502,
-                    "message": "Provider returned error"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/BadGatewayResponse"
-                }
-              }
-            },
-            "description": "Bad Gateway - Provider/upstream API failure"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 503,
-                    "message": "Service temporarily unavailable"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable - Service temporarily unavailable"
-          },
-          "524": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 524,
-                    "message": "Request timed out. Please try again later."
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
-                }
-              }
-            },
-            "description": "Infrastructure Timeout - Provider request timed out at edge network"
-          },
-          "529": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 529,
-                    "message": "Provider returned error"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
-                }
-              }
-            },
-            "description": "Provider Overloaded - Provider is temporarily overloaded"
-          }
-        },
-        "summary": "Create speech",
-        "tags": [
-          "TTS"
-        ],
-        "x-speakeasy-name-override": "createSpeech"
-      }
-    },
     "/videos": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -29074,18 +29652,7 @@
         "tags": [
           "Video Generation"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/videos/{jobId}": {
       "get": {
@@ -29180,18 +29747,7 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -29320,18 +29876,895 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
+      }
+    },
+    "/workspaces": {
+      "get": {
+        "description": "List all workspaces for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listWorkspaces",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "created_by": "user_abc123",
+                      "default_image_model": "openai/dall-e-3",
+                      "default_provider_sort": "price",
+                      "default_text_model": "openai/gpt-4o",
+                      "description": "Production environment workspace",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "is_data_discount_logging_enabled": true,
+                      "is_observability_broadcast_enabled": false,
+                      "is_observability_io_logging_enabled": false,
+                      "name": "Production",
+                      "slug": "production",
+                      "updated_at": "2025-08-24T15:45:00Z"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkspacesResponse"
+                }
+              }
+            },
+            "description": "List of workspaces"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
         },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
+        "summary": "List workspaces",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "list",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
         }
-      ]
+      },
+      "post": {
+        "description": "Create a new workspace for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "createWorkspace",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "default_image_model": "openai/dall-e-3",
+                "default_provider_sort": "price",
+                "default_text_model": "openai/gpt-4o",
+                "description": "Production environment workspace",
+                "name": "Production",
+                "slug": "production"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "created_by": "user_abc123",
+                    "default_image_model": "openai/dall-e-3",
+                    "default_provider_sort": "price",
+                    "default_text_model": "openai/gpt-4o",
+                    "description": "Production environment workspace",
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "is_data_discount_logging_enabled": true,
+                    "is_observability_broadcast_enabled": false,
+                    "is_observability_io_logging_enabled": false,
+                    "name": "Production",
+                    "slug": "production",
+                    "updated_at": null
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreateWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Workspace created successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Create a workspace",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/workspaces/{id}": {
+      "delete": {
+        "description": "Delete an existing workspace. The default workspace cannot be deleted. Workspaces with active API keys cannot be deleted. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "deleteWorkspace",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "deleted": true
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Workspace deleted successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Delete a workspace",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "description": "Get a single workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getWorkspace",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "created_by": "user_abc123",
+                    "default_image_model": "openai/dall-e-3",
+                    "default_provider_sort": "price",
+                    "default_text_model": "openai/gpt-4o",
+                    "description": "Production environment workspace",
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "is_data_discount_logging_enabled": true,
+                    "is_observability_broadcast_enabled": false,
+                    "is_observability_io_logging_enabled": false,
+                    "name": "Production",
+                    "slug": "production",
+                    "updated_at": "2025-08-24T15:45:00Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GetWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Workspace details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get a workspace",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "get"
+      },
+      "patch": {
+        "description": "Update an existing workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "updateWorkspace",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "name": "Updated Workspace",
+                "slug": "updated-workspace"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "created_by": "user_abc123",
+                    "default_image_model": "openai/dall-e-3",
+                    "default_provider_sort": "price",
+                    "default_text_model": "openai/gpt-4o",
+                    "description": "Production environment workspace",
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "is_data_discount_logging_enabled": true,
+                    "is_observability_broadcast_enabled": false,
+                    "is_observability_io_logging_enabled": false,
+                    "name": "Updated Workspace",
+                    "slug": "updated-workspace",
+                    "updated_at": "2025-08-25T10:00:00Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateWorkspaceResponse"
+                }
+              }
+            },
+            "description": "Workspace updated successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Update a workspace",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "update"
+      }
+    },
+    "/workspaces/{id}/members/add": {
+      "post": {
+        "description": "Add multiple organization members to a workspace. Members are assigned the same role they hold in the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "bulkAddWorkspaceMembers",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "user_ids": [
+                  "user_abc123",
+                  "user_def456"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BulkAddWorkspaceMembersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "added_count": 1,
+                  "data": [
+                    {
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "id": "660e8400-e29b-41d4-a716-446655440000",
+                      "role": "member",
+                      "user_id": "user_abc123",
+                      "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BulkAddWorkspaceMembersResponse"
+                }
+              }
+            },
+            "description": "Members added successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Bulk add members to a workspace",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "bulkAddMembers"
+      }
+    },
+    "/workspaces/{id}/members/remove": {
+      "post": {
+        "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "bulkRemoveWorkspaceMembers",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "user_ids": [
+                  "user_abc123",
+                  "user_def456"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BulkRemoveWorkspaceMembersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "removed_count": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BulkRemoveWorkspaceMembersResponse"
+                }
+              }
+            },
+            "description": "Members removed successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Bulk remove members from a workspace",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "bulkRemoveMembers"
+      }
     }
   },
   "security": [
@@ -29410,6 +30843,10 @@
     {
       "description": "Video Generation endpoints",
       "name": "Video Generation"
+    },
+    {
+      "description": "Workspaces endpoints",
+      "name": "Workspaces"
     },
     {
       "description": "beta.responses endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-20T11:11:19+00:00",
+  "captured_at": "2026-04-21T09:58:19+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,11 +14,11 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 43,
+  "operation_count": 51,
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "fc9cb5e5f6b4e39c",
+      "fingerprint": "62d6681f3fc2fe20",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0ff2409f46ebd93d",
+      "fingerprint": "2a479c2a2828c351",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -40,7 +40,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d143da7f6f9162c0",
+      "fingerprint": "01579a8548d64ab2",
+      "id": "DELETE /workspaces/{id}",
+      "method": "DELETE",
+      "operation_id": "deleteWorkspace",
+      "path": "/workspaces/{id}",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "a8e8f18928c3c86a",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -51,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e87fbb5bb40b4c60",
+      "fingerprint": "05cecac9b09a5e7c",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -62,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "15817abb5bf5be68",
+      "fingerprint": "af82a2b2f1a4be20",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -73,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d94195530e0414a4",
+      "fingerprint": "95f59af93f2a1940",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -84,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "327eccd5c4919e97",
+      "fingerprint": "f408120d9958824f",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -95,7 +106,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3d3e8c9561d450c5",
+      "fingerprint": "9fbe3d8789b59348",
+      "id": "GET /generation/content",
+      "method": "GET",
+      "operation_id": "listGenerationContent",
+      "path": "/generation/content",
+      "tags": [
+        "Generations"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "fb76f9599911ccb5",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -106,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b43f6f0d1e70ec62",
+      "fingerprint": "50df372af92b0439",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -117,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "93d944d97fca595b",
+      "fingerprint": "48ed8bcc9c811a11",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -128,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6a953189b58fc510",
+      "fingerprint": "aa3c9f9c9d5fe9ae",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -139,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "34604a16fa41fb79",
+      "fingerprint": "bdcc5f13eb39b87d",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -150,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6a182854d359c7c1",
+      "fingerprint": "622584d38112ff60",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -161,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6a1d8e77363531a7",
+      "fingerprint": "c73983473e1c0e0e",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -172,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "73fe6021d5d3877d",
+      "fingerprint": "bd94c1cb6e19cdd2",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -183,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb6bbfd93f43f252",
+      "fingerprint": "7d938af215f4d03a",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -194,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b65369929e313e21",
+      "fingerprint": "4ca86a27618bbd42",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -205,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "39d755b55859e6de",
+      "fingerprint": "360a71c424058693",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -216,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2bc0a0465a8d5edb",
+      "fingerprint": "1409a555c838345f",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -227,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "87017a6a418ccc83",
+      "fingerprint": "5fc00b6e69ff4f1f",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -238,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7687a0f00ba6d1b1",
+      "fingerprint": "afba5151a3299caf",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -249,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "db6ea0df829856f4",
+      "fingerprint": "6d3ec9bee71dc2ce",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -260,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "db1c62dade2d8f06",
+      "fingerprint": "14596fe6b03e4428",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -271,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "45699b9654b6db62",
+      "fingerprint": "0c91e369c0a0d9e1",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -282,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "81bf8fc0183755b8",
+      "fingerprint": "f762b88d789b2723",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -293,7 +315,29 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4c0058a2655e0d29",
+      "fingerprint": "884dec04861b659d",
+      "id": "GET /workspaces",
+      "method": "GET",
+      "operation_id": "listWorkspaces",
+      "path": "/workspaces",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "5e33269f90dfab34",
+      "id": "GET /workspaces/{id}",
+      "method": "GET",
+      "operation_id": "getWorkspace",
+      "path": "/workspaces/{id}",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "17f6c0ff95ea6247",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -304,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4ccab78044c4a13d",
+      "fingerprint": "e96abe881cfbc08b",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -315,7 +359,29 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d5a58f4512027317",
+      "fingerprint": "ac1cb8e84c7edadf",
+      "id": "PATCH /workspaces/{id}",
+      "method": "PATCH",
+      "operation_id": "updateWorkspace",
+      "path": "/workspaces/{id}",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "3263093f7a682e54",
+      "id": "POST /audio/speech",
+      "method": "POST",
+      "operation_id": "createAudioSpeech",
+      "path": "/audio/speech",
+      "tags": [
+        "TTS"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "350024ac1009cddb",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -326,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0781a831d48dec54",
+      "fingerprint": "ce53dfc76885c522",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -337,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ca135372f38e8101",
+      "fingerprint": "12af9351d354782d",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -348,7 +414,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "4d49cd207179e897",
+      "fingerprint": "3aae29d559805e6d",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -359,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0f4fe255c155ded7",
+      "fingerprint": "92a8447c3b7e796f",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -370,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2286b192a05d7bfe",
+      "fingerprint": "f1bba43860a3f2fe",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -381,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6b121e68b5bcdb55",
+      "fingerprint": "cac6ec19bd951299",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -392,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8d3111ee0fdd6842",
+      "fingerprint": "fc5f8809122a9fec",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -403,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "04c2e86ce1b63136",
+      "fingerprint": "a60d54c8a1dd80c0",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -414,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "76d6bf8fb6c08c1e",
+      "fingerprint": "95cd05e9fbc9490b",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -425,7 +491,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2384f8263630f7cc",
+      "fingerprint": "42c34e6c3b001698",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -436,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f7351c6254fd9718",
+      "fingerprint": "d745016db238548a",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -447,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "38cb2fd0bea5ce96",
+      "fingerprint": "18f4810d9d6d8bd0",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -458,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "280084097e7625ca",
+      "fingerprint": "a4ca9854311dbced",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -469,24 +535,46 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e89c88ef0c59edf6",
-      "id": "POST /tts",
-      "method": "POST",
-      "operation_id": "createTts",
-      "path": "/tts",
-      "tags": [
-        "TTS"
-      ]
-    },
-    {
-      "deprecated": false,
-      "fingerprint": "3dae513ba8623eb6",
+      "fingerprint": "624263f08072d641",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
       "path": "/videos",
       "tags": [
         "Video Generation"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "4206e4a1e2d22238",
+      "id": "POST /workspaces",
+      "method": "POST",
+      "operation_id": "createWorkspace",
+      "path": "/workspaces",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "e870d118f618fb87",
+      "id": "POST /workspaces/{id}/members/add",
+      "method": "POST",
+      "operation_id": "bulkAddWorkspaceMembers",
+      "path": "/workspaces/{id}/members/add",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "7ddc552ce8a708a0",
+      "id": "POST /workspaces/{id}/members/remove",
+      "method": "POST",
+      "operation_id": "bulkRemoveWorkspaceMembers",
+      "path": "/workspaces/{id}/members/remove",
+      "tags": [
+        "Workspaces"
       ]
     }
   ],

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::{
     error::OpenRouterError,
@@ -35,6 +38,15 @@ pub struct GenerationData {
     pub num_media_prompt: Option<u32>,
     pub num_media_completion: Option<u32>,
     pub num_search_results: Option<u32>,
+}
+
+/// Stored prompt/input and completion/output content returned by `GET /generation/content`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerationContentData {
+    #[serde(default)]
+    pub input: HashMap<String, Value>,
+    #[serde(default)]
+    pub output: HashMap<String, Value>,
 }
 
 /// Returns metadata about a specific generation request
@@ -74,6 +86,40 @@ pub(crate) async fn get_generation_with_client(
     if response.status().is_success() {
         let generation_response: ApiResponse<_> =
             transport_response::parse_json_response(response, "generation").await?;
+        Ok(generation_response.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Returns the stored prompt/input and completion/output content for a specific generation.
+pub async fn get_generation_content(
+    base_url: &str,
+    api_key: &str,
+    id: impl Into<String>,
+) -> Result<GenerationContentData, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_generation_content_with_client(&http_client, base_url, api_key, id).await
+}
+
+pub(crate) async fn get_generation_content_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    id: impl Into<String>,
+) -> Result<GenerationContentData, OpenRouterError> {
+    let id = id.into();
+    let url = format!("{base_url}/generation/content?id={id}");
+
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        let generation_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "generation content").await?;
         Ok(generation_response.data)
     } else {
         transport_response::handle_error(response).await?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -26,7 +26,7 @@
 //! - model discovery, providers, user model filters, model counts, and ZDR endpoints
 //! - embeddings
 //! - API-key and auth-code flows
-//! - credits, Coinbase charge creation, generation lookup, and activity
+//! - credits, Coinbase charge creation, generation lookup/content, and activity
 //! - guardrails and guardrail assignments
 //! - organization member listing
 //! - structured API error payloads

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
-use reqwest::Client as HttpClient;
+use reqwest::{Client as HttpClient, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -9,7 +9,10 @@ use crate::{
     transport::{request as transport_request, response as transport_response},
 };
 
-/// Supported audio output formats for `POST /tts`.
+const OFFICIAL_TTS_PATH: &str = "/audio/speech";
+const LEGACY_TTS_PATH: &str = "/tts";
+
+/// Supported audio output formats for `POST /audio/speech`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum TtsResponseFormat {
@@ -24,7 +27,7 @@ pub struct TtsProviderOptions {
     pub options: Option<HashMap<String, serde_json::Value>>,
 }
 
-/// Request payload for `POST /tts`.
+/// Request payload for `POST /audio/speech`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 pub struct TtsRequest {
@@ -82,17 +85,35 @@ pub(crate) async fn create_tts_with_client(
     app_categories: &Option<Vec<String>>,
     request: &TtsRequest,
 ) -> Result<Vec<u8>, OpenRouterError> {
-    let url = format!("{base_url}/tts");
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
+    let request_metadata = (x_title, http_referer, app_categories);
+    let response = send_tts_request(
+        http_client,
+        base_url,
         api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
-    .json(request)
-    .send()
+        request_metadata,
+        request,
+        OFFICIAL_TTS_PATH,
+    )
     .await?;
+
+    // Keep a narrow legacy fallback while upstream finishes the `/tts` -> `/audio/speech`
+    // transition so the canonical `client.tts()` surface continues to work across both paths.
+    let response = if matches!(
+        response.status(),
+        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+    ) {
+        send_tts_request(
+            http_client,
+            base_url,
+            api_key,
+            request_metadata,
+            request,
+            LEGACY_TTS_PATH,
+        )
+        .await?
+    } else {
+        response
+    };
 
     if response.status().is_success() {
         Ok(response.bytes().await?.to_vec())
@@ -100,4 +121,25 @@ pub(crate) async fn create_tts_with_client(
         transport_response::handle_error(response).await?;
         unreachable!()
     }
+}
+
+async fn send_tts_request(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    request_metadata: (&Option<String>, &Option<String>, &Option<Vec<String>>),
+    request: &TtsRequest,
+    endpoint_path: &str,
+) -> Result<reqwest::Response, OpenRouterError> {
+    let url = format!("{base_url}{endpoint_path}");
+    Ok(transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        request_metadata.0,
+        request_metadata.1,
+        request_metadata.2,
+    )?
+    .json(request)
+    .send()
+    .await?)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1216,7 +1216,7 @@ impl OpenRouterClient {
     ///
     /// # Arguments
     ///
-    /// * `request` - The GenerationRequest built using GenerationRequest::builder().
+    /// * `id` - The generation identifier returned by OpenRouter.
     ///
     /// # Returns
     ///
@@ -1240,6 +1240,40 @@ impl OpenRouterClient {
         if let Some(api_key) = &self.api_key {
             generation::get_generation_with_client(self.http_client(), &self.base_url, api_key, id)
                 .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Returns the stored prompt/input and completion/output content for a specific generation.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The generation identifier returned by OpenRouter.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use openrouter_rs::OpenRouterClient;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenRouterClient::builder().api_key("your_api_key").build()?;
+    /// let generation_content = client.get_generation_content("generation_id").await?;
+    /// println!("{:?}", generation_content.output);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_generation_content(
+        &self,
+        id: impl Into<String>,
+    ) -> Result<generation::GenerationContentData, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            generation::get_generation_content_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                id,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -1617,7 +1651,7 @@ pub struct TtsClient<'a> {
 }
 
 impl<'a> TtsClient<'a> {
-    /// Create speech audio bytes (`POST /tts`).
+    /// Create speech audio bytes (`POST /audio/speech`).
     pub async fn create(&self, request: &tts::TtsRequest) -> Result<Vec<u8>, OpenRouterError> {
         self.client.create_tts(request).await
     }
@@ -1832,6 +1866,14 @@ impl<'a> ManagementClient<'a> {
         id: impl Into<String>,
     ) -> Result<generation::GenerationData, OpenRouterError> {
         self.client.get_generation(id).await
+    }
+
+    /// Get stored generation content (`GET /generation/content?id=...`).
+    pub async fn get_generation_content(
+        &self,
+        id: impl Into<String>,
+    ) -> Result<generation::GenerationContentData, OpenRouterError> {
+        self.client.get_generation_content(id).await
     }
 
     /// Get endpoint usage activity (`GET /activity`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! - **🧩 Unified Streaming Events**: Shared stream event model across chat/responses/messages
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
 //! - **⚙️ Runtime Builder**: Explicit client setup through `OpenRouterClient::builder()`
-//! - **🎯 Full API Coverage**: Complete endpoint coverage in the current repository snapshot
+//! - **🎯 Tracked OpenAPI Coverage**: Accepted endpoint coverage is reviewed in-repo against upstream drift
 //!
 //! ## 🚀 Quick Start
 //!
@@ -156,6 +156,7 @@
 //! | Organization Members | ✅ | [`api::organization`] |
 //! | Credit Management | ✅ | [`api::credits`] |
 //! | Generation Data | ✅ | [`api::generation`] |
+//! | Generation Content | ✅ | [`api::generation`] |
 //! | Authentication | ✅ | [`api::auth`] |
 //! | Guardrails | ✅ | [`api::guardrails`] |
 //!

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -525,6 +525,10 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(
+        client.management().get_generation_content("gen_123").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
         client.management().get_activity(Some("2026-03-11")).await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
@@ -739,7 +743,7 @@ async fn test_tts_domain_create_delegates_to_api_module() {
     let captured = rx
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture request");
-    assert_eq!(captured.request_line, "POST /api/v1/tts HTTP/1.1");
+    assert_eq!(captured.request_line, "POST /api/v1/audio/speech HTTP/1.1");
 
     let body_json: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("body should be valid json");

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -98,3 +98,34 @@ async fn test_get_generation_path_and_auth_header() {
 
     server.join().expect("server thread should finish");
 }
+
+#[tokio::test]
+async fn test_get_generation_content_path_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"input":{"prompt":"What is the meaning of life?"},"output":{"completion":"42"}}}"#,
+    );
+
+    let response = generation::get_generation_content(&base_url, "api-key", "gen_123")
+        .await
+        .expect("get generation content should succeed");
+    assert_eq!(response.input["prompt"], "What is the meaning of life?");
+    assert_eq!(response.output["completion"], "42");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/generation/content?id=gen_123 HTTP/1.1"
+    );
+
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include API key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/tts.rs
+++ b/tests/unit/tts.rs
@@ -140,7 +140,7 @@ async fn test_create_tts_path_body_headers_and_binary_response() {
     let (request_line, request_text, body_text) = rx
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture request");
-    assert_eq!(request_line, "POST /api/v1/tts HTTP/1.1");
+    assert_eq!(request_line, "POST /api/v1/audio/speech HTTP/1.1");
 
     let body_json: serde_json::Value =
         serde_json::from_str(&body_text).expect("body should be valid json");
@@ -175,6 +175,88 @@ async fn test_create_tts_path_body_headers_and_binary_response() {
         "x-openrouter-categories header should be present, request:\n{}",
         request_text
     );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_create_tts_falls_back_to_legacy_path_when_official_path_is_missing() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+    let audio_bytes = b"ID3legacy-fallback".to_vec();
+
+    let server = thread::spawn(move || {
+        for attempt in 0..2 {
+            let (mut stream, _) = listener.accept().expect("server should accept request");
+            let mut request_bytes = Vec::new();
+            let mut chunk = [0_u8; 1024];
+
+            loop {
+                let read = stream.read(&mut chunk).expect("server should read request");
+                if read == 0 {
+                    break;
+                }
+                request_bytes.extend_from_slice(&chunk[..read]);
+                if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let request_text = String::from_utf8_lossy(&request_bytes).to_string();
+            let request_line = request_text.lines().next().unwrap_or_default().to_string();
+            tx.send(request_line.clone())
+                .expect("server should send captured request");
+
+            if attempt == 0 {
+                let body = r#"{"error":{"code":404,"message":"Not Found"}}"#;
+                let response = format!(
+                    "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("server should write fallback trigger response");
+            } else {
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    audio_bytes.len()
+                );
+                stream
+                    .write_all(header.as_bytes())
+                    .expect("server should write response header");
+                stream
+                    .write_all(&audio_bytes)
+                    .expect("server should write binary response");
+            }
+        }
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .build()
+        .expect("tts request should build");
+
+    let response = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+        .await
+        .expect("tts request should fall back and succeed");
+    assert_eq!(response, b"ID3legacy-fallback");
+
+    let first_request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture official request");
+    let second_request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture fallback request");
+    assert_eq!(first_request_line, "POST /api/v1/audio/speech HTTP/1.1");
+    assert_eq!(second_request_line, "POST /api/v1/tts HTTP/1.1");
 
     server.join().expect("server thread should finish");
 }


### PR DESCRIPTION
## Summary
- accept the latest reviewed OpenRouter OpenAPI baseline at `51` official method/path entries and refresh the endpoint matrix, README, and changelog accordingly
- map the canonical `client.tts().create(...)` surface to official `POST /audio/speech` while keeping a narrow legacy `/tts` fallback during the upstream transition
- add typed `GET /generation/content` support and record workspace-management follow-up work separately in #190

## Follow-ups
- closes #188
- workspace management surface: #190

## Verification
- `just openapi-refresh-baseline`
- `just openapi-drift-check`
- `just quality`