### PR TITLE
feat: add workspace management surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
+- Added typed SDK support for `GET /workspaces`, `POST /workspaces`, `GET /workspaces/{id}`, `PATCH /workspaces/{id}`, `DELETE /workspaces/{id}`, `POST /workspaces/{id}/members/add`, and `POST /workspaces/{id}/members/remove`, including canonical `client.management()` methods and a runnable `examples/list_workspaces.rs`.
+- Added workspace-aware API-key and guardrail support, including `workspace_id` fields on typed models plus `create_api_key_in_workspace(...)`, `list_api_keys_in_workspace(...)`, and `list_guardrails_in_workspace(...)`.
+- Added `openrouter-cli workspaces ...` commands, plus `--workspace-id` support for `openrouter-cli keys list|create` and `openrouter-cli guardrails list|create`.
 
 ### Changed
 - `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, including generic plain-text `404/405` status pages, so request-level `404/405` errors on the official endpoint are still preserved.
-- Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and recorded workspace-management follow-up work in `#190`.
+- Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and restored the repository snapshot to `51 / 51` official OpenAPI endpoint coverage.
 
 ## [0.8.1] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 `openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, text-to-speech, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `44 / 51` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md). Newly official workspace management endpoints are tracked separately in [#190](https://github.com/realmorrisliu/openrouter-rs/issues/190).
+The current repo snapshot implements `51 / 51` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
@@ -30,7 +30,7 @@ The current repo snapshot implements `44 / 51` official OpenAPI method/path entr
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
-- Discovery, rerank, text-to-speech, video generation, embeddings, API-key management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Discovery, rerank, text-to-speech, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -104,7 +104,7 @@ The canonical public surface in `0.8.x` is domain-oriented:
 | `tts()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/endpoints/zdr`, `/embeddings*` | API key |
-| `management()` | `create_api_key`, `list_api_keys`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_organization_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
+| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
 At runtime, the builder/client exposes the values the SDK directly consumes:
