### PR TITLE
chore: review latest openapi drift

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -54,7 +54,7 @@ jobs:
             /tmp/openapi-latest.operations.json
 
       - name: Open or refresh follow-up issue
-        if: github.event_name == 'schedule' && steps.compare.outputs.has_drift == 'true'
+        if: github.event_name == 'schedule' && steps.compare.outputs.has_actionable_drift == 'true'
         uses: actions/github-script@v7
         env:
           REPORT_PATH: /tmp/openapi-drift-report.md
@@ -73,7 +73,7 @@ jobs:
               : report;
             const body = [
               '## Summary',
-              'Detected upstream OpenAPI drift against the tracked baseline.',
+              'Detected actionable upstream OpenAPI drift against the tracked baseline.',
               '',
               '## Trigger',
               '- Source: nightly OpenAPI drift workflow',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
+- Added typed `num_fetches` support on `GET /generation` metadata responses via `GenerationData`.
 - Added typed SDK support for `GET /workspaces`, `POST /workspaces`, `GET /workspaces/{id}`, `PATCH /workspaces/{id}`, `DELETE /workspaces/{id}`, `POST /workspaces/{id}/members/add`, and `POST /workspaces/{id}/members/remove`, including canonical `client.management()` methods and a runnable `examples/list_workspaces.rs`.
 - Added workspace-aware API-key and guardrail support, including `workspace_id` fields on typed models plus `create_api_key_in_workspace(...)`, `list_api_keys_in_workspace(...)`, and `list_guardrails_in_workspace(...)`.
 - Added `openrouter-cli workspaces ...` commands, plus `--workspace-id` support for `openrouter-cli keys list|create` and `openrouter-cli guardrails list|create`.
@@ -16,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, including generic plain-text `404/405` status pages, so request-level `404/405` errors on the official endpoint are still preserved.
 - Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and restored the repository snapshot to `51 / 51` official OpenAPI endpoint coverage.
+- Accepted the 2026-04-22 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
+- Nightly OpenAPI drift reports now keep the raw upstream diff but separately classify metadata-only changes already covered by the SDK's global request-metadata handling, reducing false-positive follow-up noise.
 
 ## [0.8.1] - 2026-04-21
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-21  
+Snapshot date: 2026-04-22  
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -17,6 +17,8 @@ Drift review note:
 - Official text-to-speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.tts().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
 - Upstream added `GET /generation/content`, now exposed as `client.get_generation_content(...)` / `client.management().get_generation_content(...)`.
 - Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK and CLI now expose them; live management-key validation remains pending.
+- Upstream now declares `X-OpenRouter-Title`, `HTTP-Referer`, and `X-OpenRouter-Categories` across the official request surface. The SDK already applies those request-metadata headers through the client builder.
+- Upstream added `num_fetches` to generation metadata responses. The typed `GenerationData` surface now deserializes it.
 
 Legend:
 

--- a/docs/operations/openapi-drift-reporting.md
+++ b/docs/operations/openapi-drift-reporting.md
@@ -9,7 +9,7 @@ The endpoint matrix is useful, but it is static until someone remembers to refre
 - it fetches the latest upstream `openapi.json`
 - it compares the latest upstream operations against the tracked baseline
 - it emits a human-readable report and a machine-readable JSON summary
-- it can open or refresh a follow-up GitHub issue when drift is detected
+- it can open or refresh a follow-up GitHub issue when actionable drift is detected
 
 This keeps `openrouter-rs` aligned with upstream changes without blocking releases on every spec delta.
 
@@ -39,6 +39,18 @@ It intentionally ignores docs-only fields:
 
 That keeps the report focused on compatibility-relevant API changes rather than upstream prose edits.
 
+After the raw OpenAPI comparison, the report also applies a small repo-aware classification pass.
+Today that pass recognizes the global request metadata headers already handled by the SDK transport
+layer (`X-OpenRouter-Title`, `HTTP-Referer`, and `X-OpenRouter-Categories`) so the report can
+separate:
+
+- raw upstream drift
+- changed operations that are already covered by the repo's request-metadata handling
+- changed operations that still need SDK/docs/test follow-up
+
+This keeps the nightly issue useful when upstream bulk-adds supported metadata headers across many
+operations without hiding the underlying OpenAPI drift.
+
 The initial tracked baseline is intentionally seeded from the accepted endpoint matrix rather
 than silently fast-forwarded to whatever the latest upstream spec happens to contain. Baseline
 refresh is an explicit review step, not an automatic side effect of detection.
@@ -57,6 +69,10 @@ This writes a report to:
 - `/tmp/openrouter-openapi-drift-report.json`
 - `/tmp/openrouter-openapi-latest.operations.json`
 
+The compare command also emits both `has_drift` and `has_actionable_drift` when GitHub Actions
+passes a `GITHUB_OUTPUT` file. The nightly workflow keeps uploading the full raw drift artifacts,
+but it only opens or refreshes the follow-up issue when `has_actionable_drift=true`.
+
 Refresh the tracked baseline after reviewing and accepting upstream changes:
 
 ```bash
@@ -70,7 +86,7 @@ That updates:
 
 ## Follow-Up Flow
 
-When the nightly workflow reports drift:
+When the nightly workflow reports actionable drift:
 
 1. Keep the generated issue open as the active compatibility-update record.
 2. Review the generated report and candidate operations snapshot artifact.

--- a/docs/policies/compatibility-update-policy.md
+++ b/docs/policies/compatibility-update-policy.md
@@ -37,7 +37,7 @@ Compatibility updates use different surfaces for different jobs:
 
 | Surface | Role | When to update |
 | --- | --- | --- |
-| GitHub issue using [`.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`](../../.github/ISSUE_TEMPLATE/upstream-compatibility-update.md) | Active working record for one upstream change or one drift batch | When drift is detected, a non-spec upstream change is noticed, or follow-up work needs coordination |
+| GitHub issue using [`.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`](../../.github/ISSUE_TEMPLATE/upstream-compatibility-update.md) | Active working record for one upstream change or one drift batch | When actionable drift is detected, a non-spec upstream change is noticed, or follow-up work needs coordination |
 | [`CHANGELOG.md`](../../CHANGELOG.md) | Durable user-facing summary of accepted compatibility-affecting repo changes | In the same PR that lands a user-visible SDK/docs/test/support change |
 | [`MIGRATION.md`](../../MIGRATION.md) | Durable upgrade guidance | When canonical usage, public API names, compatibility bridges, required config, or migration steps changed |
 | [`docs/operations/official-endpoint-test-matrix.md`](../operations/official-endpoint-test-matrix.md) | Current implementation and live-test status by operation | When the accepted upstream operation surface changed or support status changed |
@@ -53,7 +53,7 @@ The cadence is intentionally small and event-driven:
 
 | Cadence | Trigger | Expected output |
 | --- | --- | --- |
-| Nightly | Upstream OpenAPI drift check | Auto-opened or refreshed drift issue plus report artifact |
+| Nightly | Upstream OpenAPI drift check | Report artifact every run; auto-opened or refreshed issue only when repo-aware classification marks the drift as actionable |
 | As needed | Non-spec upstream change noticed by maintainers, tests, or users | Manual compatibility update issue using the reusable template |
 | Same PR as acceptance | Repo accepts the change and updates code/docs/tests/baseline | `CHANGELOG.md`, `MIGRATION.md`, endpoint matrix, or baseline refresh updated in the same PR as needed |
 | Next release cut | A version is published | Release notes summarize already-landed compatibility updates; release notes do not replace the earlier docs updates |

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -15,13 +15,38 @@ from typing import Any
 UPSTREAM_OPENAPI_URL = "https://openrouter.ai/openapi.json"
 HTTP_METHODS = ("get", "post", "put", "patch", "delete", "options", "head", "trace")
 DOC_ONLY_FIELDS = {"description", "example", "examples", "externalDocs", "summary", "title"}
-REPO_SUPPORTED_METADATA_PARAMETERS = frozenset(
+REPO_KNOWN_METADATA_PARAMETERS = frozenset(
     {
         ("header", "HTTP-Referer"),
         ("header", "X-OpenRouter-Categories"),
         ("header", "X-OpenRouter-Title"),
     }
 )
+REPO_SUPPORTED_METADATA_PARAMETER_SHAPES = {
+    ("header", "HTTP-Referer"): {
+        "in": "header",
+        "name": "HTTP-Referer",
+        "schema": {
+            "type": "string",
+        },
+    },
+    ("header", "X-OpenRouter-Categories"): {
+        "in": "header",
+        "name": "X-OpenRouter-Categories",
+        "schema": {
+            "type": "string",
+        },
+        "x-speakeasy-name-override": "appCategories",
+    },
+    ("header", "X-OpenRouter-Title"): {
+        "in": "header",
+        "name": "X-OpenRouter-Title",
+        "schema": {
+            "type": "string",
+        },
+        "x-speakeasy-name-override": "appTitle",
+    },
+}
 BASELINE_TOP_LEVEL_FIELDS = (
     "components",
     "info",
@@ -216,16 +241,28 @@ def normalize_parameter_order(parameters: Any) -> Any:
     return sorted(parameters, key=parameter_sort_key)
 
 
-def is_repo_supported_metadata_parameter(parameter: Any) -> bool:
+def repo_known_metadata_parameter_key(parameter: Any) -> tuple[str, str] | None:
     if not isinstance(parameter, dict):
-        return False
+        return None
 
     name = parameter.get("name")
     location = parameter.get("in")
-    return isinstance(name, str) and isinstance(location, str) and (
-        location,
-        name,
-    ) in REPO_SUPPORTED_METADATA_PARAMETERS
+    if not isinstance(name, str) or not isinstance(location, str):
+        return None
+
+    parameter_key = (location, name)
+    if parameter_key not in REPO_KNOWN_METADATA_PARAMETERS:
+        return None
+
+    return parameter_key
+
+
+def is_repo_supported_metadata_parameter(parameter: Any) -> bool:
+    parameter_key = repo_known_metadata_parameter_key(parameter)
+    if parameter_key is None:
+        return False
+
+    return parameter == REPO_SUPPORTED_METADATA_PARAMETER_SHAPES[parameter_key]
 
 
 def collect_repo_supported_metadata_parameters(operation: Any) -> list[str]:
@@ -239,9 +276,25 @@ def collect_repo_supported_metadata_parameters(operation: Any) -> list[str]:
     supported_parameters = {
         f"{parameter['in']} {parameter['name']}"
         for parameter in parameters
-        if is_repo_supported_metadata_parameter(parameter)
+        if repo_known_metadata_parameter_key(parameter) is not None
     }
     return sorted(supported_parameters)
+
+
+def collect_exact_repo_supported_metadata_parameters(operation: Any) -> list[str]:
+    if not isinstance(operation, dict):
+        return []
+
+    parameters = operation.get("parameters")
+    if not isinstance(parameters, list):
+        return []
+
+    exact_supported_parameters = {
+        f"{parameter['in']} {parameter['name']}"
+        for parameter in parameters
+        if is_repo_supported_metadata_parameter(parameter)
+    }
+    return sorted(exact_supported_parameters)
 
 
 def strip_repo_supported_metadata_parameters(operation: Any) -> Any:
@@ -279,6 +332,12 @@ def classify_repo_impact_for_changed_operation(
             *collect_repo_supported_metadata_parameters(candidate_normalized),
         }
     )
+    exact_supported_parameters = sorted(
+        {
+            *collect_exact_repo_supported_metadata_parameters(baseline_normalized),
+            *collect_exact_repo_supported_metadata_parameters(candidate_normalized),
+        }
+    )
 
     baseline_without_supported = strip_repo_supported_metadata_parameters(
         baseline_normalized
@@ -287,7 +346,10 @@ def classify_repo_impact_for_changed_operation(
         candidate_normalized
     )
 
-    if supported_parameters and baseline_without_supported == candidate_without_supported:
+    if (
+        exact_supported_parameters
+        and baseline_without_supported == candidate_without_supported
+    ):
         return {
             "category": "metadata_only_already_supported",
             "supported_parameters": supported_parameters,

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -15,6 +15,13 @@ from typing import Any
 UPSTREAM_OPENAPI_URL = "https://openrouter.ai/openapi.json"
 HTTP_METHODS = ("get", "post", "put", "patch", "delete", "options", "head", "trace")
 DOC_ONLY_FIELDS = {"description", "example", "examples", "externalDocs", "summary", "title"}
+REPO_SUPPORTED_METADATA_PARAMETERS = frozenset(
+    {
+        ("header", "HTTP-Referer"),
+        ("header", "X-OpenRouter-Categories"),
+        ("header", "X-OpenRouter-Title"),
+    }
+)
 BASELINE_TOP_LEVEL_FIELDS = (
     "components",
     "info",
@@ -207,6 +214,89 @@ def normalize_parameter_order(parameters: Any) -> Any:
         return (1, "", "", canonical_json(parameter))
 
     return sorted(parameters, key=parameter_sort_key)
+
+
+def is_repo_supported_metadata_parameter(parameter: Any) -> bool:
+    if not isinstance(parameter, dict):
+        return False
+
+    name = parameter.get("name")
+    location = parameter.get("in")
+    return isinstance(name, str) and isinstance(location, str) and (
+        location,
+        name,
+    ) in REPO_SUPPORTED_METADATA_PARAMETERS
+
+
+def collect_repo_supported_metadata_parameters(operation: Any) -> list[str]:
+    if not isinstance(operation, dict):
+        return []
+
+    parameters = operation.get("parameters")
+    if not isinstance(parameters, list):
+        return []
+
+    supported_parameters = {
+        f"{parameter['in']} {parameter['name']}"
+        for parameter in parameters
+        if is_repo_supported_metadata_parameter(parameter)
+    }
+    return sorted(supported_parameters)
+
+
+def strip_repo_supported_metadata_parameters(operation: Any) -> Any:
+    if not isinstance(operation, dict):
+        return operation
+
+    stripped_operation = dict(operation)
+    parameters = stripped_operation.get("parameters")
+    if not isinstance(parameters, list):
+        return stripped_operation
+
+    filtered_parameters = [
+        parameter
+        for parameter in parameters
+        if not is_repo_supported_metadata_parameter(parameter)
+    ]
+
+    if filtered_parameters:
+        stripped_operation["parameters"] = normalize_parameter_order(filtered_parameters)
+    else:
+        stripped_operation.pop("parameters", None)
+
+    return stripped_operation
+
+
+def classify_repo_impact_for_changed_operation(
+    baseline_operation: dict[str, Any],
+    candidate_operation: dict[str, Any],
+) -> dict[str, Any]:
+    baseline_normalized = baseline_operation["normalized"]
+    candidate_normalized = candidate_operation["normalized"]
+    supported_parameters = sorted(
+        {
+            *collect_repo_supported_metadata_parameters(baseline_normalized),
+            *collect_repo_supported_metadata_parameters(candidate_normalized),
+        }
+    )
+
+    baseline_without_supported = strip_repo_supported_metadata_parameters(
+        baseline_normalized
+    )
+    candidate_without_supported = strip_repo_supported_metadata_parameters(
+        candidate_normalized
+    )
+
+    if supported_parameters and baseline_without_supported == candidate_without_supported:
+        return {
+            "category": "metadata_only_already_supported",
+            "supported_parameters": supported_parameters,
+        }
+
+    return {
+        "category": "actionable",
+        "supported_parameters": supported_parameters,
+    }
 
 
 def normalize_security_order(security: Any) -> Any:
@@ -442,6 +532,8 @@ def build_report(
     added = sorted(candidate_keys - baseline_keys)
     removed = sorted(baseline_keys - candidate_keys)
     changed = []
+    metadata_only_supported_count = 0
+    actionable_changed_count = 0
 
     for operation_key in sorted(baseline_keys & candidate_keys):
         baseline_operation = baseline_operations[operation_key]
@@ -449,11 +541,21 @@ def build_report(
         if baseline_operation["fingerprint"] == candidate_operation["fingerprint"]:
             continue
 
+        repo_impact = classify_repo_impact_for_changed_operation(
+            baseline_operation,
+            candidate_operation,
+        )
+        if repo_impact["category"] == "metadata_only_already_supported":
+            metadata_only_supported_count += 1
+        else:
+            actionable_changed_count += 1
+
         changed.append(
             {
                 "id": operation_key,
                 "baseline_fingerprint": baseline_operation["fingerprint"],
                 "candidate_fingerprint": candidate_operation["fingerprint"],
+                "repo_impact": repo_impact,
                 "diff_preview": diff_preview(
                     baseline_operation["normalized"],
                     candidate_operation["normalized"],
@@ -476,10 +578,17 @@ def build_report(
         "compared_at": utc_now_iso(),
         "source_url": source_url,
         "has_drift": bool(added or removed or changed),
+        "has_actionable_drift": bool(added or removed or actionable_changed_count),
         "summary": {
             "added": len(added),
             "removed": len(removed),
             "changed": len(changed),
+        },
+        "repo_summary": {
+            "metadata_only_already_supported": metadata_only_supported_count,
+            "actionable_added": len(added),
+            "actionable_removed": len(removed),
+            "actionable_changed": actionable_changed_count,
         },
         "added": [
             {
@@ -511,6 +620,17 @@ def markdown_list(title: str, items: list[str]) -> list[str]:
 
 
 def render_markdown_report(report: dict[str, Any]) -> str:
+    metadata_only_changes = [
+        entry
+        for entry in report["changed"]
+        if entry["repo_impact"]["category"] == "metadata_only_already_supported"
+    ]
+    actionable_changes = [
+        entry
+        for entry in report["changed"]
+        if entry["repo_impact"]["category"] == "actionable"
+    ]
+
     lines = [
         "# OpenRouter OpenAPI Drift Report",
         "",
@@ -546,20 +666,65 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             ]
         )
 
+    lines.extend(
+        [
+            "## Repo-Aware Classification",
+            "",
+            f"- Actionable added operations: `{report['repo_summary']['actionable_added']}`",
+            f"- Actionable removed operations: `{report['repo_summary']['actionable_removed']}`",
+            f"- Actionable changed operations: `{report['repo_summary']['actionable_changed']}`",
+            (
+                "- Changed operations already supported by repo metadata handling: "
+                f"`{report['repo_summary']['metadata_only_already_supported']}`"
+            ),
+            "",
+        ]
+    )
+
+    if report["has_drift"] and not report["has_actionable_drift"]:
+        lines.extend(
+            [
+                "No actionable repo drift detected after repo-aware classification.",
+                "The tracked baseline is stale, but the changed operations are already covered by",
+                "the repository's global request-metadata handling.",
+                "",
+            ]
+        )
+
     lines.extend(markdown_list("Added Operations", [entry["id"] for entry in report["added"]]))
     lines.extend(markdown_list("Removed Operations", [entry["id"] for entry in report["removed"]]))
 
-    lines.append("## Changed Operations")
+    lines.append("## Metadata-Only Changes Already Supported By Repo")
     lines.append("")
-    if not report["changed"]:
+    if not metadata_only_changes:
         lines.append("- None")
         lines.append("")
     else:
-        for entry in report["changed"]:
+        for entry in metadata_only_changes:
+            supported_parameters = ", ".join(
+                f"`{parameter}`"
+                for parameter in entry["repo_impact"]["supported_parameters"]
+            )
+            lines.append(f"- `{entry['id']}` ({supported_parameters})")
+        lines.append("")
+
+    lines.append("## Actionable Changed Operations")
+    lines.append("")
+    if not actionable_changes:
+        lines.append("- None")
+        lines.append("")
+    else:
+        for entry in actionable_changes:
             lines.append(
                 f"- `{entry['id']}` "
                 f"(`{entry['baseline_fingerprint']}` -> `{entry['candidate_fingerprint']}`)"
             )
+            if entry["repo_impact"]["supported_parameters"]:
+                supported_parameters = ", ".join(
+                    f"`{parameter}`"
+                    for parameter in entry["repo_impact"]["supported_parameters"]
+                )
+                lines.append(f"  Repo metadata already covers: {supported_parameters}")
             lines.append("")
             lines.append("```diff")
             lines.extend(entry["diff_preview"] or ["# normalized operation diff was empty"])
@@ -580,10 +745,21 @@ def render_markdown_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def write_github_output(path: Path, *, has_drift: bool, report_md: Path, report_json: Path) -> None:
+def write_github_output(
+    path: Path,
+    *,
+    has_drift: bool,
+    has_actionable_drift: bool,
+    report_md: Path,
+    report_json: Path,
+) -> None:
     ensure_parent(path)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(f"has_drift={'true' if has_drift else 'false'}\n")
+        handle.write(
+            "has_actionable_drift="
+            f"{'true' if has_actionable_drift else 'false'}\n"
+        )
         handle.write(f"report_markdown={report_md}\n")
         handle.write(f"report_json={report_json}\n")
 
@@ -642,6 +818,7 @@ def command_compare(args: argparse.Namespace) -> int:
         write_github_output(
             args.github_output,
             has_drift=report["has_drift"],
+            has_actionable_drift=report["has_actionable_drift"],
             report_md=args.report_md,
             report_json=args.report_json,
         )
@@ -653,7 +830,10 @@ def command_compare(args: argparse.Namespace) -> int:
         f"Compared baseline `{args.baseline_label}` to candidate `{args.candidate_label}`: "
         f"added={report['summary']['added']}, "
         f"removed={report['summary']['removed']}, "
-        f"changed={report['summary']['changed']}"
+        f"changed={report['summary']['changed']}, "
+        f"actionable_changed={report['repo_summary']['actionable_changed']}, "
+        "metadata_only_already_supported="
+        f"{report['repo_summary']['metadata_only_already_supported']}"
     )
     print(f"- markdown report: {args.report_md}")
     print(f"- json report: {args.report_json}")

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,13 +1,23 @@
 {
   "components": {
     "parameters": {
+      "AppCategories": {
+        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
+        "in": "header",
+        "name": "X-OpenRouter-Categories",
+        "schema": {
+          "type": "string"
+        },
+        "x-speakeasy-name-override": "appCategories"
+      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-Title",
+        "name": "X-OpenRouter-Title",
         "schema": {
           "type": "string"
-        }
+        },
+        "x-speakeasy-name-override": "appTitle"
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -3927,7 +3937,8 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField"
+            "$ref": "#/components/schemas/ResponsesErrorField",
+            "nullable": true
           },
           "frequency_penalty": {
             "format": "double",
@@ -3938,10 +3949,12 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails"
+            "$ref": "#/components/schemas/IncompleteDetails",
+            "nullable": true
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs"
+            "$ref": "#/components/schemas/BaseInputs",
+            "nullable": true
           },
           "max_output_tokens": {
             "nullable": true,
@@ -4022,7 +4035,8 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig"
+            "$ref": "#/components/schemas/BaseReasoningConfig",
+            "nullable": true
           },
           "safety_identifier": {
             "nullable": true,
@@ -4043,7 +4057,8 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig"
+            "$ref": "#/components/schemas/TextConfig",
+            "nullable": true
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -4132,6 +4147,7 @@
             "type": "array"
           },
           "top_logprobs": {
+            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -4140,7 +4156,8 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation"
+            "$ref": "#/components/schemas/Truncation",
+            "nullable": true
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -5209,6 +5226,9 @@
           },
           {
             "$ref": "#/components/schemas/ChatSearchModelsServerTool"
+          },
+          {
+            "$ref": "#/components/schemas/WebFetchServerTool"
           },
           {
             "$ref": "#/components/schemas/OpenRouterWebSearchServerTool"
@@ -8669,6 +8689,12 @@
                 "nullable": true,
                 "type": "integer"
               },
+              "num_fetches": {
+                "description": "Number of web fetches performed",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              },
               "num_input_audio_prompt": {
                 "description": "Number of audio inputs in the prompt",
                 "example": 0,
@@ -8811,6 +8837,7 @@
               "num_input_audio_prompt",
               "num_media_completion",
               "num_search_results",
+              "num_fetches",
               "web_search_engine",
               "origin",
               "usage",
@@ -12051,6 +12078,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ChatSearchModelsServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchServerTool"
                 },
                 {
                   "$ref": "#/components/schemas/OpenRouterWebSearchServerTool"
@@ -17756,6 +17786,9 @@
                   "$ref": "#/components/schemas/ChatSearchModelsServerTool"
                 },
                 {
+                  "$ref": "#/components/schemas/WebFetchServerTool"
+                },
+                {
                   "$ref": "#/components/schemas/WebSearchServerTool_OpenRouter"
                 }
               ]
@@ -20808,6 +20841,80 @@
         ],
         "type": "object"
       },
