### PR TITLE
fix: restore generic tts route fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
 
 ### Changed
-- `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, so request-level `404/405` errors on the official endpoint are preserved.
+- `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, including generic plain-text `404/405` status pages, so request-level `404/405` errors on the official endpoint are still preserved.
 - Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and recorded workspace-management follow-up work in `#190`.
 
 ## [0.8.1] - 2026-04-21

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -167,13 +167,14 @@ fn should_retry_legacy_tts(error: &OpenRouterError) -> bool {
 }
 
 fn is_generic_status_page(message: &str, code: &str, reason_phrase: &str) -> bool {
-    matches!(message, "not found" | "method not allowed")
-        || message.contains(&format!("{code} page {reason_phrase}"))
-        || message.contains(&format!("{code} {reason_phrase}"))
-        || message.starts_with(&format!("{code} ")) && message.contains(reason_phrase)
-        || message.starts_with(&format!("{code}:")) && message.contains(reason_phrase)
-        || message.starts_with(&format!("http/1.1 {code}")) && message.contains(reason_phrase)
-        || message.starts_with(&format!("http/2 {code}")) && message.contains(reason_phrase)
+    let message = message.trim_end_matches(['.', '!', '?', ';']);
+    let bare_reason_phrase = matches!(message, "not found" | "method not allowed");
+    let exact_status_page = message == format!("{code} page {reason_phrase}")
+        || message == format!("{code} {reason_phrase}")
+        || message == format!("http/1.1 {code} {reason_phrase}")
+        || message == format!("http/2 {code} {reason_phrase}");
+
+    bare_reason_phrase || exact_status_page
 }
 
 fn is_path_specific_route_error(message: &str) -> bool {

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -152,21 +152,36 @@ fn should_retry_legacy_tts(error: &OpenRouterError) -> bool {
         return false;
     };
 
-    if !matches!(
-        api_error.status,
-        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
-    ) {
-        return false;
-    }
-
     let message = api_error.message.trim().to_ascii_lowercase();
-    if matches!(message.as_str(), "not found" | "method not allowed") {
-        return true;
+    match api_error.status {
+        StatusCode::NOT_FOUND => {
+            is_generic_status_page(&message, "404", "not found")
+                || is_path_specific_route_error(&message)
+        }
+        StatusCode::METHOD_NOT_ALLOWED => {
+            is_generic_status_page(&message, "405", "method not allowed")
+                || is_path_specific_route_error(&message)
+        }
+        _ => false,
     }
+}
 
+fn is_generic_status_page(message: &str, code: &str, reason_phrase: &str) -> bool {
+    matches!(message, "not found" | "method not allowed")
+        || message.contains(&format!("{code} page {reason_phrase}"))
+        || message.contains(&format!("{code} {reason_phrase}"))
+        || message.starts_with(&format!("{code} ")) && message.contains(reason_phrase)
+        || message.starts_with(&format!("{code}:")) && message.contains(reason_phrase)
+        || message.starts_with(&format!("http/1.1 {code}")) && message.contains(reason_phrase)
+        || message.starts_with(&format!("http/2 {code}")) && message.contains(reason_phrase)
+}
+
+fn is_path_specific_route_error(message: &str) -> bool {
     let route_unavailable_signal = message.contains("cannot post")
+        || message.contains("cannot get")
         || message.contains("route")
         || message.contains("endpoint")
+        || message.contains("path")
         || message.contains("method not allowed");
 
     route_unavailable_signal && message.contains(OFFICIAL_TTS_PATH)

--- a/tests/unit/tts.rs
+++ b/tests/unit/tts.rs
@@ -334,3 +334,85 @@ async fn test_create_tts_does_not_fall_back_for_request_level_404() {
 
     server.join().expect("server thread should finish");
 }
+
+#[tokio::test]
+async fn test_create_tts_falls_back_for_plain_text_404_page_not_found() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+    let audio_bytes = b"ID3plain-text-fallback".to_vec();
+
+    let server = thread::spawn(move || {
+        for attempt in 0..2 {
+            let (mut stream, _) = listener.accept().expect("server should accept request");
+            let mut request_bytes = Vec::new();
+            let mut chunk = [0_u8; 1024];
+
+            loop {
+                let read = stream.read(&mut chunk).expect("server should read request");
+                if read == 0 {
+                    break;
+                }
+                request_bytes.extend_from_slice(&chunk[..read]);
+                if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let request_text = String::from_utf8_lossy(&request_bytes).to_string();
+            let request_line = request_text.lines().next().unwrap_or_default().to_string();
+            tx.send(request_line.clone())
+                .expect("server should send captured request");
+
+            if attempt == 0 {
+                let body = "404 page not found";
+                let response = format!(
+                    "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("server should write fallback trigger response");
+            } else {
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    audio_bytes.len()
+                );
+                stream
+                    .write_all(header.as_bytes())
+                    .expect("server should write response header");
+                stream
+                    .write_all(&audio_bytes)
+                    .expect("server should write binary response");
+            }
+        }
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .build()
+        .expect("tts request should build");
+
+    let response = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+        .await
+        .expect("tts request should fall back and succeed");
+    assert_eq!(response, b"ID3plain-text-fallback");
+
+    let first_request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture official request");
+    let second_request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture fallback request");
+    assert_eq!(first_request_line, "POST /api/v1/audio/speech HTTP/1.1");
+    assert_eq!(second_request_line, "POST /api/v1/tts HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/tts.rs
+++ b/tests/unit/tts.rs
@@ -336,6 +336,79 @@ async fn test_create_tts_does_not_fall_back_for_request_level_404() {
 }
 
 #[tokio::test]
+async fn test_create_tts_does_not_fall_back_for_plain_text_request_level_404() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("server should accept request");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_text = String::from_utf8_lossy(&request_bytes).to_string();
+        let request_line = request_text.lines().next().unwrap_or_default().to_string();
+        tx.send(request_line)
+            .expect("server should send captured request");
+
+        let body = "404 not found: invalid model";
+        let response = format!(
+            "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write error response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let request = TtsRequest::builder()
+        .model("elevenlabs/eleven-turbo-v2")
+        .input("Hello world")
+        .voice("alloy")
+        .response_format(TtsResponseFormat::Mp3)
+        .build()
+        .expect("tts request should build");
+
+    let error = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+        .await
+        .expect_err("tts request should surface the official error");
+
+    match error {
+        openrouter_rs::error::OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::NOT_FOUND);
+            assert_eq!(api_error.message, "404 not found: invalid model");
+        }
+        other => panic!("expected api error, got {other:?}"),
+    }
+
+    let first_request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture official request");
+    assert_eq!(first_request_line, "POST /api/v1/audio/speech HTTP/1.1");
+    assert!(
+        rx.recv_timeout(Duration::from_millis(250)).is_err(),
+        "should not issue a legacy fallback request for plain-text request-level errors"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
 async fn test_create_tts_falls_back_for_plain_text_404_page_not_found() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener


### PR DESCRIPTION
## Summary
- restore legacy `/tts` fallback for generic plain-text `404/405` route-missing responses such as `404 page not found`
- keep request-level official `/audio/speech` errors such as `Model not found` from falling through to a second synthesis request
- add unit coverage for both the restored generic fallback path and the preserved non-fallback request-error path

## Context
- follow-up to the unresolved Codex review thread on #192

## Verification
- `cargo test --test unit tts -- --nocapture`
- `just quality`