### PR TITLE
fix: narrow legacy tts fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
 
 ### Changed
-- `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` when the newer route is unavailable.
+- `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, so request-level `404/405` errors on the official endpoint are preserved.
 - Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and recorded workspace-management follow-up work in `#190`.
 
 ## [0.8.1] - 2026-04-21

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -86,7 +86,7 @@ pub(crate) async fn create_tts_with_client(
     request: &TtsRequest,
 ) -> Result<Vec<u8>, OpenRouterError> {
     let request_metadata = (x_title, http_referer, app_categories);
-    let response = send_tts_request(
+    let official_response = send_tts_request(
         http_client,
         base_url,
         api_key,
@@ -96,13 +96,17 @@ pub(crate) async fn create_tts_with_client(
     )
     .await?;
 
+    if official_response.status().is_success() {
+        return Ok(official_response.bytes().await?.to_vec());
+    }
+
+    let official_error = transport_response::error_from_response(official_response).await;
+
     // Keep a narrow legacy fallback while upstream finishes the `/tts` -> `/audio/speech`
-    // transition so the canonical `client.tts()` surface continues to work across both paths.
-    let response = if matches!(
-        response.status(),
-        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
-    ) {
-        send_tts_request(
+    // transition so the canonical `client.tts()` surface continues to work across both paths
+    // without masking request-level failures from the official route.
+    if should_retry_legacy_tts(&official_error) {
+        let legacy_response = send_tts_request(
             http_client,
             base_url,
             api_key,
@@ -110,17 +114,16 @@ pub(crate) async fn create_tts_with_client(
             request,
             LEGACY_TTS_PATH,
         )
-        .await?
-    } else {
-        response
-    };
+        .await?;
 
-    if response.status().is_success() {
-        Ok(response.bytes().await?.to_vec())
-    } else {
-        transport_response::handle_error(response).await?;
-        unreachable!()
+        if legacy_response.status().is_success() {
+            return Ok(legacy_response.bytes().await?.to_vec());
+        }
+
+        transport_response::handle_error(legacy_response).await?;
     }
+
+    Err(official_error)
 }
 
 async fn send_tts_request(
@@ -142,4 +145,29 @@ async fn send_tts_request(
     .json(request)
     .send()
     .await?)
+}
+
+fn should_retry_legacy_tts(error: &OpenRouterError) -> bool {
+    let OpenRouterError::Api(api_error) = error else {
+        return false;
+    };
+
+    if !matches!(
+        api_error.status,
+        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+    ) {
+        return false;
+    }
+
+    let message = api_error.message.trim().to_ascii_lowercase();
+    if matches!(message.as_str(), "not found" | "method not allowed") {
+        return true;
+    }
+
+    let route_unavailable_signal = message.contains("cannot post")
+        || message.contains("route")
+        || message.contains("endpoint")
+        || message.contains("method not allowed");
+
+    route_unavailable_signal && message.contains(OFFICIAL_TTS_PATH)
 }

--- a/src/transport/response.rs
+++ b/src/transport/response.rs
@@ -83,19 +83,17 @@ pub(crate) async fn parse_json_response<T: DeserializeOwned>(
     }
 }
 
-pub(crate) async fn handle_error(response: Response) -> Result<(), OpenRouterError> {
+pub(crate) async fn error_from_response(response: Response) -> OpenRouterError {
     let status = response.status();
     let request_id = response_request_id(&response);
     let text = match response.text().await {
         Ok(text) => text,
-        Err(error) => {
-            return Err(unreadable_error_response(
-                status,
-                request_id,
-                &error.to_string(),
-            ));
-        }
+        Err(error) => return unreadable_error_response(status, request_id, &error.to_string()),
     };
 
-    Err(parse_api_error(status, request_id, &text))
+    parse_api_error(status, request_id, &text)
+}
+
+pub(crate) async fn handle_error(response: Response) -> Result<(), OpenRouterError> {
+    Err(error_from_response(response).await)
 }

--- a/tests/unit/tts.rs
+++ b/tests/unit/tts.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use http::StatusCode;
 use openrouter_rs::api::tts::{self, TtsProviderOptions, TtsRequest, TtsResponseFormat};
 
 #[test]
@@ -257,6 +258,79 @@ async fn test_create_tts_falls_back_to_legacy_path_when_official_path_is_missing
         .expect("should capture fallback request");
     assert_eq!(first_request_line, "POST /api/v1/audio/speech HTTP/1.1");
     assert_eq!(second_request_line, "POST /api/v1/tts HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_create_tts_does_not_fall_back_for_request_level_404() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("server should accept request");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_text = String::from_utf8_lossy(&request_bytes).to_string();
+        let request_line = request_text.lines().next().unwrap_or_default().to_string();
+        tx.send(request_line)
+            .expect("server should send captured request");
+
+        let body = r#"{"error":{"code":404,"message":"Model not found"}}"#;
+        let response = format!(
+            "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write error response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .build()
+        .expect("tts request should build");
+
+    let error = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+        .await
+        .expect_err("tts request should surface the official error");
+
+    match error {
+        openrouter_rs::error::OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::NOT_FOUND);
+            assert_eq!(api_error.message, "Model not found");
+        }
+        other => panic!("expected api error, got {other:?}"),
+    }
+
+    let first_request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture official request");
+    assert_eq!(first_request_line, "POST /api/v1/audio/speech HTTP/1.1");
+    assert!(
+        rx.recv_timeout(Duration::from_millis(250)).is_err(),
+        "should not issue a legacy fallback request for request-level errors"
+    );
 
     server.join().expect("server thread should finish");
 }


### PR DESCRIPTION
## Summary
- preserve official `/audio/speech` request-level `404/405` errors instead of retrying legacy `/tts` for every such response
- keep the compatibility retry only for route-unavailable signals such as generic `Not Found` / `Method Not Allowed` or path-specific route errors
- add unit coverage for both the fallback path and the non-fallback request-error path

## Context
- follow-up to the unresolved Codex review thread on #191

## Verification
- `cargo test --test unit tts -- --nocapture`
- `just quality`