@@ -126,7 +126,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, embeddings, and ZDR endpoints
-- management-key workflows for keys, auth codes, organization members, guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
+- management-key workflows for keys, workspace-scoped keys, auth codes, organization members, workspaces, workspace membership, guardrails, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 
@@ -165,6 +165,7 @@ The repo includes runnable examples for the highest-value workflows:
 | [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
 | [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
 | [`examples/list_organization_members.rs`](examples/list_organization_members.rs) | `management().list_organization_members(...)` |
+| [`examples/list_workspaces.rs`](examples/list_workspaces.rs) | `management().list_workspaces(...)` |
 | [`examples/exchange_code_for_api_key.rs`](examples/exchange_code_for_api_key.rs) | PKCE/auth-code flow |
 | [`examples/send_completion_request.rs`](examples/send_completion_request.rs) | Legacy completions (`legacy-completions` required) |
 
@@ -197,6 +198,7 @@ cargo run -p openrouter-cli -- --help
 cargo run -p openrouter-cli -- profile show
 cargo run -p openrouter-cli -- models list --category programming
 cargo run -p openrouter-cli -- keys list --include-disabled
+cargo run -p openrouter-cli -- workspaces list --limit 20
 cargo run -p openrouter-cli -- usage activity --date 2026-03-01
 ```
 
@@ -207,7 +209,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, with the current workspace-management gap tracked in [#190](https://github.com/realmorrisliu/openrouter-rs/issues/190)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`51 / 51`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.7.x -> 0.8.0` transport/error-surface release, plus the archived `0.5.x -> 0.6.x` naming guide, lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -6,7 +6,7 @@ It currently focuses on four areas:
 
 - profile/config resolution
 - model and provider discovery
-- API-key, organization, and guardrail management
+- API-key, workspace, organization, and guardrail management
 - credits, billing, and usage activity
 
 The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.1.3`.
@@ -55,13 +55,15 @@ guardrails list|create|get|update|delete
 guardrails assignments keys list|assign|unassign
 guardrails assignments members list|assign|unassign
 organization members list
+workspaces list|create|get|update|delete
+workspaces members add|remove
 usage activity
 ```
 
 Auth expectations by command group:
 
 - `models`, `providers`, `credits show`, `credits charge`: API key
-- `keys`, `guardrails`, `organization`, `usage activity`: management key
+- `keys`, `guardrails`, `organization`, `workspaces`, `usage activity`: management key
 - `profile`, `config`: no API call required
 
 ## Config And Resolution Order
@@ -144,8 +146,14 @@ openrouter-cli --api-key "$OPENROUTER_API_KEY" providers list
 # List keys
 openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys list --include-disabled
 
+# List keys in one workspace
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys list --workspace-id ws_123
+
 # Create one
 openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys create --name "ci-bot" --limit 100
+
+# Create one directly inside a workspace
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys create --name "ci-bot" --limit 100 --workspace-id ws_123
 
 # Inspect one
 openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys get sk-or-v1-hash
@@ -163,12 +171,16 @@ openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" keys delete sk-or-v
 # List guardrails
 openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" guardrails list --limit 20
 
+# List guardrails in one workspace
+openrouter-cli --management-key "$OPENROUTER_MANAGEMENT_KEY" guardrails list --workspace-id ws_123
+
 # Create one
 openrouter-cli \
   --management-key "$OPENROUTER_MANAGEMENT_KEY" \
   guardrails create \
   --name "ci-budget-cap" \
   --limit-usd 25 \
+  --workspace-id ws_123 \
   --enforce-zdr
 
 # Update and clear allowlists
@@ -215,6 +227,46 @@ Member assignment commands mirror the same shape under `guardrails assignments m
 openrouter-cli \
   --management-key "$OPENROUTER_MANAGEMENT_KEY" \
   organization members list --limit 25
+```
+
+### Workspaces
+
+```bash
+# List workspaces
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  workspaces list --limit 25
+
+# Create a workspace
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  workspaces create \
+  --name "platform" \
+  --slug "platform" \
+  --default-text-model openai/gpt-4.1 \
+  --enable-observability-broadcast
+
+# Update a workspace
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  workspaces update ws_123 \
+  --description "Platform engineering" \
+  --disable-data-discount-logging
+
+# Add members to a workspace
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  workspaces members add ws_123 user_1 user_2
+
+# Remove members from a workspace
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  workspaces members remove ws_123 user_1 user_2 --yes
+
+# Delete a workspace
+openrouter-cli \
+  --management-key "$OPENROUTER_MANAGEMENT_KEY" \
+  workspaces delete ws_123 --yes
 ```
 
 ## Credits And Usage

--- a/crates/openrouter-cli/src/cli.rs
+++ b/crates/openrouter-cli/src/cli.rs
@@ -210,6 +210,10 @@ pub struct KeysListArgs {
     /// Include disabled keys.
     #[arg(long)]
     pub include_disabled: bool,
+
+    /// Filter keys by workspace ID.
+    #[arg(long)]
+    pub workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -221,6 +225,10 @@ pub struct KeysCreateArgs {
     /// Optional spending limit in USD.
     #[arg(long)]
     pub limit: Option<f64>,
+
+    /// Create the key inside a specific workspace.
+    #[arg(long)]
+    pub workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -287,6 +295,16 @@ pub struct PaginationArgs {
 }
 
 #[derive(Debug, Clone, Args)]
+pub struct GuardrailsListArgs {
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
+
+    /// Filter guardrails by workspace ID.
+    #[arg(long)]
+    pub workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
 pub struct GuardrailsGetArgs {
     /// Guardrail ID.
     pub id: String,
@@ -331,6 +349,10 @@ pub struct GuardrailsCreateArgs {
     /// Enforce ZDR.
     #[arg(long)]
     pub enforce_zdr: bool,
+
+    /// Create the guardrail inside a specific workspace.
+    #[arg(long)]
+    pub workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -466,7 +488,7 @@ pub enum GuardrailAssignmentCommands {
 #[derive(Debug, Clone, Subcommand)]
 pub enum GuardrailsCommands {
     /// List guardrails.
-    List(PaginationArgs),
+    List(GuardrailsListArgs),
     /// Create a guardrail.
     Create(GuardrailsCreateArgs),
     /// Get a guardrail.
@@ -479,6 +501,210 @@ pub enum GuardrailsCommands {
     Assignments {
         #[command(subcommand)]
         command: GuardrailAssignmentCommands,
+    },
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct WorkspaceGetArgs {
+    /// Workspace ID or slug.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct WorkspaceDeleteArgs {
+    /// Workspace ID or slug.
+    pub id: String,
+
+    /// Confirm destructive action.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct WorkspacesCreateArgs {
+    /// Workspace name.
+    #[arg(long)]
+    pub name: String,
+
+    /// Optional URL-friendly slug.
+    #[arg(long)]
+    pub slug: Option<String>,
+
+    /// Optional description.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Optional default text model.
+    #[arg(long)]
+    pub default_text_model: Option<String>,
+
+    /// Optional default image model.
+    #[arg(long)]
+    pub default_image_model: Option<String>,
+
+    /// Optional default provider sort.
+    #[arg(long)]
+    pub default_provider_sort: Option<String>,
+
+    /// Set data discount logging enabled.
+    #[arg(
+        long = "enable-data-discount-logging",
+        conflicts_with = "disable_data_discount_logging"
+    )]
+    pub enable_data_discount_logging: bool,
+
+    /// Set data discount logging disabled.
+    #[arg(
+        long = "disable-data-discount-logging",
+        conflicts_with = "enable_data_discount_logging"
+    )]
+    pub disable_data_discount_logging: bool,
+
+    /// Set observability broadcast enabled.
+    #[arg(
+        long = "enable-observability-broadcast",
+        conflicts_with = "disable_observability_broadcast"
+    )]
+    pub enable_observability_broadcast: bool,
+
+    /// Set observability broadcast disabled.
+    #[arg(
+        long = "disable-observability-broadcast",
+        conflicts_with = "enable_observability_broadcast"
+    )]
+    pub disable_observability_broadcast: bool,
+
+    /// Set observability IO logging enabled.
+    #[arg(
+        long = "enable-observability-io-logging",
+        conflicts_with = "disable_observability_io_logging"
+    )]
+    pub enable_observability_io_logging: bool,
+
+    /// Set observability IO logging disabled.
+    #[arg(
+        long = "disable-observability-io-logging",
+        conflicts_with = "enable_observability_io_logging"
+    )]
+    pub disable_observability_io_logging: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct WorkspacesUpdateArgs {
+    /// Workspace ID or slug.
+    pub id: String,
+
+    /// Optional new name.
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Optional new slug.
+    #[arg(long)]
+    pub slug: Option<String>,
+
+    /// Optional new description.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Optional new default text model.
+    #[arg(long)]
+    pub default_text_model: Option<String>,
+
+    /// Optional new default image model.
+    #[arg(long)]
+    pub default_image_model: Option<String>,
+
+    /// Optional new default provider sort.
+    #[arg(long)]
+    pub default_provider_sort: Option<String>,
+
+    /// Set data discount logging enabled.
+    #[arg(
+        long = "enable-data-discount-logging",
+        conflicts_with = "disable_data_discount_logging"
+    )]
+    pub enable_data_discount_logging: bool,
+
+    /// Set data discount logging disabled.
+    #[arg(
+        long = "disable-data-discount-logging",
+        conflicts_with = "enable_data_discount_logging"
+    )]
+    pub disable_data_discount_logging: bool,
+
+    /// Set observability broadcast enabled.
+    #[arg(
+        long = "enable-observability-broadcast",
+        conflicts_with = "disable_observability_broadcast"
+    )]
+    pub enable_observability_broadcast: bool,
+
+    /// Set observability broadcast disabled.
+    #[arg(
+        long = "disable-observability-broadcast",
+        conflicts_with = "enable_observability_broadcast"
+    )]
+    pub disable_observability_broadcast: bool,
+
+    /// Set observability IO logging enabled.
+    #[arg(
+        long = "enable-observability-io-logging",
+        conflicts_with = "disable_observability_io_logging"
+    )]
+    pub enable_observability_io_logging: bool,
+
+    /// Set observability IO logging disabled.
+    #[arg(
+        long = "disable-observability-io-logging",
+        conflicts_with = "enable_observability_io_logging"
+    )]
+    pub disable_observability_io_logging: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct WorkspaceMembersApplyArgs {
+    /// Workspace ID or slug.
+    pub workspace_id: String,
+
+    /// One or more member user IDs.
+    #[arg(value_name = "MEMBER_USER_ID", required = true, num_args = 1..)]
+    pub user_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct WorkspaceMembersRemoveArgs {
+    #[command(flatten)]
+    pub request: WorkspaceMembersApplyArgs,
+
+    /// Confirm destructive action.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum WorkspaceMemberCommands {
+    /// Add organization members to a workspace.
+    Add(WorkspaceMembersApplyArgs),
+    /// Remove organization members from a workspace.
+    Remove(WorkspaceMembersRemoveArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum WorkspacesCommands {
+    /// List workspaces.
+    List(PaginationArgs),
+    /// Create a workspace.
+    Create(WorkspacesCreateArgs),
+    /// Get a workspace.
+    Get(WorkspaceGetArgs),
+    /// Update a workspace.
+    Update(WorkspacesUpdateArgs),
+    /// Delete a workspace.
+    Delete(WorkspaceDeleteArgs),
+    /// Manage workspace members.
+    Members {
+        #[command(subcommand)]
+        command: WorkspaceMemberCommands,
     },
 }
 
@@ -523,6 +749,11 @@ pub enum Commands {
     Organization {
         #[command(subcommand)]
         command: OrganizationCommands,
+    },
+    /// Workspace management commands.
+    Workspaces {
+        #[command(subcommand)]
+        command: WorkspacesCommands,
     },
     /// Usage commands.
     Usage {

--- a/crates/openrouter-cli/src/main.rs
+++ b/crates/openrouter-cli/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::{Result, anyhow, bail};
 use clap::{Parser, error::ErrorKind};
 use openrouter_rs::{
     OpenRouterClient,
-    api::{credits, discovery, guardrails, models},
+    api::{credits, discovery, guardrails, models, workspaces},
     types::{ModelCategory, PaginationOptions, SupportedParameters},
 };
 use serde::Serialize;
@@ -16,7 +16,8 @@ use crate::{
         GuardrailKeyAssignmentCommands, GuardrailMemberAssignmentCommands, GuardrailsCommands,
         KeysCommands, ModelCategoryArg, ModelsCommands, OrganizationCommands,
         OrganizationMemberCommands, OutputFormat, PaginationArgs, ProfileCommands,
-        ProvidersCommands, SupportedParameterArg, UsageCommands,
+        ProvidersCommands, SupportedParameterArg, UsageCommands, WorkspaceMemberCommands,
+        WorkspacesCommands,
     },
     config::{Environment, ResolvedProfile, resolve_profile},
 };
@@ -253,6 +254,16 @@ fn resolve_disabled_flag(disable: bool, enable: bool) -> Option<bool> {
     if disable {
         Some(true)
     } else if enable {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn resolve_enabled_flag(enable: bool, disable: bool) -> Option<bool> {
+    if enable {
+        Some(true)
+    } else if disable {
         Some(false)
     } else {
         None
@@ -549,12 +560,22 @@ async fn run(cli: Cli) -> Result<()> {
                         None
                     };
                     let response = management
-                        .list_api_keys(pagination, include_disabled)
+                        .list_api_keys_in_workspace(
+                            pagination,
+                            include_disabled,
+                            args.workspace_id.as_deref(),
+                        )
                         .await?;
                     print_value(&response, cli.global.output)?;
                 }
                 KeysCommands::Create(args) => {
-                    let response = management.create_api_key(&args.name, args.limit).await?;
+                    let response = management
+                        .create_api_key_in_workspace(
+                            &args.name,
+                            args.limit,
+                            args.workspace_id.as_deref(),
+                        )
+                        .await?;
                     print_value(&response, cli.global.output)?;
                 }
                 KeysCommands::Get(args) => {
@@ -593,8 +614,10 @@ async fn run(cli: Cli) -> Result<()> {
 
             match command {
                 GuardrailsCommands::List(args) => {
-                    let pagination = pagination_from_args(&args);
-                    let response = management.list_guardrails(pagination).await?;
+                    let pagination = pagination_from_args(&args.pagination);
+                    let response = management
+                        .list_guardrails_in_workspace(pagination, args.workspace_id.as_deref())
+                        .await?;
                     print_value(&response, cli.global.output)?;
                 }
                 GuardrailsCommands::Create(args) => {
@@ -618,6 +641,9 @@ async fn run(cli: Cli) -> Result<()> {
                     }
                     if args.enforce_zdr {
                         builder.enforce_zdr(true);
+                    }
+                    if let Some(workspace_id) = args.workspace_id {
+                        builder.workspace_id(workspace_id);
                     }
 
                     let request = builder.build()?;
@@ -773,6 +799,164 @@ async fn run(cli: Cli) -> Result<()> {
                     OrganizationMemberCommands::List(args) => {
                         let pagination = pagination_from_args(&args);
                         let response = management.list_organization_members(pagination).await?;
+                        print_value(&response, cli.global.output)?;
+                    }
+                },
+            }
+        }
+        Commands::Workspaces { command } => {
+            let client = build_management_client(&resolved)?;
+            let management = client.management();
+
+            match command {
+                WorkspacesCommands::List(args) => {
+                    let pagination = pagination_from_args(&args);
+                    let response = management.list_workspaces(pagination).await?;
+                    print_value(&response, cli.global.output)?;
+                }
+                WorkspacesCommands::Create(args) => {
+                    let data_discount_logging = resolve_enabled_flag(
+                        args.enable_data_discount_logging,
+                        args.disable_data_discount_logging,
+                    );
+                    let observability_broadcast = resolve_enabled_flag(
+                        args.enable_observability_broadcast,
+                        args.disable_observability_broadcast,
+                    );
+                    let observability_io_logging = resolve_enabled_flag(
+                        args.enable_observability_io_logging,
+                        args.disable_observability_io_logging,
+                    );
+
+                    let mut builder = workspaces::CreateWorkspaceRequest::builder();
+                    builder.name(args.name);
+
+                    if let Some(slug) = args.slug {
+                        builder.slug(slug);
+                    }
+                    if let Some(description) = args.description {
+                        builder.description(description);
+                    }
+                    if let Some(default_text_model) = args.default_text_model {
+                        builder.default_text_model(default_text_model);
+                    }
+                    if let Some(default_image_model) = args.default_image_model {
+                        builder.default_image_model(default_image_model);
+                    }
+                    if let Some(default_provider_sort) = args.default_provider_sort {
+                        builder.default_provider_sort(default_provider_sort);
+                    }
+                    if let Some(enabled) = data_discount_logging {
+                        builder.is_data_discount_logging_enabled(enabled);
+                    }
+                    if let Some(enabled) = observability_broadcast {
+                        builder.is_observability_broadcast_enabled(enabled);
+                    }
+                    if let Some(enabled) = observability_io_logging {
+                        builder.is_observability_io_logging_enabled(enabled);
+                    }
+
+                    let request = builder.build()?;
+                    let response = management.create_workspace(&request).await?;
+                    print_value(&response, cli.global.output)?;
+                }
+                WorkspacesCommands::Get(args) => {
+                    let response = management.get_workspace(&args.id).await?;
+                    print_value(&response, cli.global.output)?;
+                }
+                WorkspacesCommands::Update(args) => {
+                    let data_discount_logging = resolve_enabled_flag(
+                        args.enable_data_discount_logging,
+                        args.disable_data_discount_logging,
+                    );
+                    let observability_broadcast = resolve_enabled_flag(
+                        args.enable_observability_broadcast,
+                        args.disable_observability_broadcast,
+                    );
+                    let observability_io_logging = resolve_enabled_flag(
+                        args.enable_observability_io_logging,
+                        args.disable_observability_io_logging,
+                    );
+
+                    if args.name.is_none()
+                        && args.slug.is_none()
+                        && args.description.is_none()
+                        && args.default_text_model.is_none()
+                        && args.default_image_model.is_none()
+                        && args.default_provider_sort.is_none()
+                        && data_discount_logging.is_none()
+                        && observability_broadcast.is_none()
+                        && observability_io_logging.is_none()
+                    {
+                        bail!("no update fields provided; pass at least one update argument");
+                    }
+
+                    let mut builder = workspaces::UpdateWorkspaceRequest::builder();
+                    if let Some(name) = args.name {
+                        builder.name(name);
+                    }
+                    if let Some(slug) = args.slug {
+                        builder.slug(slug);
+                    }
+                    if let Some(description) = args.description {
+                        builder.description(description);
+                    }
+                    if let Some(default_text_model) = args.default_text_model {
+                        builder.default_text_model(default_text_model);
+                    }
+                    if let Some(default_image_model) = args.default_image_model {
+                        builder.default_image_model(default_image_model);
+                    }
+                    if let Some(default_provider_sort) = args.default_provider_sort {
+                        builder.default_provider_sort(default_provider_sort);
+                    }
+                    if let Some(enabled) = data_discount_logging {
+                        builder.is_data_discount_logging_enabled(enabled);
+                    }
+                    if let Some(enabled) = observability_broadcast {
+                        builder.is_observability_broadcast_enabled(enabled);
+                    }
+                    if let Some(enabled) = observability_io_logging {
+                        builder.is_observability_io_logging_enabled(enabled);
+                    }
+
+                    let request = builder.build()?;
+                    let response = management.update_workspace(&args.id, &request).await?;
+                    print_value(&response, cli.global.output)?;
+                }
+                WorkspacesCommands::Delete(args) => {
+                    require_yes(args.yes, "delete workspace")?;
+                    let deleted = management.delete_workspace(&args.id).await?;
+                    print_value(
+                        &serde_json::json!({
+                            "id": args.id,
+                            "deleted": deleted,
+                        }),
+                        cli.global.output,
+                    )?;
+                }
+                WorkspacesCommands::Members { command } => match command {
+                    WorkspaceMemberCommands::Add(args) => {
+                        let workspace_id = args.workspace_id;
+                        let user_ids = args.user_ids;
+                        let request = workspaces::WorkspaceMembersRequest::builder()
+                            .user_ids(user_ids)
+                            .build()?;
+                        let response = management
+                            .add_workspace_members(&workspace_id, &request)
+                            .await?;
+                        print_value(&response, cli.global.output)?;
+                    }
+                    WorkspaceMemberCommands::Remove(args) => {
+                        require_yes(args.yes, "remove members from workspace")?;
+                        let workspace_id = args.request.workspace_id;
+                        let user_ids = args.request.user_ids;
+                        let request = workspaces::WorkspaceMembersRequest::builder()
+                            .user_ids(user_ids)
+                            .build()?;
+                        let response = management
+                            .remove_workspace_members(&workspace_id, &request)
+                            .await?;
                         print_value(&response, cli.global.output)?;
                     }
                 },

--- a/crates/openrouter-cli/tests/help.rs
+++ b/crates/openrouter-cli/tests/help.rs
@@ -10,7 +10,8 @@ fn test_help_starts() {
         .stdout(contains("OpenRouter CLI"))
         .stdout(contains("--profile"))
         .stdout(contains("profile"))
-        .stdout(contains("organization"));
+        .stdout(contains("organization"))
+        .stdout(contains("workspaces"));
 }
 
 #[test]

--- a/crates/openrouter-cli/tests/management_commands.rs
+++ b/crates/openrouter-cli/tests/management_commands.rs
@@ -160,6 +160,38 @@ fn test_keys_list_happy_path() {
 }
 
 #[test]
+fn test_keys_list_with_workspace_filter_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"name":"ops","hash":"key_hash_1","disabled":false,"workspace_id":"ws_123"}]}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("keys")
+        .arg("list")
+        .arg("--workspace-id")
+        .arg("ws_123");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(
+        parsed
+            .pointer("/data/0/workspace_id")
+            .and_then(Value::as_str),
+        Some("ws_123")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/keys?workspace_id=ws_123 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
 fn test_guardrails_create_happy_path() {
     let (base_url, rx, server) = spawn_json_server(
         r#"{"data":{"id":"gr_1","name":"Prod","created_at":"2026-03-01T00:00:00.000Z"}}"#,
@@ -224,6 +256,38 @@ fn test_guardrails_create_happy_path() {
 }
 
 #[test]
+fn test_guardrails_list_with_workspace_filter_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"gr_1","name":"Prod","workspace_id":"ws_123","created_at":"2026-03-01T00:00:00.000Z"}],"total_count":1}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("guardrails")
+        .arg("list")
+        .arg("--workspace-id")
+        .arg("ws_123");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(
+        parsed
+            .pointer("/data/data/0/workspace_id")
+            .and_then(Value::as_str),
+        Some("ws_123")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/guardrails?workspace_id=ws_123 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
 fn test_guardrail_key_assignment_assign_happy_path() {
     let (base_url, rx, server) = spawn_json_server(r#"{"assigned_count":2}"#);
 
@@ -258,6 +322,275 @@ fn test_guardrail_key_assignment_assign_happy_path() {
         body.get("key_hashes")
             .and_then(Value::as_array)
             .map(Vec::len),
+        Some(2)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspaces_list_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"ws_1","name":"Core","slug":"core","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}],"total_count":1}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("list")
+        .arg("--offset")
+        .arg("2")
+        .arg("--limit")
+        .arg("5");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(
+        parsed
+            .get("data")
+            .and_then(|value| value.get("total_count"))
+            .and_then(Value::as_f64),
+        Some(1.0)
+    );
+    assert_eq!(
+        parsed.pointer("/data/data/0/slug").and_then(Value::as_str),
+        Some("core")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces?offset=2&limit=5 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspaces_create_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","description":"Core team","default_text_model":"openai/gpt-4.1","is_observability_io_logging_enabled":true,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("create")
+        .arg("--name")
+        .arg("Core")
+        .arg("--slug")
+        .arg("core")
+        .arg("--description")
+        .arg("Core team")
+        .arg("--default-text-model")
+        .arg("openai/gpt-4.1")
+        .arg("--enable-data-discount-logging")
+        .arg("--disable-observability-broadcast")
+        .arg("--enable-observability-io-logging");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+
+    assert_eq!(
+        parsed.pointer("/data/id").and_then(Value::as_str),
+        Some("ws_1")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(captured.request_line, "POST /api/v1/workspaces HTTP/1.1");
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(body.get("name").and_then(Value::as_str), Some("Core"));
+    assert_eq!(body.get("slug").and_then(Value::as_str), Some("core"));
+    assert_eq!(
+        body.get("description").and_then(Value::as_str),
+        Some("Core team")
+    );
+    assert_eq!(
+        body.get("default_text_model").and_then(Value::as_str),
+        Some("openai/gpt-4.1")
+    );
+    assert_eq!(
+        body.get("is_data_discount_logging_enabled")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        body.get("is_observability_broadcast_enabled")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        body.get("is_observability_io_logging_enabled")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspaces_get_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces").arg("get").arg("ws_1");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed.pointer("/data/slug").and_then(Value::as_str),
+        Some("core")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces/ws_1 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspaces_update_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_1","name":"Core Updated","slug":"core","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z","updated_at":"2026-03-02T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("update")
+        .arg("ws_1")
+        .arg("--name")
+        .arg("Core Updated")
+        .arg("--disable-data-discount-logging");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed.pointer("/data/name").and_then(Value::as_str),
+        Some("Core Updated")
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "PATCH /api/v1/workspaces/ws_1 HTTP/1.1"
+    );
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(
+        body.get("name").and_then(Value::as_str),
+        Some("Core Updated")
+    );
+    assert_eq!(
+        body.get("is_data_discount_logging_enabled")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspaces_delete_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"deleted":true}"#);
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces").arg("delete").arg("ws_1").arg("--yes");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed.pointer("/data/deleted").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "DELETE /api/v1/workspaces/ws_1 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspace_members_add_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"added_count":2,"data":[{"id":"wsm_1","workspace_id":"ws_1","user_id":"user_1","role":"member","created_at":"2026-03-01T00:00:00.000Z"},{"id":"wsm_2","workspace_id":"ws_1","user_id":"user_2","role":"member","created_at":"2026-03-01T00:00:00.000Z"}]}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("members")
+        .arg("add")
+        .arg("ws_1")
+        .arg("user_1")
+        .arg("user_2");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed.pointer("/data/added_count").and_then(Value::as_f64),
+        Some(2.0)
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/workspaces/ws_1/members/add HTTP/1.1"
+    );
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(
+        body.get("user_ids").and_then(Value::as_array).map(Vec::len),
+        Some(2)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspace_members_remove_happy_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"removed_count":2}"#);
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("members")
+        .arg("remove")
+        .arg("ws_1")
+        .arg("user_1")
+        .arg("user_2")
+        .arg("--yes");
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let parsed: Value = serde_json::from_slice(&output).expect("stdout should be json");
+    assert_eq!(
+        parsed
+            .pointer("/data/removed_count")
+            .and_then(Value::as_f64),
+        Some(2.0)
+    );
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/workspaces/ws_1/members/remove HTTP/1.1"
+    );
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(
+        body.get("user_ids").and_then(Value::as_array).map(Vec::len),
         Some(2)
     );
 
@@ -393,6 +726,13 @@ fn test_keys_delete_requires_yes() {
 }
 
 #[test]
+fn test_workspaces_delete_requires_yes() {
+    let mut cmd = base_cmd("http://127.0.0.1:9/api/v1");
+    cmd.arg("workspaces").arg("delete").arg("ws_1");
+    cmd.assert().failure().stderr(contains("without --yes"));
+}
+
+#[test]
 fn test_guardrail_key_assignment_unassign_requires_yes() {
     let mut cmd = base_cmd("http://127.0.0.1:9/api/v1");
     cmd.arg("guardrails")
@@ -401,5 +741,16 @@ fn test_guardrail_key_assignment_unassign_requires_yes() {
         .arg("unassign")
         .arg("gr_1")
         .arg("key_hash_1");
+    cmd.assert().failure().stderr(contains("without --yes"));
+}
+
+#[test]
+fn test_workspace_members_remove_requires_yes() {
+    let mut cmd = base_cmd("http://127.0.0.1:9/api/v1");
+    cmd.arg("workspaces")
+        .arg("members")
+        .arg("remove")
+        .arg("ws_1")
+        .arg("user_1");
     cmd.assert().failure().stderr(contains("without --yes"));
 }

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -8,7 +8,7 @@ Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 ## Coverage Summary
 
 - Official OpenAPI endpoints: `51` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `44 / 51` (`86.3%`).
+- SDK implementation coverage (`src/api` + domain client): `51 / 51` (`100.0%`).
 - Live integration coverage (`tests/integration`): `24 / 51` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
@@ -16,7 +16,7 @@ Drift review note:
 
 - Official text-to-speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.tts().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
 - Upstream added `GET /generation/content`, now exposed as `client.get_generation_content(...)` / `client.management().get_generation_content(...)`.
-- Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK follow-up is tracked in `#190`.
+- Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK and CLI now expose them; live management-key validation remains pending.
 
 Legend:
 
@@ -44,7 +44,7 @@ Legend:
 | `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | Yes | Keep |
 | `GET /generation` | `client.get_generation(...)` / `client.management().get_generation(...)` | Yes | Path | No | P2 |
 | `GET /generation/content` | `client.get_generation_content(...)` / `client.management().get_generation_content(...)` | Yes | Path | No | P2 |
-| `GET /guardrails` | `client.management().list_guardrails(...)` | Yes | Path | Yes | Keep |
+| `GET /guardrails` | `client.management().list_guardrails(...)` / `client.management().list_guardrails_in_workspace(...)` | Yes | Path | Yes | Keep |
 | `POST /guardrails` | `client.management().create_guardrail(...)` | Yes | Contract | Yes | Keep |
 | `GET /guardrails/{id}` | `client.management().get_guardrail(...)` | Yes | Contract | Yes | Keep |
 | `PATCH /guardrails/{id}` | `client.management().update_guardrail(...)` | Yes | Contract | Yes | Keep |
@@ -58,8 +58,8 @@ Legend:
 | `GET /guardrails/assignments/keys` | `client.management().list_key_assignments(...)` | Yes | Path | No | P1 |
 | `GET /guardrails/assignments/members` | `client.management().list_member_assignments(...)` | Yes | Path | No | P1 |
 | `GET /key` | `client.get_current_api_key_info()` / `client.management().get_current_api_key_info()` | Yes | Contract | Yes | Keep |
-| `GET /keys` | `client.management().list_api_keys(...)` | Yes | Path | Yes | Keep |
-| `POST /keys` | `client.create_api_key(...)` / `client.management().create_api_key(...)` | Yes | Path | Yes | Keep |
+| `GET /keys` | `client.management().list_api_keys(...)` / `client.management().list_api_keys_in_workspace(...)` | Yes | Path | Yes | Keep |
+| `POST /keys` | `client.create_api_key(...)` / `client.create_api_key_in_workspace(...)` / `client.management().create_api_key(...)` / `client.management().create_api_key_in_workspace(...)` | Yes | Path | Yes | Keep |
 | `GET /keys/{hash}` | `client.get_api_key(...)` / `client.management().get_api_key(...)` | Yes | Path | Yes | Keep |
 | `PATCH /keys/{hash}` | `client.update_api_key(...)` / `client.management().update_api_key(...)` | Yes | Path | Yes | Keep |
 | `DELETE /keys/{hash}` | `client.delete_api_key(...)` / `client.management().delete_api_key(...)` | Yes | Path | Yes | Keep |
@@ -69,21 +69,21 @@ Legend:
 | `GET /models/user` | `client.list_models_for_user()` / `client.models().list_user_models()` | Yes | Path | Yes | Keep |
 | `GET /organization/members` | `client.management().list_organization_members(...)` | Yes | Path | Yes | Keep |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
-| `GET /workspaces` | Tracked in `#190` | No | None | No | P1 |
-| `GET /workspaces/{id}` | Tracked in `#190` | No | None | No | P1 |
+| `GET /workspaces` | `client.management().list_workspaces(...)` | Yes | Path | No | P1 |
+| `GET /workspaces/{id}` | `client.management().get_workspace(...)` | Yes | Path | No | P1 |
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
 | `POST /audio/speech` | `client.tts().create(...)` | Yes | Path | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
-| `POST /workspaces` | Tracked in `#190` | No | None | No | P1 |
-| `POST /workspaces/{id}/members/add` | Tracked in `#190` | No | None | No | P1 |
-| `POST /workspaces/{id}/members/remove` | Tracked in `#190` | No | None | No | P1 |
+| `POST /workspaces` | `client.management().create_workspace(...)` | Yes | Path | No | P1 |
+| `POST /workspaces/{id}/members/add` | `client.management().add_workspace_members(...)` | Yes | Path | No | P1 |
+| `POST /workspaces/{id}/members/remove` | `client.management().remove_workspace_members(...)` | Yes | Path | No | P1 |
 | `GET /videos/models` | `client.videos().list_models()` | Yes | Path | No | P2 |
 | `GET /videos/{jobId}` | `client.videos().get_generation(...)` | Yes | Path | No | P2 |
 | `GET /videos/{jobId}/content` | `client.videos().get_content(...)` | Yes | Path | No | P2 |
-| `PATCH /workspaces/{id}` | Tracked in `#190` | No | None | No | P1 |
-| `DELETE /workspaces/{id}` | Tracked in `#190` | No | None | No | P1 |
+| `PATCH /workspaces/{id}` | `client.management().update_workspace(...)` | Yes | Path | No | P1 |
+| `DELETE /workspaces/{id}` | `client.management().delete_workspace(...)` | Yes | Path | No | P1 |
 
 ## Supplemental (Legacy)
 
@@ -100,7 +100,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 2. P1: add management-key live smoke coverage for `/activity`.
 3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
 4. P1/P2: add low-cost live or smoke coverage for `/audio/speech` and `/videos*` once stable fixtures and cost controls are defined.
-5. P1: add typed workspace management support and then cover `/workspaces*` in unit and live management-key validation (`#190`).
+5. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
 
 ## Reproduce Snapshot
 

--- a/examples/list_workspaces.rs
+++ b/examples/list_workspaces.rs
@@ -1,0 +1,23 @@
+use openrouter_rs::{OpenRouterClient, types::PaginationOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let management_key =
+        std::env::var("OPENROUTER_MANAGEMENT_KEY").expect("OPENROUTER_MANAGEMENT_KEY must be set");
+
+    let client = OpenRouterClient::builder()
+        .management_key(management_key)
+        .build()?;
+
+    let workspaces = client
+        .management()
+        .list_workspaces(Some(PaginationOptions::with_offset_and_limit(0, 25)))
+        .await?;
+
+    println!("workspace count: {}", workspaces.total_count);
+    for workspace in workspaces.data {
+        println!("{} ({})", workspace.name, workspace.slug);
+    }
+
+    Ok(())
+}

--- a/src/api/api_keys.rs
+++ b/src/api/api_keys.rs
@@ -17,6 +17,8 @@ pub struct ApiKey {
     pub updated_at: Option<String>,
     pub hash: Option<String>,
     pub key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
 }
 
 #[derive(Serialize, Debug)]
@@ -74,7 +76,10 @@ pub struct RateLimit {
 #[derive(Serialize)]
 struct CreateApiKeyRequest {
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -90,6 +95,8 @@ struct ListApiKeysQuery {
     offset: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     include_disabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
 }
 
 /// Get information on the API key associated with the current authentication session
@@ -151,12 +158,13 @@ pub async fn list_api_keys(
     include_disabled: Option<bool>,
 ) -> Result<Vec<ApiKey>, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
-    list_api_keys_with_client(
+    list_api_keys_in_workspace_with_client(
         &http_client,
         base_url,
         management_key,
         pagination,
         include_disabled,
+        None,
     )
     .await
 }
@@ -168,16 +176,58 @@ pub(crate) async fn list_api_keys_with_client(
     pagination: Option<PaginationOptions>,
     include_disabled: Option<bool>,
 ) -> Result<Vec<ApiKey>, OpenRouterError> {
+    list_api_keys_in_workspace_with_client(
+        http_client,
+        base_url,
+        management_key,
+        pagination,
+        include_disabled,
+        None,
+    )
+    .await
+}
+
+pub async fn list_api_keys_in_workspace(
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+    include_disabled: Option<bool>,
+    workspace_id: Option<&str>,
+) -> Result<Vec<ApiKey>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_api_keys_in_workspace_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        pagination,
+        include_disabled,
+        workspace_id,
+    )
+    .await
+}
+
+pub(crate) async fn list_api_keys_in_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+    include_disabled: Option<bool>,
+    workspace_id: Option<&str>,
+) -> Result<Vec<ApiKey>, OpenRouterError> {
     let url = format!("{base_url}/keys");
     let query = ListApiKeysQuery {
         offset: pagination.and_then(|p| p.offset),
         include_disabled,
+        workspace_id: workspace_id.map(ToOwned::to_owned),
     };
     let req = transport_request::with_bearer_auth(
         transport_request::get(http_client, &url),
         management_key,
     );
-    let response = if query.offset.is_none() && query.include_disabled.is_none() {
+    let response = if query.offset.is_none()
+        && query.include_disabled.is_none()
+        && query.workspace_id.is_none()
+    {
         req.send().await?
     } else {
         req.query(&query).send().await?
@@ -212,7 +262,15 @@ pub async fn create_api_key(
     limit: Option<f64>,
 ) -> Result<ApiKey, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
-    create_api_key_with_client(&http_client, base_url, management_key, name, limit).await
+    create_api_key_in_workspace_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        name,
+        limit,
+        None,
+    )
+    .await
 }
 
 pub(crate) async fn create_api_key_with_client(
@@ -222,10 +280,49 @@ pub(crate) async fn create_api_key_with_client(
     name: &str,
     limit: Option<f64>,
 ) -> Result<ApiKey, OpenRouterError> {
+    create_api_key_in_workspace_with_client(
+        http_client,
+        base_url,
+        management_key,
+        name,
+        limit,
+        None,
+    )
+    .await
+}
+
+pub async fn create_api_key_in_workspace(
+    base_url: &str,
+    management_key: &str,
+    name: &str,
+    limit: Option<f64>,
+    workspace_id: Option<&str>,
+) -> Result<ApiKey, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_api_key_in_workspace_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        name,
+        limit,
+        workspace_id,
+    )
+    .await
+}
+
+pub(crate) async fn create_api_key_in_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    name: &str,
+    limit: Option<f64>,
+    workspace_id: Option<&str>,
+) -> Result<ApiKey, OpenRouterError> {
     let url = format!("{base_url}/keys");
     let request = CreateApiKeyRequest {
         name: name.to_string(),
         limit,
+        workspace_id: workspace_id.map(ToOwned::to_owned),
     };
 
     let response = transport_request::with_bearer_auth(

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -30,6 +30,8 @@ pub struct Guardrail {
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
 }
 
 /// Paginated guardrails list response.
@@ -63,6 +65,9 @@ pub struct CreateGuardrailRequest {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     enforce_zdr: Option<bool>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
 }
 
 impl CreateGuardrailRequestBuilder {
@@ -194,6 +199,16 @@ pub struct UnassignedCountResponse {
     pub unassigned_count: f64,
 }
 
+#[derive(Serialize)]
+struct ListGuardrailsQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    offset: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
+}
+
 fn with_pagination(url: String, pagination: Option<PaginationOptions>) -> String {
     let params = pagination
         .map(PaginationOptions::to_query_pairs)
@@ -215,7 +230,14 @@ pub async fn list_guardrails(
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailListResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
-    list_guardrails_with_client(&http_client, base_url, management_key, pagination).await
+    list_guardrails_in_workspace_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        pagination,
+        None,
+    )
+    .await
 }
 
 pub(crate) async fn list_guardrails_with_client(
@@ -224,13 +246,56 @@ pub(crate) async fn list_guardrails_with_client(
     management_key: &str,
     pagination: Option<PaginationOptions>,
 ) -> Result<GuardrailListResponse, OpenRouterError> {
-    let url = with_pagination(format!("{base_url}/guardrails"), pagination);
-    let response = transport_request::with_bearer_auth(
+    list_guardrails_in_workspace_with_client(
+        http_client,
+        base_url,
+        management_key,
+        pagination,
+        None,
+    )
+    .await
+}
+
+pub async fn list_guardrails_in_workspace(
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+    workspace_id: Option<&str>,
+) -> Result<GuardrailListResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_guardrails_in_workspace_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        pagination,
+        workspace_id,
+    )
+    .await
+}
+
+pub(crate) async fn list_guardrails_in_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+    workspace_id: Option<&str>,
+) -> Result<GuardrailListResponse, OpenRouterError> {
+    let url = format!("{base_url}/guardrails");
+    let query = ListGuardrailsQuery {
+        offset: pagination.and_then(|p| p.offset),
+        limit: pagination.and_then(|p| p.limit),
+        workspace_id: workspace_id.map(ToOwned::to_owned),
+    };
+    let req = transport_request::with_bearer_auth(
         transport_request::get(http_client, &url),
         management_key,
-    )
-    .send()
-    .await?;
+    );
+    let response =
+        if query.offset.is_none() && query.limit.is_none() && query.workspace_id.is_none() {
+            req.send().await?
+        } else {
+            req.query(&query).send().await?
+        };
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "guardrail list").await

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,7 +12,7 @@
 //! - `client.tts()` -> [`tts`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
-//! - `client.management()` -> [`api_keys`], [`auth`], [`credits`], [`generation`], [`guardrails`], [`organization`]
+//! - `client.management()` -> [`api_keys`], [`auth`], [`credits`], [`generation`], [`guardrails`], [`organization`], [`workspaces`]
 //! - `client.legacy()` -> [`legacy`] (feature `legacy-completions`)
 //!
 //! Endpoint families currently implemented here:
@@ -29,6 +29,7 @@
 //! - credits, Coinbase charge creation, generation lookup/content, and activity
 //! - guardrails and guardrail assignments
 //! - organization member listing
+//! - workspace CRUD and membership management
 //! - structured API error payloads
 //!
 //! ## Quick Examples
@@ -128,6 +129,7 @@ pub mod rerank;
 pub mod responses;
 pub mod tts;
 pub mod videos;
+pub mod workspaces;
 
 #[cfg(feature = "legacy-completions")]
 pub mod legacy;

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1,0 +1,401 @@
+use derive_builder::Builder;
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use urlencoding::encode;
+
+use crate::{
+    error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
+    types::{ApiResponse, PaginationOptions},
+};
+
+#[derive(Serialize)]
+struct ListWorkspacesQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    offset: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Workspace {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_text_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_image_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_provider_sort: Option<String>,
+    pub is_observability_io_logging_enabled: bool,
+    pub is_observability_broadcast_enabled: bool,
+    pub is_data_discount_logging_enabled: bool,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WorkspaceListResponse {
+    pub data: Vec<Workspace>,
+    pub total_count: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct CreateWorkspaceRequest {
+    #[builder(setter(into))]
+    pub name: String,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_text_model: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_image_model: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_provider_sort: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_data_discount_logging_enabled: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_observability_broadcast_enabled: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_observability_io_logging_enabled: Option<bool>,
+}
+
+impl CreateWorkspaceRequest {
+    pub fn builder() -> CreateWorkspaceRequestBuilder {
+        CreateWorkspaceRequestBuilder::default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct UpdateWorkspaceRequest {
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_text_model: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_image_model: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_provider_sort: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_data_discount_logging_enabled: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_observability_broadcast_enabled: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_observability_io_logging_enabled: Option<bool>,
+}
+
+impl UpdateWorkspaceRequest {
+    pub fn builder() -> UpdateWorkspaceRequestBuilder {
+        UpdateWorkspaceRequestBuilder::default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct DeleteWorkspaceResponse {
+    deleted: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WorkspaceMember {
+    pub id: String,
+    pub workspace_id: String,
+    pub user_id: String,
+    pub role: String,
+    pub created_at: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct WorkspaceMembersRequest {
+    pub user_ids: Vec<String>,
+}
+
+impl WorkspaceMembersRequest {
+    pub fn builder() -> WorkspaceMembersRequestBuilder {
+        WorkspaceMembersRequestBuilder::default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WorkspaceMembersAddResponse {
+    pub added_count: f64,
+    pub data: Vec<WorkspaceMember>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WorkspaceMembersRemoveResponse {
+    pub removed_count: f64,
+}
+
+pub async fn list_workspaces(
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<WorkspaceListResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_workspaces_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_workspaces_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<WorkspaceListResponse, OpenRouterError> {
+    let url = format!("{base_url}/workspaces");
+    let query = ListWorkspacesQuery {
+        offset: pagination.and_then(|p| p.offset),
+        limit: pagination.and_then(|p| p.limit),
+    };
+    let req = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    );
+    let response = if query.offset.is_none() && query.limit.is_none() {
+        req.send().await?
+    } else {
+        req.query(&query).send().await?
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "workspace list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn create_workspace(
+    base_url: &str,
+    management_key: &str,
+    request: &CreateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_workspace_with_client(&http_client, base_url, management_key, request).await
+}
+
+pub(crate) async fn create_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    request: &CreateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    let url = format!("{base_url}/workspaces");
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<Workspace> =
+            transport_response::parse_json_response(response, "workspace creation").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn get_workspace(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<Workspace, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_workspace_with_client(&http_client, base_url, management_key, id).await
+}
+
+pub(crate) async fn get_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<Workspace, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}", encode(id));
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<Workspace> =
+            transport_response::parse_json_response(response, "workspace lookup").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn update_workspace(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    update_workspace_with_client(&http_client, base_url, management_key, id, request).await
+}
+
+pub(crate) async fn update_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}", encode(id));
+    let response = transport_request::with_bearer_auth(
+        transport_request::patch(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<Workspace> =
+            transport_response::parse_json_response(response, "workspace update").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn delete_workspace(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<bool, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_workspace_with_client(&http_client, base_url, management_key, id).await
+}
+
+pub(crate) async fn delete_workspace_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<bool, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}", encode(id));
+    let response = transport_request::with_bearer_auth(
+        transport_request::delete(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: DeleteWorkspaceResponse =
+            transport_response::parse_json_response(response, "workspace deletion").await?;
+        Ok(payload.deleted)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn add_workspace_members(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &WorkspaceMembersRequest,
+) -> Result<WorkspaceMembersAddResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    add_workspace_members_with_client(&http_client, base_url, management_key, id, request).await
+}
+
+pub(crate) async fn add_workspace_members_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &WorkspaceMembersRequest,
+) -> Result<WorkspaceMembersAddResponse, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}/members/add", encode(id));
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "workspace member bulk add").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn remove_workspace_members(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &WorkspaceMembersRequest,
+) -> Result<WorkspaceMembersRemoveResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    remove_workspace_members_with_client(&http_client, base_url, management_key, id, request).await
+}
+
+pub(crate) async fn remove_workspace_members_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &WorkspaceMembersRequest,
+) -> Result<WorkspaceMembersRemoveResponse, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}/members/remove", encode(id));
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "workspace member bulk removal").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use crate::api::legacy::completion;
 use crate::{
     api::{
         api_keys, auth, chat, credits, discovery, embeddings, generation, guardrails, messages,
-        models, organization, rerank, responses, tts, videos,
+        models, organization, rerank, responses, tts, videos, workspaces,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -213,6 +213,28 @@ impl OpenRouterClient {
         }
     }
 
+    /// Creates a new API key in the specified workspace. Requires a management API key.
+    pub async fn create_api_key_in_workspace(
+        &self,
+        name: &str,
+        limit: Option<f64>,
+        workspace_id: Option<&str>,
+    ) -> Result<api_keys::ApiKey, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            api_keys::create_api_key_in_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                name,
+                limit,
+                workspace_id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Get information on the API key associated with the current authentication session.
     ///
     /// # Returns
@@ -342,6 +364,27 @@ impl OpenRouterClient {
         }
     }
 
+    async fn list_api_keys_in_workspace_paginated(
+        &self,
+        pagination: Option<PaginationOptions>,
+        include_disabled: Option<bool>,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<api_keys::ApiKey>, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            api_keys::list_api_keys_in_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+                include_disabled,
+                workspace_id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Returns details about a specific API key. Requires a management API key.
     ///
     /// # Arguments
@@ -437,6 +480,26 @@ impl OpenRouterClient {
                 &self.base_url,
                 management_key,
                 pagination,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List guardrails scoped to a workspace (`GET /guardrails?workspace_id=...`).
+    pub async fn list_guardrails_in_workspace(
+        &self,
+        pagination: Option<PaginationOptions>,
+        workspace_id: Option<&str>,
+    ) -> Result<guardrails::GuardrailListResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            guardrails::list_guardrails_in_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+                workspace_id,
             )
             .await
         } else {
@@ -1515,6 +1578,132 @@ impl OpenRouterClient {
             Err(OpenRouterError::KeyNotConfigured)
         }
     }
+
+    /// List workspaces for the configured management key.
+    pub async fn list_workspaces(
+        &self,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<workspaces::WorkspaceListResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::list_workspaces_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Create a workspace (`POST /workspaces`).
+    pub async fn create_workspace(
+        &self,
+        request: &workspaces::CreateWorkspaceRequest,
+    ) -> Result<workspaces::Workspace, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::create_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Get a workspace (`GET /workspaces/{id}`).
+    pub async fn get_workspace(&self, id: &str) -> Result<workspaces::Workspace, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::get_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Update a workspace (`PATCH /workspaces/{id}`).
+    pub async fn update_workspace(
+        &self,
+        id: &str,
+        request: &workspaces::UpdateWorkspaceRequest,
+    ) -> Result<workspaces::Workspace, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::update_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Delete a workspace (`DELETE /workspaces/{id}`).
+    pub async fn delete_workspace(&self, id: &str) -> Result<bool, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::delete_workspace_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Add multiple organization members to a workspace (`POST /workspaces/{id}/members/add`).
+    pub async fn add_workspace_members(
+        &self,
+        id: &str,
+        request: &workspaces::WorkspaceMembersRequest,
+    ) -> Result<workspaces::WorkspaceMembersAddResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::add_workspace_members_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Remove multiple organization members from a workspace (`POST /workspaces/{id}/members/remove`).
+    pub async fn remove_workspace_members(
+        &self,
+        id: &str,
+        request: &workspaces::WorkspaceMembersRequest,
+    ) -> Result<workspaces::WorkspaceMembersRemoveResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::remove_workspace_members_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
 }
 
 /// Domain client for chat completions.
@@ -1786,6 +1975,18 @@ impl<'a> ManagementClient<'a> {
         self.client.create_api_key(name, limit).await
     }
 
+    /// Create a managed API key in a workspace (`POST /keys`).
+    pub async fn create_api_key_in_workspace(
+        &self,
+        name: &str,
+        limit: Option<f64>,
+        workspace_id: Option<&str>,
+    ) -> Result<api_keys::ApiKey, OpenRouterError> {
+        self.client
+            .create_api_key_in_workspace(name, limit, workspace_id)
+            .await
+    }
+
     /// Get current key session info (`GET /key`).
     pub async fn get_current_api_key_info(
         &self,
@@ -1819,6 +2020,18 @@ impl<'a> ManagementClient<'a> {
     ) -> Result<Vec<api_keys::ApiKey>, OpenRouterError> {
         self.client
             .list_api_keys_paginated(pagination, include_disabled)
+            .await
+    }
+
+    /// List API keys scoped to a workspace (`GET /keys?workspace_id=...`).
+    pub async fn list_api_keys_in_workspace(
+        &self,
+        pagination: Option<PaginationOptions>,
+        include_disabled: Option<bool>,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<api_keys::ApiKey>, OpenRouterError> {
+        self.client
+            .list_api_keys_in_workspace_paginated(pagination, include_disabled, workspace_id)
             .await
     }
 
@@ -1890,6 +2103,17 @@ impl<'a> ManagementClient<'a> {
         pagination: Option<PaginationOptions>,
     ) -> Result<guardrails::GuardrailListResponse, OpenRouterError> {
         self.client.list_guardrails(pagination).await
+    }
+
+    /// List guardrails scoped to a workspace (`GET /guardrails?workspace_id=...`).
+    pub async fn list_guardrails_in_workspace(
+        &self,
+        pagination: Option<PaginationOptions>,
+        workspace_id: Option<&str>,
+    ) -> Result<guardrails::GuardrailListResponse, OpenRouterError> {
+        self.client
+            .list_guardrails_in_workspace(pagination, workspace_id)
+            .await
     }
 
     /// Create a guardrail (`POST /guardrails`).
@@ -2005,6 +2229,59 @@ impl<'a> ManagementClient<'a> {
         pagination: Option<PaginationOptions>,
     ) -> Result<organization::OrganizationMembersResponse, OpenRouterError> {
         self.client.list_organization_members(pagination).await
+    }
+
+    /// List workspaces (`GET /workspaces`).
+    pub async fn list_workspaces(
+        &self,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<workspaces::WorkspaceListResponse, OpenRouterError> {
+        self.client.list_workspaces(pagination).await
+    }
+
+    /// Create a workspace (`POST /workspaces`).
+    pub async fn create_workspace(
+        &self,
+        request: &workspaces::CreateWorkspaceRequest,
+    ) -> Result<workspaces::Workspace, OpenRouterError> {
+        self.client.create_workspace(request).await
+    }
+
+    /// Get a workspace (`GET /workspaces/{id}`).
+    pub async fn get_workspace(&self, id: &str) -> Result<workspaces::Workspace, OpenRouterError> {
+        self.client.get_workspace(id).await
+    }
+
+    /// Update a workspace (`PATCH /workspaces/{id}`).
+    pub async fn update_workspace(
+        &self,
+        id: &str,
+        request: &workspaces::UpdateWorkspaceRequest,
+    ) -> Result<workspaces::Workspace, OpenRouterError> {
+        self.client.update_workspace(id, request).await
+    }
+
+    /// Delete a workspace (`DELETE /workspaces/{id}`).
+    pub async fn delete_workspace(&self, id: &str) -> Result<bool, OpenRouterError> {
+        self.client.delete_workspace(id).await
+    }
+
+    /// Add workspace members (`POST /workspaces/{id}/members/add`).
+    pub async fn add_workspace_members(
+        &self,
+        id: &str,
+        request: &workspaces::WorkspaceMembersRequest,
+    ) -> Result<workspaces::WorkspaceMembersAddResponse, OpenRouterError> {
+        self.client.add_workspace_members(id, request).await
+    }
+
+    /// Remove workspace members (`POST /workspaces/{id}/members/remove`).
+    pub async fn remove_workspace_members(
+        &self,
+        id: &str,
+        request: &workspaces::WorkspaceMembersRequest,
+    ) -> Result<workspaces::WorkspaceMembersRemoveResponse, OpenRouterError> {
+        self.client.remove_workspace_members(id, request).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@
 //! | Generation Content | ✅ | [`api::generation`] |
 //! | Authentication | ✅ | [`api::auth`] |
 //! | Guardrails | ✅ | [`api::guardrails`] |
+//! | Workspaces | ✅ | [`api::workspaces`] |
 //!
 //! ## 📖 Examples
 //!

--- a/tests/unit/api_keys.rs
+++ b/tests/unit/api_keys.rs
@@ -298,6 +298,169 @@ async fn test_list_api_keys_serializes_pagination_query() {
     server.join().expect("server thread should finish");
 }
 
+#[test]
+fn test_api_key_deserializes_workspace_id() {
+    let raw = r#"{
+        "name":"ops",
+        "label":"Operations",
+        "hash":"key_hash_1",
+        "workspace_id":"ws_123"
+    }"#;
+
+    let parsed: api_keys::ApiKey = serde_json::from_str(raw).expect("api key should deserialize");
+    assert_eq!(parsed.workspace_id.as_deref(), Some("ws_123"));
+}
+
+#[tokio::test]
+async fn test_list_api_keys_serializes_workspace_filter_query() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_line = String::from_utf8_lossy(&request_bytes)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        tx.send(request_line)
+            .expect("server should send request line");
+
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"data\":[]}";
+        stream
+            .write_all(response)
+            .expect("server should write response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let response = api_keys::list_api_keys_in_workspace(
+        &base_url,
+        "mgmt-key",
+        Some(PaginationOptions::with_offset(7)),
+        Some(true),
+        Some("ws_123"),
+    )
+    .await
+    .expect("list_api_keys_in_workspace should succeed");
+    assert!(response.is_empty());
+
+    let request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request line");
+    assert_eq!(
+        request_line,
+        "GET /api/v1/keys?offset=7&include_disabled=true&workspace_id=ws_123 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_api_keys_serializes_workspace_filter_without_other_query_params() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<String>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+
+        loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let request_line = String::from_utf8_lossy(&request_bytes)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        tx.send(request_line)
+            .expect("server should send request line");
+
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"data\":[]}";
+        stream
+            .write_all(response)
+            .expect("server should write response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let response =
+        api_keys::list_api_keys_in_workspace(&base_url, "mgmt-key", None, None, Some("ws_456"))
+            .await
+            .expect("list_api_keys_in_workspace should succeed");
+    assert!(response.is_empty());
+
+    let request_line = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request line");
+    assert_eq!(
+        request_line,
+        "GET /api/v1/keys?workspace_id=ws_456 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_create_api_key_serializes_workspace_id() {
+    let (base_url, rx, server) =
+        spawn_json_server(r#"{"data":{"name":"ops","hash":"key_hash_1","workspace_id":"ws_123"}}"#);
+
+    let response = api_keys::create_api_key_in_workspace(
+        &base_url,
+        "mgmt-key",
+        "ops",
+        Some(25.0),
+        Some("ws_123"),
+    )
+    .await
+    .expect("create_api_key_in_workspace should succeed");
+    assert_eq!(response.workspace_id.as_deref(), Some("ws_123"));
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "POST /api/v1/keys HTTP/1.1");
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(body["name"], "ops");
+    assert_eq!(body["limit"], 25.0);
+    assert_eq!(body["workspace_id"], "ws_123");
+
+    server.join().expect("server thread should finish");
+}
+
 #[tokio::test]
 async fn test_create_api_key_sends_path_body_and_auth_header() {
     let (base_url, rx, server) =

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -8,7 +8,10 @@ use std::{
 
 use openrouter_rs::{
     OpenRouterClient,
-    api::{auth, chat, credits, embeddings, guardrails, messages, rerank, responses, tts, videos},
+    api::{
+        auth, chat, credits, embeddings, guardrails, messages, rerank, responses, tts, videos,
+        workspaces,
+    },
     error::OpenRouterError,
     types::{ModelCategory, PaginationOptions, Role, SupportedParameters},
 };
@@ -472,6 +475,18 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         .member_user_ids(vec!["user_1".to_string()])
         .build()
         .expect("bulk member request should build");
+    let create_workspace_request = workspaces::CreateWorkspaceRequest::builder()
+        .name("Production")
+        .build()
+        .expect("create workspace request should build");
+    let update_workspace_request = workspaces::UpdateWorkspaceRequest::builder()
+        .name("Updated")
+        .build()
+        .expect("update workspace request should build");
+    let workspace_members_request = workspaces::WorkspaceMembersRequest::builder()
+        .user_ids(vec!["user_1".to_string()])
+        .build()
+        .expect("workspace members request should build");
 
     assert!(matches!(
         client.management().get_current_api_key_info().await,
@@ -499,7 +514,21 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(
+        client
+            .management()
+            .list_api_keys_in_workspace(None, Some(true), Some("ws_123"))
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
         client.management().get_api_key("hash").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .create_api_key_in_workspace("ops", Some(1.0), Some("ws_123"))
+            .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(
@@ -534,6 +563,13 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
     ));
     assert!(matches!(
         client.management().list_guardrails(None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .list_guardrails_in_workspace(None, Some("ws_123"))
+            .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(
@@ -610,6 +646,46 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
     ));
     assert!(matches!(
         client.management().list_organization_members(None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().list_workspaces(None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .create_workspace(&create_workspace_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().get_workspace("ws_123").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .update_workspace("ws_123", &update_workspace_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().delete_workspace("ws_123").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .add_workspace_members("ws_123", &workspace_members_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .remove_workspace_members("ws_123", &workspace_members_request)
+            .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
 }
@@ -839,6 +915,42 @@ async fn test_management_domain_list_organization_members_without_pagination_del
         captured.request_line,
         "GET /api/v1/organization/members HTTP/1.1"
     );
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("authorization: bearer management-key")
+            || captured
+                .request_text
+                .to_ascii_lowercase()
+                .contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_management_domain_list_workspaces_without_pagination_delegates() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .management_key("management-key")
+        .build()
+        .expect("client should build");
+
+    let response = client
+        .management()
+        .list_workspaces(None)
+        .await
+        .expect("list_workspaces should succeed");
+    assert_eq!(response.total_count, 0.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "GET /api/v1/workspaces HTTP/1.1");
     assert!(
         captured
             .request_text

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -118,6 +118,7 @@ fn test_create_guardrail_request_serialization() {
             "anthropic/claude-sonnet-4".to_string(),
         ])
         .enforce_zdr(true)
+        .workspace_id("ws_123")
         .build()
         .expect("create guardrail request should build");
 
@@ -129,6 +130,7 @@ fn test_create_guardrail_request_serialization() {
     assert_eq!(value["allowed_providers"][0], "openai");
     assert_eq!(value["allowed_models"][1], "anthropic/claude-sonnet-4");
     assert_eq!(value["enforce_zdr"], true);
+    assert_eq!(value["workspace_id"], "ws_123");
 }
 
 #[test]
@@ -158,6 +160,7 @@ fn test_guardrail_response_deserialization() {
             "allowed_providers": ["openai"],
             "allowed_models": ["openai/gpt-4.1"],
             "enforce_zdr": true,
+            "workspace_id": "ws_123",
             "created_at": "2025-01-01T00:00:00.000Z",
             "updated_at": "2025-01-02T00:00:00.000Z"
         }
@@ -169,6 +172,7 @@ fn test_guardrail_response_deserialization() {
     assert_eq!(parsed.data.name, "Production Guardrail");
     assert_eq!(parsed.data.allowed_providers.unwrap_or_default().len(), 1);
     assert_eq!(parsed.data.enforce_zdr, Some(true));
+    assert_eq!(parsed.data.workspace_id.as_deref(), Some("ws_123"));
 }
 
 #[test]
@@ -183,6 +187,7 @@ fn test_guardrail_list_and_assignment_deserialization() {
             "allowed_providers": ["openai"],
             "allowed_models": ["openai/gpt-4.1"],
             "enforce_zdr": true,
+            "workspace_id": "ws_123",
             "created_at": "2025-01-01T00:00:00.000Z",
             "updated_at": "2025-01-02T00:00:00.000Z"
         }],
@@ -269,6 +274,27 @@ async fn test_list_guardrails_with_pagination_and_auth_header() {
             || request_lower.contains("authorization:bearer mgmt-key"),
         "authorization header should include management key, request:\n{}",
         captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_guardrails_with_workspace_filter_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+
+    let result =
+        guardrails::list_guardrails_in_workspace(&base_url, "mgmt-key", None, Some("ws_123"))
+            .await
+            .expect("list guardrails should succeed");
+    assert_eq!(result.total_count, 0.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/guardrails?workspace_id=ws_123 HTTP/1.1"
     );
 
     server.join().expect("server thread should finish");

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -32,3 +32,4 @@ pub mod tool_builder;
 pub mod tts;
 pub mod unified_stream;
 pub mod videos;
+pub mod workspaces;

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -1,0 +1,419 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::{
+    api::workspaces::{
+        self, CreateWorkspaceRequest, UpdateWorkspaceRequest, Workspace, WorkspaceListResponse,
+        WorkspaceMembersAddResponse, WorkspaceMembersRemoveResponse, WorkspaceMembersRequest,
+    },
+    types::{ApiResponse, PaginationOptions},
+};
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send captured request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+#[test]
+fn test_create_workspace_request_serialization() {
+    let request = CreateWorkspaceRequest::builder()
+        .name("Production")
+        .slug("production")
+        .description("Production environment")
+        .default_text_model("openai/gpt-4o")
+        .default_image_model("openai/dall-e-3")
+        .default_provider_sort("price")
+        .is_data_discount_logging_enabled(true)
+        .is_observability_broadcast_enabled(false)
+        .is_observability_io_logging_enabled(false)
+        .build()
+        .expect("create workspace request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["name"], "Production");
+    assert_eq!(value["slug"], "production");
+    assert_eq!(value["description"], "Production environment");
+    assert_eq!(value["default_text_model"], "openai/gpt-4o");
+    assert_eq!(value["default_image_model"], "openai/dall-e-3");
+    assert_eq!(value["default_provider_sort"], "price");
+    assert_eq!(value["is_data_discount_logging_enabled"], true);
+    assert_eq!(value["is_observability_broadcast_enabled"], false);
+    assert_eq!(value["is_observability_io_logging_enabled"], false);
+}
+
+#[test]
+fn test_update_workspace_request_serialization() {
+    let request = UpdateWorkspaceRequest::builder()
+        .name("Updated")
+        .slug("updated")
+        .is_data_discount_logging_enabled(false)
+        .build()
+        .expect("update workspace request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["name"], "Updated");
+    assert_eq!(value["slug"], "updated");
+    assert_eq!(value["is_data_discount_logging_enabled"], false);
+    assert!(value.get("description").is_none());
+}
+
+#[test]
+fn test_workspace_response_deserialization() {
+    let raw = r#"{
+        "data": {
+            "id": "ws_123",
+            "name": "Production",
+            "slug": "production",
+            "description": "Production environment",
+            "default_text_model": "openai/gpt-4o",
+            "default_image_model": "openai/dall-e-3",
+            "default_provider_sort": "price",
+            "is_observability_io_logging_enabled": false,
+            "is_observability_broadcast_enabled": false,
+            "is_data_discount_logging_enabled": true,
+            "created_at": "2025-01-01T00:00:00.000Z",
+            "updated_at": "2025-01-02T00:00:00.000Z",
+            "created_by": "user_123"
+        }
+    }"#;
+
+    let parsed: ApiResponse<Workspace> =
+        serde_json::from_str(raw).expect("workspace response should deserialize");
+    assert_eq!(parsed.data.id, "ws_123");
+    assert_eq!(parsed.data.slug, "production");
+    assert_eq!(parsed.data.created_by.as_deref(), Some("user_123"));
+}
+
+#[test]
+fn test_workspace_list_and_member_response_deserialization() {
+    let list_raw = r#"{
+        "data": [{
+            "id": "ws_123",
+            "name": "Production",
+            "slug": "production",
+            "description": "Production environment",
+            "default_text_model": "openai/gpt-4o",
+            "default_image_model": "openai/dall-e-3",
+            "default_provider_sort": "price",
+            "is_observability_io_logging_enabled": false,
+            "is_observability_broadcast_enabled": false,
+            "is_data_discount_logging_enabled": true,
+            "created_at": "2025-01-01T00:00:00.000Z",
+            "updated_at": "2025-01-02T00:00:00.000Z",
+            "created_by": "user_123"
+        }],
+        "total_count": 1
+    }"#;
+
+    let add_raw = r#"{
+        "added_count": 1,
+        "data": [{
+            "id": "wm_1",
+            "workspace_id": "ws_123",
+            "user_id": "user_123",
+            "role": "member",
+            "created_at": "2025-01-01T00:00:00.000Z"
+        }]
+    }"#;
+
+    let remove_raw = r#"{"removed_count":2}"#;
+
+    let list: WorkspaceListResponse =
+        serde_json::from_str(list_raw).expect("workspace list should deserialize");
+    let add: WorkspaceMembersAddResponse =
+        serde_json::from_str(add_raw).expect("workspace member add should deserialize");
+    let remove: WorkspaceMembersRemoveResponse =
+        serde_json::from_str(remove_raw).expect("workspace member remove should deserialize");
+
+    assert_eq!(list.total_count, 1.0);
+    assert_eq!(add.added_count, 1.0);
+    assert_eq!(add.data[0].workspace_id, "ws_123");
+    assert_eq!(remove.removed_count, 2.0);
+}
+
+#[tokio::test]
+async fn test_list_workspaces_path_pagination_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+
+    let result = workspaces::list_workspaces(
+        &base_url,
+        "mgmt-key",
+        Some(PaginationOptions::with_offset_and_limit(3, 25)),
+    )
+    .await
+    .expect("list workspaces should succeed");
+    assert_eq!(result.total_count, 0.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces?offset=3&limit=25 HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer mgmt-key")
+            || request_lower.contains("authorization:bearer mgmt-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_create_workspace_posts_body_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_123","name":"Production","slug":"production","description":"Production","default_text_model":"openai/gpt-4o","default_image_model":"openai/dall-e-3","default_provider_sort":"price","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":null,"created_by":"user_123"}}"#,
+    );
+    let request = CreateWorkspaceRequest::builder()
+        .name("Production")
+        .slug("production")
+        .build()
+        .expect("request should build");
+
+    let response = workspaces::create_workspace(&base_url, "mgmt-key", &request)
+        .await
+        .expect("create workspace should succeed");
+    assert_eq!(response.id, "ws_123");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "POST /api/v1/workspaces HTTP/1.1");
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body["name"], "Production");
+    assert_eq!(body["slug"], "production");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_workspace_encodes_id_path() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_123","name":"Production","slug":"production","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":null,"created_by":"user_123"}}"#,
+    );
+
+    let response = workspaces::get_workspace(&base_url, "mgmt-key", "team/prod 1")
+        .await
+        .expect("get workspace should succeed");
+    assert_eq!(response.id, "ws_123");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces/team%2Fprod%201 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_update_workspace_encodes_id_and_sends_body() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_123","name":"Updated","slug":"updated","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":"2025-01-02T00:00:00.000Z","created_by":"user_123"}}"#,
+    );
+    let request = UpdateWorkspaceRequest::builder()
+        .name("Updated")
+        .build()
+        .expect("request should build");
+
+    let response = workspaces::update_workspace(&base_url, "mgmt-key", "team/prod 1", &request)
+        .await
+        .expect("update workspace should succeed");
+    assert_eq!(response.name, "Updated");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "PATCH /api/v1/workspaces/team%2Fprod%201 HTTP/1.1"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body["name"], "Updated");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_delete_workspace_encodes_id_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"deleted":true}"#);
+
+    let deleted = workspaces::delete_workspace(&base_url, "mgmt-key", "team/prod 1")
+        .await
+        .expect("delete workspace should succeed");
+    assert!(deleted);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "DELETE /api/v1/workspaces/team%2Fprod%201 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_add_workspace_members_encodes_id_and_sends_body() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"added_count":1,"data":[{"id":"wm_1","workspace_id":"ws_123","user_id":"user_123","role":"member","created_at":"2025-01-01T00:00:00.000Z"}]}"#,
+    );
+    let request = WorkspaceMembersRequest::builder()
+        .user_ids(vec!["user_123".to_string()])
+        .build()
+        .expect("request should build");
+
+    let response =
+        workspaces::add_workspace_members(&base_url, "mgmt-key", "team/prod 1", &request)
+            .await
+            .expect("add members should succeed");
+    assert_eq!(response.added_count, 1.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/workspaces/team%2Fprod%201/members/add HTTP/1.1"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(
+        body.get("user_ids")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(1)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_remove_workspace_members_encodes_id_and_sends_body() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"removed_count":1}"#);
+    let request = WorkspaceMembersRequest::builder()
+        .user_ids(vec!["user_123".to_string()])
+        .build()
+        .expect("request should build");
+
+    let response =
+        workspaces::remove_workspace_members(&base_url, "mgmt-key", "team/prod 1", &request)
+            .await
+            .expect("remove members should succeed");
+    assert_eq!(response.removed_count, 1.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/workspaces/team%2Fprod%201/members/remove HTTP/1.1"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(
+        body.get("user_ids")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(1)
+    );
+
+    server.join().expect("server thread should finish");
+}


### PR DESCRIPTION
Closes #190

## Summary
- add typed SDK support for `/workspaces*` CRUD and member management endpoints
- add workspace-aware API key and guardrail helpers plus `workspace_id` typed fields
- integrate workspace operations into `openrouter-cli`, including `workspaces` commands and `--workspace-id` support for keys/guardrails
- update examples, README, changelog, and endpoint coverage docs

## Validation
- just quality
- cargo test -p openrouter-cli -- --nocapture