+      "WebFetchEngineEnum": {
+        "description": "Which fetch engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in fetch. \"exa\" uses Exa Contents API (supports BYOK). \"openrouter\" uses direct HTTP fetch. \"firecrawl\" uses Firecrawl scrape (requires BYOK).",
+        "enum": [
+          "auto",
+          "native",
+          "openrouter",
+          "firecrawl",
+          "exa"
+        ],
+        "example": "auto",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "WebFetchServerTool": {
+        "description": "OpenRouter built-in server tool: fetches full content from a URL (web page or PDF)",
+        "example": {
+          "parameters": {
+            "max_uses": 10
+          },
+          "type": "openrouter:web_fetch"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/WebFetchServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:web_fetch"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "WebFetchServerToolConfig": {
+        "description": "Configuration for the openrouter:web_fetch server tool",
+        "example": {
+          "max_content_tokens": 100000,
+          "max_uses": 10
+        },
+        "properties": {
+          "allowed_domains": {
+            "description": "Only fetch from these domains.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "blocked_domains": {
+            "description": "Never fetch from these domains.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/WebFetchEngineEnum"
+          },
+          "max_content_tokens": {
+            "description": "Maximum content length in approximate tokens. Content exceeding this limit is truncated.",
+            "example": 100000,
+            "type": "integer"
+          },
+          "max_uses": {
+            "description": "Maximum number of web fetches per request. Once exceeded, the tool returns an error.",
+            "example": 10,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "WebSearchCallCompletedEvent": {
         "allOf": [
           {
@@ -21530,9 +21637,31 @@
         "tags": [
           "Analytics"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/audio/speech": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Synthesizes audio from the input text",
         "operationId": "createAudioSpeech",
@@ -21736,6 +21865,17 @@
       }
     },
     "/auth/keys": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -21878,6 +22018,17 @@
       }
     },
     "/auth/keys/code": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -22107,6 +22258,17 @@
       }
     },
     "/chat/completions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
@@ -22529,9 +22691,31 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/credits/coinbase": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -22568,6 +22752,17 @@
       }
     },
     "/embeddings": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -23169,7 +23364,18 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/endpoints/zdr": {
       "get": {
@@ -23304,7 +23510,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation": {
       "get": {
@@ -23509,7 +23726,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation/content": {
       "get": {
@@ -23688,7 +23916,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails": {
       "get": {
@@ -23826,6 +24065,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -24071,7 +24321,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -24185,7 +24446,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/{id}": {
       "delete": {
@@ -24378,6 +24650,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
@@ -24655,6 +24938,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
@@ -24774,6 +25068,17 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -25033,6 +25338,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -25153,6 +25469,17 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -25574,7 +25901,18 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/keys": {
       "get": {
@@ -25920,6 +26258,17 @@
         ],
         "x-speakeasy-name-override": "list"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
@@ -26780,6 +27129,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -27185,6 +27545,17 @@
       }
     },
     "/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
@@ -27559,7 +27930,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/count": {
       "get": {
@@ -27631,7 +28013,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/user": {
       "get": {
@@ -27753,7 +28146,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -27919,7 +28323,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/organization/members": {
       "get": {
@@ -28107,7 +28522,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/providers": {
       "get": {
@@ -28758,9 +29184,31 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/rerank": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -29137,6 +29585,17 @@
       }
     },
     "/responses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
@@ -29427,6 +29886,17 @@
       }
     },
     "/videos": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -29652,7 +30122,18 @@
         "tags": [
           "Video Generation"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}": {
       "get": {
@@ -29747,7 +30228,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -29876,7 +30368,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/workspaces": {
       "get": {
@@ -29998,6 +30501,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new workspace for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createWorkspace",
@@ -30338,6 +30852,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateWorkspace",
@@ -30486,6 +31011,17 @@
       }
     },
     "/workspaces/{id}/members/add": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Add multiple organization members to a workspace. Members are assigned the same role they hold in the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAddWorkspaceMembers",
@@ -30631,6 +31167,17 @@
       }
     },
     "/workspaces/{id}/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkRemoveWorkspaceMembers",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-21T09:58:19+00:00",
+  "captured_at": "2026-04-22T05:55:41+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -18,7 +18,7 @@
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "62d6681f3fc2fe20",
+      "fingerprint": "fc9cb5e5f6b4e39c",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2a479c2a2828c351",
+      "fingerprint": "0ff2409f46ebd93d",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "01579a8548d64ab2",
+      "fingerprint": "0366f25ef11315e3",
       "id": "DELETE /workspaces/{id}",
       "method": "DELETE",
       "operation_id": "deleteWorkspace",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a8e8f18928c3c86a",
+      "fingerprint": "d143da7f6f9162c0",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "05cecac9b09a5e7c",
+      "fingerprint": "e87fbb5bb40b4c60",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "af82a2b2f1a4be20",
+      "fingerprint": "30cba935ed98ef92",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "95f59af93f2a1940",
+      "fingerprint": "d94195530e0414a4",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f408120d9958824f",
+      "fingerprint": "0edcf488ff274fea",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9fbe3d8789b59348",
+      "fingerprint": "9cccd989d9cf69e1",
       "id": "GET /generation/content",
       "method": "GET",
       "operation_id": "listGenerationContent",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb76f9599911ccb5",
+      "fingerprint": "3d3e8c9561d450c5",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "50df372af92b0439",
+      "fingerprint": "b43f6f0d1e70ec62",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "48ed8bcc9c811a11",
+      "fingerprint": "93d944d97fca595b",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "aa3c9f9c9d5fe9ae",
+      "fingerprint": "6a953189b58fc510",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -161,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bdcc5f13eb39b87d",
+      "fingerprint": "34604a16fa41fb79",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -172,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "622584d38112ff60",
+      "fingerprint": "6a182854d359c7c1",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c73983473e1c0e0e",
+      "fingerprint": "6a1d8e77363531a7",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bd94c1cb6e19cdd2",
+      "fingerprint": "73fe6021d5d3877d",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7d938af215f4d03a",
+      "fingerprint": "fb6bbfd93f43f252",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4ca86a27618bbd42",
+      "fingerprint": "2fa2acafbf6ad7ef",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "360a71c424058693",
+      "fingerprint": "39d755b55859e6de",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1409a555c838345f",
+      "fingerprint": "4f89ab2b49b36d23",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5fc00b6e69ff4f1f",
+      "fingerprint": "285752418aed97c4",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "afba5151a3299caf",
+      "fingerprint": "7687a0f00ba6d1b1",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6d3ec9bee71dc2ce",
+      "fingerprint": "db6ea0df829856f4",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "14596fe6b03e4428",
+      "fingerprint": "db1c62dade2d8f06",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0c91e369c0a0d9e1",
+      "fingerprint": "45699b9654b6db62",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f762b88d789b2723",
+      "fingerprint": "81bf8fc0183755b8",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "884dec04861b659d",
+      "fingerprint": "3a9c1ed02a70dbbc",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5e33269f90dfab34",
+      "fingerprint": "022156582f1948b1",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -337,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "17f6c0ff95ea6247",
+      "fingerprint": "4c0058a2655e0d29",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -348,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e96abe881cfbc08b",
+      "fingerprint": "4ccab78044c4a13d",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ac1cb8e84c7edadf",
+      "fingerprint": "b2f88fd0f3e4d4f3",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3263093f7a682e54",
+      "fingerprint": "36acd96bab4c7e68",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "350024ac1009cddb",
+      "fingerprint": "d5a58f4512027317",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ce53dfc76885c522",
+      "fingerprint": "0781a831d48dec54",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "12af9351d354782d",
+      "fingerprint": "1562181e4b362b9f",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -414,7 +414,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "3aae29d559805e6d",
+      "fingerprint": "4d49cd207179e897",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "92a8447c3b7e796f",
+      "fingerprint": "0f4fe255c155ded7",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f1bba43860a3f2fe",
+      "fingerprint": "2286b192a05d7bfe",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -447,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cac6ec19bd951299",
+      "fingerprint": "6b121e68b5bcdb55",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -458,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fc5f8809122a9fec",
+      "fingerprint": "8d3111ee0fdd6842",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -469,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a60d54c8a1dd80c0",
+      "fingerprint": "04c2e86ce1b63136",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -480,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "95cd05e9fbc9490b",
+      "fingerprint": "76d6bf8fb6c08c1e",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -491,7 +491,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "42c34e6c3b001698",
+      "fingerprint": "2384f8263630f7cc",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -502,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d745016db238548a",
+      "fingerprint": "96eb9d6251d766c0",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -513,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "18f4810d9d6d8bd0",
+      "fingerprint": "38cb2fd0bea5ce96",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -524,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a4ca9854311dbced",
+      "fingerprint": "5fbef18da5e4a468",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -535,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "624263f08072d641",
+      "fingerprint": "3dae513ba8623eb6",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -546,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4206e4a1e2d22238",
+      "fingerprint": "a94b578527cd26f6",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -557,7 +557,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e870d118f618fb87",
+      "fingerprint": "46c26f63f1cae2e4",
       "id": "POST /workspaces/{id}/members/add",
       "method": "POST",
       "operation_id": "bulkAddWorkspaceMembers",
@@ -568,7 +568,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7ddc552ce8a708a0",
+      "fingerprint": "d3ee5d978118adf4",
       "id": "POST /workspaces/{id}/members/remove",
       "method": "POST",
       "operation_id": "bulkRemoveWorkspaceMembers",

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -35,6 +35,7 @@ pub struct GenerationData {
     pub native_tokens_prompt: Option<u32>,
     pub native_tokens_completion: Option<u32>,
     pub native_tokens_reasoning: Option<u32>,
+    pub num_fetches: Option<u32>,
     pub num_media_prompt: Option<u32>,
     pub num_media_completion: Option<u32>,
     pub num_search_results: Option<u32>,

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -58,11 +58,13 @@ class OpenApiDriftReportTests(unittest.TestCase):
                     "in": "header",
                     "name": "X-OpenRouter-Title",
                     "schema": {"type": "string"},
+                    "x-speakeasy-name-override": "appTitle",
                 },
                 {
                     "in": "header",
                     "name": "X-OpenRouter-Categories",
                     "schema": {"type": "string"},
+                    "x-speakeasy-name-override": "appCategories",
                 },
             ]
         )
@@ -125,6 +127,48 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 0)
         self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+
+    def test_required_metadata_header_change_remains_actionable(self):
+        baseline = build_spec(
+            parameters=[
+                {
+                    "in": "header",
+                    "name": "X-OpenRouter-Title",
+                    "schema": {"type": "string"},
+                    "x-speakeasy-name-override": "appTitle",
+                }
+            ]
+        )
+        candidate = build_spec(
+            parameters=[
+                {
+                    "in": "header",
+                    "name": "X-OpenRouter-Title",
+                    "required": True,
+                    "schema": {"type": "string"},
+                    "x-speakeasy-name-override": "appTitle",
+                }
+            ]
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["supported_parameters"],
+            ["header X-OpenRouter-Title"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -1,0 +1,131 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "openapi_drift.py"
+SPEC = importlib.util.spec_from_file_location("openapi_drift", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+openapi_drift = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(openapi_drift)
+
+
+def build_spec(*, parameters=None, response_properties=None):
+    operation = {
+        "operationId": "getModels",
+        "responses": {
+            "200": {
+                "description": "ok",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": response_properties or {
+                                "id": {"type": "string"},
+                            },
+                        }
+                    }
+                },
+            }
+        },
+    }
+    if parameters is not None:
+        operation["parameters"] = parameters
+
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Test", "version": "1.0.0"},
+        "paths": {
+            "/models": {
+                "get": operation,
+            }
+        },
+    }
+
+
+class OpenApiDriftReportTests(unittest.TestCase):
+    def test_metadata_only_header_drift_is_classified_as_already_supported(self):
+        baseline = build_spec()
+        candidate = build_spec(
+            parameters=[
+                {
+                    "in": "header",
+                    "name": "HTTP-Referer",
+                    "schema": {"type": "string"},
+                },
+                {
+                    "in": "header",
+                    "name": "X-OpenRouter-Title",
+                    "schema": {"type": "string"},
+                },
+                {
+                    "in": "header",
+                    "name": "X-OpenRouter-Categories",
+                    "schema": {"type": "string"},
+                },
+            ]
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["summary"]["changed"], 1)
+        self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["category"],
+            "metadata_only_already_supported",
+        )
+
+    def test_non_metadata_schema_change_remains_actionable(self):
+        baseline = build_spec(
+            parameters=[
+                {
+                    "in": "header",
+                    "name": "HTTP-Referer",
+                    "schema": {"type": "string"},
+                }
+            ]
+        )
+        candidate = build_spec(
+            parameters=[
+                {
+                    "in": "header",
+                    "name": "HTTP-Referer",
+                    "schema": {"type": "string"},
+                }
+            ],
+            response_properties={
+                "id": {"type": "string"},
+                "num_fetches": {"type": "integer", "nullable": True},
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["summary"]["changed"], 1)
+        self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use openrouter_rs::api::generation;
+use openrouter_rs::types::ApiResponse;
 
 struct CapturedRequest {
     request_line: String,
@@ -128,4 +129,28 @@ async fn test_get_generation_content_path_and_auth_header() {
     );
 
     server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_generation_response_deserializes_num_fetches() {
+    let raw = r#"{
+        "data": {
+            "id": "gen_123",
+            "total_cost": 0.1,
+            "created_at": "2026-04-22T00:00:00Z",
+            "model": "openai/gpt-4o-mini",
+            "origin": "chat",
+            "usage": 42.0,
+            "is_byok": false,
+            "native_tokens_reasoning": 8,
+            "num_fetches": 3
+        }
+    }"#;
+
+    let parsed: ApiResponse<generation::GenerationData> =
+        serde_json::from_str(raw).expect("generation response should deserialize");
+
+    assert_eq!(parsed.data.id, "gen_123");
+    assert_eq!(parsed.data.native_tokens_reasoning, Some(8));
+    assert_eq!(parsed.data.num_fetches, Some(3));
 }


### PR DESCRIPTION
## Summary
- refresh the accepted OpenAPI baseline for the 2026-04-22 upstream drift review
- add typed `num_fetches` support for `GET /generation` and cover it with a unit test
- classify metadata-only drift that is already covered by SDK request metadata handling and only open nightly follow-up issues for actionable drift

## Testing
- `python3 -m unittest discover -s tests -p 'test_openapi_drift.py'`
- `cargo test --test unit generation`

Closes #195