### PR TITLE
chore: accept OpenAPI drift 197

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, including generic plain-text `404/405` status pages, so request-level `404/405` errors on the official endpoint are still preserved.
 - Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and restored the repository snapshot to `51 / 51` official OpenAPI endpoint coverage.
 - Accepted the 2026-04-22 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
-- Nightly OpenAPI drift reports now keep the raw upstream diff but separately classify metadata-only changes already covered by the SDK's global request-metadata handling, reducing false-positive follow-up noise.
+- Accepted the 2026-04-23 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
+- Nightly OpenAPI drift reports now keep the raw upstream diff but separately classify changes already covered by the SDK's global request-metadata handling, dynamic `String` taxonomy fields, provider options maps, and Responses `Option`/`Value` parsing, reducing false-positive follow-up noise.
 
 ## [0.8.1] - 2026-04-21
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-22  
+Snapshot date: 2026-04-23
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -17,8 +17,9 @@ Drift review note:
 - Official text-to-speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.tts().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
 - Upstream added `GET /generation/content`, now exposed as `client.get_generation_content(...)` / `client.management().get_generation_content(...)`.
 - Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK and CLI now expose them; live management-key validation remains pending.
-- Upstream now declares `X-OpenRouter-Title`, `HTTP-Referer`, and `X-OpenRouter-Categories` across the official request surface. The SDK already applies those request-metadata headers through the client builder.
+- Upstream now exposes request metadata through generator globals (`HTTP-Referer`, `X-Title`) instead of repeating path-level metadata parameters. The SDK already applies `HTTP-Referer`, `X-Title`, `X-OpenRouter-Title`, and optional `X-OpenRouter-Categories` through the client builder.
 - Upstream added `num_fetches` to generation metadata responses. The typed `GenerationData` surface now deserializes it.
+- Upstream refreshed dynamic taxonomy details (`OutputModality` now uses `speech` instead of `tts`, provider lists now include `Nex AGI`, and Responses result nullable annotations were narrowed). The SDK already carries those surfaces through flexible `String`, `Value`, `HashMap`, and `Option` fields, so no public API migration is required.
 
 Legend:
 

--- a/docs/operations/openapi-drift-reporting.md
+++ b/docs/operations/openapi-drift-reporting.md
@@ -40,16 +40,22 @@ It intentionally ignores docs-only fields:
 That keeps the report focused on compatibility-relevant API changes rather than upstream prose edits.
 
 After the raw OpenAPI comparison, the report also applies a small repo-aware classification pass.
-Today that pass recognizes the global request metadata headers already handled by the SDK transport
-layer (`X-OpenRouter-Title`, `HTTP-Referer`, and `X-OpenRouter-Categories`) so the report can
-separate:
+Today that pass recognizes changes already handled by the SDK transport and flexible schema
+surfaces:
+
+- global request metadata headers (`X-OpenRouter-Title`, `X-Title`, `HTTP-Referer`, and `X-OpenRouter-Categories`)
+- dynamic provider-name and output-modality enums surfaced as `String` values by the SDK
+- provider-specific passthrough options surfaced as `HashMap<String, Value>`
+- Responses result nullable annotations covered by `Option`/`Value` response parsing
+
+This lets the report separate:
 
 - raw upstream drift
-- changed operations that are already covered by the repo's request-metadata handling
+- changed operations that are already covered by the repo's existing handling
 - changed operations that still need SDK/docs/test follow-up
 
-This keeps the nightly issue useful when upstream bulk-adds supported metadata headers across many
-operations without hiding the underlying OpenAPI drift.
+This keeps the nightly issue useful when upstream bulk-edits supported metadata or dynamic taxonomy
+schemas across many operations without hiding the underlying OpenAPI drift artifacts.
 
 The initial tracked baseline is intentionally seeded from the accepted endpoint matrix rather
 than silently fast-forwarded to whatever the latest upstream spec happens to contain. Baseline

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -348,7 +348,12 @@ def scalar_enum_values(value: Any) -> set[Any]:
     enum_values = value.get("enum") if isinstance(value, dict) else None
     if not isinstance(enum_values, list):
         return set()
-    return set(enum_values)
+
+    return {
+        item
+        for item in enum_values
+        if item is None or isinstance(item, (str, int, float, bool))
+    }
 
 
 def is_repo_supported_dynamic_provider_name_enum(value: Any) -> bool:
@@ -396,10 +401,18 @@ def is_repo_supported_provider_options_map(value: Any) -> bool:
     )
 
 
-def strip_repo_supported_schema_details(operation_key: str, value: Any) -> Any:
+def is_responses_response_payload_path(operation_key: str, path: tuple[Any, ...]) -> bool:
+    return operation_key == "POST /responses" and bool(path) and path[0] == "responses"
+
+
+def strip_repo_supported_schema_details(
+    operation_key: str,
+    value: Any,
+    path: tuple[Any, ...] = (),
+) -> Any:
     if isinstance(value, dict):
         stripped = {
-            key: strip_repo_supported_schema_details(operation_key, item)
+            key: strip_repo_supported_schema_details(operation_key, item, path + (key,))
             for key, item in value.items()
         }
 
@@ -414,7 +427,7 @@ def strip_repo_supported_schema_details(operation_key: str, value: Any) -> Any:
                 "<repo-supported-provider-options>": REPO_FLEXIBLE_PROVIDER_OPTION_VALUE_SCHEMA
             }
 
-        if operation_key == "POST /responses":
+        if is_responses_response_payload_path(operation_key, path):
             properties = stripped.get("properties")
             if isinstance(properties, dict):
                 for field_name in REPO_RESPONSES_FLEXIBLE_NULLABILITY_FIELDS:
@@ -426,8 +439,8 @@ def strip_repo_supported_schema_details(operation_key: str, value: Any) -> Any:
 
     if isinstance(value, list):
         return [
-            strip_repo_supported_schema_details(operation_key, item)
-            for item in value
+            strip_repo_supported_schema_details(operation_key, item, path + (index,))
+            for index, item in enumerate(value)
         ]
 
     return value
@@ -436,7 +449,7 @@ def strip_repo_supported_schema_details(operation_key: str, value: Any) -> Any:
 def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[str]:
     rules: set[str] = set()
 
-    def collect(item: Any) -> None:
+    def collect(item: Any, path: tuple[Any, ...] = ()) -> None:
         if isinstance(item, dict):
             if is_repo_supported_dynamic_provider_name_enum(item):
                 rules.add("dynamic provider name enum")
@@ -444,7 +457,7 @@ def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[
                 rules.add("dynamic output modality enum")
             if is_repo_supported_provider_options_map(item):
                 rules.add("provider-specific options map")
-            if operation_key == "POST /responses":
+            if is_responses_response_payload_path(operation_key, path):
                 properties = item.get("properties")
                 if isinstance(properties, dict):
                     for field_name in REPO_RESPONSES_FLEXIBLE_NULLABILITY_FIELDS:
@@ -452,13 +465,13 @@ def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[
                         if isinstance(field_schema, dict) and field_schema.get("nullable") is True:
                             rules.add("Responses flexible nullable fields")
 
-            for child in item.values():
-                collect(child)
+            for key, child in item.items():
+                collect(child, path + (key,))
             return
 
         if isinstance(item, list):
-            for child in item:
-                collect(child)
+            for index, child in enumerate(item):
+                collect(child, path + (index,))
 
     collect(value)
     return sorted(rules)

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -18,6 +18,7 @@ DOC_ONLY_FIELDS = {"description", "example", "examples", "externalDocs", "summar
 REPO_KNOWN_METADATA_PARAMETERS = frozenset(
     {
         ("header", "HTTP-Referer"),
+        ("header", "X-Title"),
         ("header", "X-OpenRouter-Categories"),
         ("header", "X-OpenRouter-Title"),
     }
@@ -38,6 +39,13 @@ REPO_SUPPORTED_METADATA_PARAMETER_SHAPES = {
         },
         "x-speakeasy-name-override": "appCategories",
     },
+    ("header", "X-Title"): {
+        "in": "header",
+        "name": "X-Title",
+        "schema": {
+            "type": "string",
+        },
+    },
     ("header", "X-OpenRouter-Title"): {
         "in": "header",
         "name": "X-OpenRouter-Title",
@@ -47,6 +55,22 @@ REPO_SUPPORTED_METADATA_PARAMETER_SHAPES = {
         "x-speakeasy-name-override": "appTitle",
     },
 }
+REPO_DYNAMIC_PROVIDER_NAME_MARKERS = frozenset({"Anthropic", "Google", "OpenAI"})
+REPO_DYNAMIC_OUTPUT_MODALITY_MARKERS = frozenset({"image", "text", "video"})
+REPO_FLEXIBLE_PROVIDER_OPTION_MARKERS = frozenset({"anthropic", "google-vertex", "openai"})
+REPO_FLEXIBLE_PROVIDER_OPTION_VALUE_SCHEMA = {
+    "additionalProperties": {
+        "nullable": True,
+    },
+    "type": "object",
+}
+REPO_RESPONSES_FLEXIBLE_NULLABILITY_FIELDS = frozenset(
+    {
+        "instructions",
+        "text",
+        "top_logprobs",
+    }
+)
 BASELINE_TOP_LEVEL_FIELDS = (
     "components",
     "info",
@@ -320,7 +344,128 @@ def strip_repo_supported_metadata_parameters(operation: Any) -> Any:
     return stripped_operation
 
 
+def scalar_enum_values(value: Any) -> set[Any]:
+    enum_values = value.get("enum") if isinstance(value, dict) else None
+    if not isinstance(enum_values, list):
+        return set()
+    return set(enum_values)
+
+
+def is_repo_supported_dynamic_provider_name_enum(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    enum_values = scalar_enum_values(value)
+    string_values = {item for item in enum_values if isinstance(item, str)}
+    return (
+        value.get("type") == "string"
+        and value.get("x-speakeasy-unknown-values") == "allow"
+        and REPO_DYNAMIC_PROVIDER_NAME_MARKERS.issubset(string_values)
+    )
+
+
+def is_repo_supported_dynamic_output_modality_enum(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    enum_values = scalar_enum_values(value)
+    string_values = {item for item in enum_values if isinstance(item, str)}
+    return (
+        value.get("type") == "string"
+        and value.get("x-speakeasy-unknown-values") == "allow"
+        and REPO_DYNAMIC_OUTPUT_MODALITY_MARKERS.issubset(string_values)
+    )
+
+
+def is_repo_supported_provider_options_map(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    properties = value.get("properties")
+    if not isinstance(properties, dict):
+        return False
+
+    property_names = set(properties)
+    return (
+        value.get("type") == "object"
+        and REPO_FLEXIBLE_PROVIDER_OPTION_MARKERS.issubset(property_names)
+        and all(
+            property_schema == REPO_FLEXIBLE_PROVIDER_OPTION_VALUE_SCHEMA
+            for property_schema in properties.values()
+        )
+    )
+
+
+def strip_repo_supported_schema_details(operation_key: str, value: Any) -> Any:
+    if isinstance(value, dict):
+        stripped = {
+            key: strip_repo_supported_schema_details(operation_key, item)
+            for key, item in value.items()
+        }
+
+        if (
+            is_repo_supported_dynamic_provider_name_enum(stripped)
+            or is_repo_supported_dynamic_output_modality_enum(stripped)
+        ):
+            stripped["enum"] = ["<repo-supported-dynamic-enum>"]
+
+        if is_repo_supported_provider_options_map(stripped):
+            stripped["properties"] = {
+                "<repo-supported-provider-options>": REPO_FLEXIBLE_PROVIDER_OPTION_VALUE_SCHEMA
+            }
+
+        if operation_key == "POST /responses":
+            properties = stripped.get("properties")
+            if isinstance(properties, dict):
+                for field_name in REPO_RESPONSES_FLEXIBLE_NULLABILITY_FIELDS:
+                    field_schema = properties.get(field_name)
+                    if isinstance(field_schema, dict):
+                        field_schema.pop("nullable", None)
+
+        return stripped
+
+    if isinstance(value, list):
+        return [
+            strip_repo_supported_schema_details(operation_key, item)
+            for item in value
+        ]
+
+    return value
+
+
+def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[str]:
+    rules: set[str] = set()
+
+    def collect(item: Any) -> None:
+        if isinstance(item, dict):
+            if is_repo_supported_dynamic_provider_name_enum(item):
+                rules.add("dynamic provider name enum")
+            if is_repo_supported_dynamic_output_modality_enum(item):
+                rules.add("dynamic output modality enum")
+            if is_repo_supported_provider_options_map(item):
+                rules.add("provider-specific options map")
+            if operation_key == "POST /responses":
+                properties = item.get("properties")
+                if isinstance(properties, dict):
+                    for field_name in REPO_RESPONSES_FLEXIBLE_NULLABILITY_FIELDS:
+                        field_schema = properties.get(field_name)
+                        if isinstance(field_schema, dict) and field_schema.get("nullable") is True:
+                            rules.add("Responses flexible nullable fields")
+
+            for child in item.values():
+                collect(child)
+            return
+
+        if isinstance(item, list):
+            for child in item:
+                collect(child)
+
+    collect(value)
+    return sorted(rules)
+
+
 def classify_repo_impact_for_changed_operation(
+    operation_key: str,
     baseline_operation: dict[str, Any],
     candidate_operation: dict[str, Any],
 ) -> dict[str, Any]:
@@ -345,18 +490,35 @@ def classify_repo_impact_for_changed_operation(
     candidate_without_supported = strip_repo_supported_metadata_parameters(
         candidate_normalized
     )
+    schema_rules = sorted(
+        {
+            *collect_repo_supported_schema_rules(operation_key, baseline_without_supported),
+            *collect_repo_supported_schema_rules(operation_key, candidate_without_supported),
+        }
+    )
+
+    baseline_without_supported = strip_repo_supported_schema_details(
+        operation_key,
+        baseline_without_supported,
+    )
+    candidate_without_supported = strip_repo_supported_schema_details(
+        operation_key,
+        candidate_without_supported,
+    )
 
     if (
-        exact_supported_parameters
+        (exact_supported_parameters or schema_rules)
         and baseline_without_supported == candidate_without_supported
     ):
         return {
-            "category": "metadata_only_already_supported",
+            "category": "already_supported",
+            "schema_rules": schema_rules,
             "supported_parameters": supported_parameters,
         }
 
     return {
         "category": "actionable",
+        "schema_rules": schema_rules,
         "supported_parameters": supported_parameters,
     }
 
@@ -594,7 +756,7 @@ def build_report(
     added = sorted(candidate_keys - baseline_keys)
     removed = sorted(baseline_keys - candidate_keys)
     changed = []
-    metadata_only_supported_count = 0
+    already_supported_count = 0
     actionable_changed_count = 0
 
     for operation_key in sorted(baseline_keys & candidate_keys):
@@ -604,11 +766,12 @@ def build_report(
             continue
 
         repo_impact = classify_repo_impact_for_changed_operation(
+            operation_key,
             baseline_operation,
             candidate_operation,
         )
-        if repo_impact["category"] == "metadata_only_already_supported":
-            metadata_only_supported_count += 1
+        if repo_impact["category"] == "already_supported":
+            already_supported_count += 1
         else:
             actionable_changed_count += 1
 
@@ -647,7 +810,7 @@ def build_report(
             "changed": len(changed),
         },
         "repo_summary": {
-            "metadata_only_already_supported": metadata_only_supported_count,
+            "already_supported_changed": already_supported_count,
             "actionable_added": len(added),
             "actionable_removed": len(removed),
             "actionable_changed": actionable_changed_count,
@@ -682,10 +845,10 @@ def markdown_list(title: str, items: list[str]) -> list[str]:
 
 
 def render_markdown_report(report: dict[str, Any]) -> str:
-    metadata_only_changes = [
+    already_supported_changes = [
         entry
         for entry in report["changed"]
-        if entry["repo_impact"]["category"] == "metadata_only_already_supported"
+        if entry["repo_impact"]["category"] == "already_supported"
     ]
     actionable_changes = [
         entry
@@ -736,8 +899,8 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             f"- Actionable removed operations: `{report['repo_summary']['actionable_removed']}`",
             f"- Actionable changed operations: `{report['repo_summary']['actionable_changed']}`",
             (
-                "- Changed operations already supported by repo metadata handling: "
-                f"`{report['repo_summary']['metadata_only_already_supported']}`"
+                "- Changed operations already supported by repo handling: "
+                f"`{report['repo_summary']['already_supported_changed']}`"
             ),
             "",
         ]
@@ -748,7 +911,7 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             [
                 "No actionable repo drift detected after repo-aware classification.",
                 "The tracked baseline is stale, but the changed operations are already covered by",
-                "the repository's global request-metadata handling.",
+                "the repository's global request-metadata or flexible schema handling.",
                 "",
             ]
         )
@@ -756,18 +919,26 @@ def render_markdown_report(report: dict[str, Any]) -> str:
     lines.extend(markdown_list("Added Operations", [entry["id"] for entry in report["added"]]))
     lines.extend(markdown_list("Removed Operations", [entry["id"] for entry in report["removed"]]))
 
-    lines.append("## Metadata-Only Changes Already Supported By Repo")
+    lines.append("## Changes Already Supported By Repo")
     lines.append("")
-    if not metadata_only_changes:
+    if not already_supported_changes:
         lines.append("- None")
         lines.append("")
     else:
-        for entry in metadata_only_changes:
-            supported_parameters = ", ".join(
-                f"`{parameter}`"
-                for parameter in entry["repo_impact"]["supported_parameters"]
-            )
-            lines.append(f"- `{entry['id']}` ({supported_parameters})")
+        for entry in already_supported_changes:
+            support_notes = []
+            if entry["repo_impact"]["supported_parameters"]:
+                support_notes.extend(
+                    f"`{parameter}`"
+                    for parameter in entry["repo_impact"]["supported_parameters"]
+                )
+            if entry["repo_impact"].get("schema_rules"):
+                support_notes.extend(
+                    f"`{rule}`"
+                    for rule in entry["repo_impact"]["schema_rules"]
+                )
+            support_note = ", ".join(support_notes)
+            lines.append(f"- `{entry['id']}` ({support_note})")
         lines.append("")
 
     lines.append("## Actionable Changed Operations")
@@ -781,12 +952,19 @@ def render_markdown_report(report: dict[str, Any]) -> str:
                 f"- `{entry['id']}` "
                 f"(`{entry['baseline_fingerprint']}` -> `{entry['candidate_fingerprint']}`)"
             )
+            support_notes = []
             if entry["repo_impact"]["supported_parameters"]:
-                supported_parameters = ", ".join(
+                support_notes.extend(
                     f"`{parameter}`"
                     for parameter in entry["repo_impact"]["supported_parameters"]
                 )
-                lines.append(f"  Repo metadata already covers: {supported_parameters}")
+            if entry["repo_impact"].get("schema_rules"):
+                support_notes.extend(
+                    f"`{rule}`"
+                    for rule in entry["repo_impact"]["schema_rules"]
+                )
+            if support_notes:
+                lines.append(f"  Repo already covers: {', '.join(support_notes)}")
             lines.append("")
             lines.append("```diff")
             lines.extend(entry["diff_preview"] or ["# normalized operation diff was empty"])
@@ -894,8 +1072,8 @@ def command_compare(args: argparse.Namespace) -> int:
         f"removed={report['summary']['removed']}, "
         f"changed={report['summary']['changed']}, "
         f"actionable_changed={report['repo_summary']['actionable_changed']}, "
-        "metadata_only_already_supported="
-        f"{report['repo_summary']['metadata_only_already_supported']}"
+        "already_supported_changed="
+        f"{report['repo_summary']['already_supported_changed']}"
     )
     print(f"- markdown report: {args.report_md}")
     print(f"- json report: {args.report_json}")

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,23 +1,13 @@
 {
   "components": {
     "parameters": {
-      "AppCategories": {
-        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
-        "in": "header",
-        "name": "X-OpenRouter-Categories",
-        "schema": {
-          "type": "string"
-        },
-        "x-speakeasy-name-override": "appCategories"
-      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-OpenRouter-Title",
+        "name": "X-Title",
         "schema": {
           "type": "string"
-        },
-        "x-speakeasy-name-override": "appTitle"
+        }
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -3937,8 +3927,7 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField",
-            "nullable": true
+            "$ref": "#/components/schemas/ResponsesErrorField"
           },
           "frequency_penalty": {
             "format": "double",
@@ -3949,12 +3938,10 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails",
-            "nullable": true
+            "$ref": "#/components/schemas/IncompleteDetails"
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs",
-            "nullable": true
+            "$ref": "#/components/schemas/BaseInputs"
           },
           "max_output_tokens": {
             "nullable": true,
@@ -4035,8 +4022,7 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig",
-            "nullable": true
+            "$ref": "#/components/schemas/BaseReasoningConfig"
           },
           "safety_identifier": {
             "nullable": true,
@@ -4057,8 +4043,7 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig",
-            "nullable": true
+            "$ref": "#/components/schemas/TextConfig"
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -4147,7 +4132,6 @@
             "type": "array"
           },
           "top_logprobs": {
-            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -4156,8 +4140,7 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation",
-            "nullable": true
+            "$ref": "#/components/schemas/Truncation"
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -12365,6 +12348,7 @@
                   "Morph",
                   "NCompass",
                   "Nebius",
+                  "Nex AGI",
                   "NextBit",
                   "Novita",
                   "Nvidia",
@@ -15123,7 +15107,7 @@
           "audio",
           "video",
           "rerank",
-          "tts"
+          "speech"
         ],
         "example": "text",
         "type": "string",
@@ -15900,6 +15884,7 @@
           "Morph",
           "NCompass",
           "Nebius",
+          "Nex AGI",
           "NextBit",
           "Novita",
           "Nvidia",
@@ -16281,6 +16266,7 @@
               "Morph",
               "NCompass",
               "Nebius",
+              "Nex AGI",
               "NextBit",
               "Novita",
               "Nvidia",
@@ -17847,7 +17833,7 @@
         "type": "object"
       },
       "SearchQualityLevel": {
-        "description": "How much context to retrieve per result. Defaults to medium (15000 chars). Only applies when using the Exa engine; ignored with native provider search.",
+        "description": "How much context to retrieve per result. Defaults to medium (15000 chars). Applies to Exa and Parallel engines; ignored with native provider search and Firecrawl.",
         "enum": [
           "low",
           "medium",
@@ -18385,6 +18371,12 @@
                     "type": "object"
                   },
                   "nebius": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "nex-agi": {
                     "additionalProperties": {
                       "nullable": true
                     },
@@ -20275,6 +20267,12 @@
                     },
                     "type": "object"
                   },
+                  "nex-agi": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
                   "nextbit": {
                     "additionalProperties": {
                       "nullable": true
@@ -21637,31 +21635,9 @@
         "tags": [
           "Analytics"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/audio/speech": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Synthesizes audio from the input text",
         "operationId": "createAudioSpeech",
@@ -21865,17 +21841,6 @@
       }
     },
     "/auth/keys": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -22018,17 +21983,6 @@
       }
     },
     "/auth/keys/code": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -22258,17 +22212,6 @@
       }
     },
     "/chat/completions": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
@@ -22691,31 +22634,9 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/credits/coinbase": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -22752,17 +22673,6 @@
       }
     },
     "/embeddings": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -23364,18 +23274,7 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/endpoints/zdr": {
       "get": {
@@ -23510,18 +23409,7 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/generation": {
       "get": {
@@ -23726,18 +23614,7 @@
         "tags": [
           "Generations"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/generation/content": {
       "get": {
@@ -23916,18 +23793,7 @@
         "tags": [
           "Generations"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails": {
       "get": {
@@ -24065,17 +23931,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -24321,18 +24176,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -24446,18 +24290,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails/{id}": {
       "delete": {
@@ -24650,17 +24483,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
@@ -24938,17 +24760,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
@@ -25068,17 +24879,6 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -25338,17 +25138,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -25469,17 +25258,6 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -25901,18 +25679,7 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/keys": {
       "get": {
@@ -26258,17 +26025,6 @@
         ],
         "x-speakeasy-name-override": "list"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
@@ -27129,17 +26885,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -27545,17 +27290,6 @@
       }
     },
     "/messages": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
@@ -27930,18 +27664,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/count": {
       "get": {
@@ -28013,18 +27736,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/user": {
       "get": {
@@ -28146,18 +27858,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -28323,18 +28024,7 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/organization/members": {
       "get": {
@@ -28522,18 +28212,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/providers": {
       "get": {
@@ -29184,31 +28863,9 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/rerank": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -29585,17 +29242,6 @@
       }
     },
     "/responses": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
@@ -29886,17 +29532,6 @@
       }
     },
     "/videos": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -30122,18 +29757,7 @@
         "tags": [
           "Video Generation"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/videos/{jobId}": {
       "get": {
@@ -30228,18 +29852,7 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -30368,18 +29981,7 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/workspaces": {
       "get": {
@@ -30501,17 +30103,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new workspace for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createWorkspace",
@@ -30852,17 +30443,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateWorkspace",
@@ -31011,17 +30591,6 @@
       }
     },
     "/workspaces/{id}/members/add": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Add multiple organization members to a workspace. Members are assigned the same role they hold in the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAddWorkspaceMembers",
@@ -31167,17 +30736,6 @@
       }
     },
     "/workspaces/{id}/members/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkRemoveWorkspaceMembers",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-22T05:55:41+00:00",
+  "captured_at": "2026-04-23T04:35:16+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -18,7 +18,7 @@
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "fc9cb5e5f6b4e39c",
+      "fingerprint": "62d6681f3fc2fe20",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0ff2409f46ebd93d",
+      "fingerprint": "2a479c2a2828c351",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0366f25ef11315e3",
+      "fingerprint": "01579a8548d64ab2",
       "id": "DELETE /workspaces/{id}",
       "method": "DELETE",
       "operation_id": "deleteWorkspace",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d143da7f6f9162c0",
+      "fingerprint": "a8e8f18928c3c86a",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e87fbb5bb40b4c60",
+      "fingerprint": "05cecac9b09a5e7c",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "30cba935ed98ef92",
+      "fingerprint": "f9245e7ad764aaf0",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d94195530e0414a4",
+      "fingerprint": "2b64539bdea63842",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0edcf488ff274fea",
+      "fingerprint": "47828cc6e721062e",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9cccd989d9cf69e1",
+      "fingerprint": "9fbe3d8789b59348",
       "id": "GET /generation/content",
       "method": "GET",
       "operation_id": "listGenerationContent",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3d3e8c9561d450c5",
+      "fingerprint": "fb76f9599911ccb5",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b43f6f0d1e70ec62",
+      "fingerprint": "50df372af92b0439",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "93d944d97fca595b",
+      "fingerprint": "48ed8bcc9c811a11",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6a953189b58fc510",
+      "fingerprint": "aa3c9f9c9d5fe9ae",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -161,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "34604a16fa41fb79",
+      "fingerprint": "bdcc5f13eb39b87d",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -172,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6a182854d359c7c1",
+      "fingerprint": "622584d38112ff60",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6a1d8e77363531a7",
+      "fingerprint": "c73983473e1c0e0e",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "73fe6021d5d3877d",
+      "fingerprint": "bd94c1cb6e19cdd2",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb6bbfd93f43f252",
+      "fingerprint": "7d938af215f4d03a",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2fa2acafbf6ad7ef",
+      "fingerprint": "6c89b5d549bc33a9",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "39d755b55859e6de",
+      "fingerprint": "360a71c424058693",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4f89ab2b49b36d23",
+      "fingerprint": "4c77c4b4c9a82e2a",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "285752418aed97c4",
+      "fingerprint": "06aa57cbae9f7f82",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7687a0f00ba6d1b1",
+      "fingerprint": "afba5151a3299caf",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "db6ea0df829856f4",
+      "fingerprint": "6d3ec9bee71dc2ce",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "db1c62dade2d8f06",
+      "fingerprint": "14596fe6b03e4428",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "45699b9654b6db62",
+      "fingerprint": "0c91e369c0a0d9e1",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "81bf8fc0183755b8",
+      "fingerprint": "f762b88d789b2723",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3a9c1ed02a70dbbc",
+      "fingerprint": "884dec04861b659d",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "022156582f1948b1",
+      "fingerprint": "5e33269f90dfab34",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -337,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4c0058a2655e0d29",
+      "fingerprint": "17f6c0ff95ea6247",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -348,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4ccab78044c4a13d",
+      "fingerprint": "e96abe881cfbc08b",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b2f88fd0f3e4d4f3",
+      "fingerprint": "ac1cb8e84c7edadf",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "36acd96bab4c7e68",
+      "fingerprint": "3accdcf44d289173",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d5a58f4512027317",
+      "fingerprint": "350024ac1009cddb",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0781a831d48dec54",
+      "fingerprint": "ce53dfc76885c522",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1562181e4b362b9f",
+      "fingerprint": "0e7bdf1d47712c06",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -414,7 +414,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "4d49cd207179e897",
+      "fingerprint": "3aae29d559805e6d",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0f4fe255c155ded7",
+      "fingerprint": "e91b05a24b6c789c",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2286b192a05d7bfe",
+      "fingerprint": "f1bba43860a3f2fe",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -447,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6b121e68b5bcdb55",
+      "fingerprint": "cac6ec19bd951299",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -458,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8d3111ee0fdd6842",
+      "fingerprint": "fc5f8809122a9fec",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -469,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "04c2e86ce1b63136",
+      "fingerprint": "a60d54c8a1dd80c0",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -480,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "76d6bf8fb6c08c1e",
+      "fingerprint": "95cd05e9fbc9490b",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -491,7 +491,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2384f8263630f7cc",
+      "fingerprint": "42c34e6c3b001698",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -502,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "96eb9d6251d766c0",
+      "fingerprint": "22fcb0e38708b304",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -513,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "38cb2fd0bea5ce96",
+      "fingerprint": "081bd95b8cb9101b",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -524,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5fbef18da5e4a468",
+      "fingerprint": "a1f95f0feef3f81b",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -535,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3dae513ba8623eb6",
+      "fingerprint": "b0c72b4a38bf99da",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -546,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a94b578527cd26f6",
+      "fingerprint": "4206e4a1e2d22238",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -557,7 +557,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "46c26f63f1cae2e4",
+      "fingerprint": "e870d118f618fb87",
       "id": "POST /workspaces/{id}/members/add",
       "method": "POST",
       "operation_id": "bulkAddWorkspaceMembers",
@@ -568,7 +568,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d3ee5d978118adf4",
+      "fingerprint": "7ddc552ce8a708a0",
       "id": "POST /workspaces/{id}/members/remove",
       "method": "POST",
       "operation_id": "bulkRemoveWorkspaceMembers",

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -17,6 +17,7 @@ def build_spec(
     path="/models",
     operation_id="getModels",
     parameters=None,
+    request_properties=None,
     response_properties=None,
 ):
     operation = {
@@ -37,6 +38,17 @@ def build_spec(
             }
         },
     }
+    if request_properties is not None:
+        operation["requestBody"] = {
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": request_properties,
+                    }
+                }
+            }
+        }
     if parameters is not None:
         operation["parameters"] = parameters
 
@@ -221,6 +233,41 @@ class OpenApiDriftReportTests(unittest.TestCase):
             ["dynamic provider name enum"],
         )
 
+    def test_dynamic_enum_with_object_members_does_not_crash(self):
+        baseline = build_spec(
+            response_properties={
+                "provider_name": {
+                    "enum": ["Anthropic", "Google", "OpenAI", {"custom": True}],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow",
+                }
+            }
+        )
+        candidate = build_spec(
+            response_properties={
+                "provider_name": {
+                    "enum": ["Anthropic", "Google", "Nex AGI", "OpenAI", {"custom": True}],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow",
+                }
+            }
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+
     def test_dynamic_modality_enum_drift_is_classified_as_already_supported(self):
         baseline = build_spec(
             response_properties={
@@ -361,6 +408,39 @@ class OpenApiDriftReportTests(unittest.TestCase):
         )
         candidate = build_spec(
             response_properties={
+                "top_logprobs": {"type": "integer"},
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+
+    def test_responses_request_nullable_drift_remains_actionable(self):
+        baseline = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            request_properties={
+                "top_logprobs": {"nullable": True, "type": "integer"},
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            request_properties={
                 "top_logprobs": {"type": "integer"},
             },
         )

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -11,9 +11,16 @@ openapi_drift = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(openapi_drift)
 
 
-def build_spec(*, parameters=None, response_properties=None):
+def build_spec(
+    *,
+    method="get",
+    path="/models",
+    operation_id="getModels",
+    parameters=None,
+    response_properties=None,
+):
     operation = {
-        "operationId": "getModels",
+        "operationId": operation_id,
         "responses": {
             "200": {
                 "description": "ok",
@@ -37,8 +44,8 @@ def build_spec(*, parameters=None, response_properties=None):
         "openapi": "3.1.0",
         "info": {"title": "Test", "version": "1.0.0"},
         "paths": {
-            "/models": {
-                "get": operation,
+            path: {
+                method: operation,
             }
         },
     }
@@ -62,6 +69,11 @@ class OpenApiDriftReportTests(unittest.TestCase):
                 },
                 {
                     "in": "header",
+                    "name": "X-Title",
+                    "schema": {"type": "string"},
+                },
+                {
+                    "in": "header",
                     "name": "X-OpenRouter-Categories",
                     "schema": {"type": "string"},
                     "x-speakeasy-name-override": "appCategories",
@@ -81,11 +93,11 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertTrue(report["has_drift"])
         self.assertFalse(report["has_actionable_drift"])
         self.assertEqual(report["summary"]["changed"], 1)
-        self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 1)
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
         self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
         self.assertEqual(
             report["changed"][0]["repo_impact"]["category"],
-            "metadata_only_already_supported",
+            "already_supported",
         )
 
     def test_non_metadata_schema_change_remains_actionable(self):
@@ -124,7 +136,7 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertTrue(report["has_drift"])
         self.assertTrue(report["has_actionable_drift"])
         self.assertEqual(report["summary"]["changed"], 1)
-        self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 0)
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
         self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
 
@@ -162,13 +174,211 @@ class OpenApiDriftReportTests(unittest.TestCase):
 
         self.assertTrue(report["has_drift"])
         self.assertTrue(report["has_actionable_drift"])
-        self.assertEqual(report["repo_summary"]["metadata_only_already_supported"], 0)
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
         self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
         self.assertEqual(
             report["changed"][0]["repo_impact"]["supported_parameters"],
             ["header X-OpenRouter-Title"],
         )
+
+    def test_dynamic_provider_enum_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            response_properties={
+                "provider_name": {
+                    "enum": ["Anthropic", "Google", "OpenAI"],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow",
+                }
+            }
+        )
+        candidate = build_spec(
+            response_properties={
+                "provider_name": {
+                    "enum": ["Anthropic", "Google", "Nex AGI", "OpenAI"],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow",
+                }
+            }
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["dynamic provider name enum"],
+        )
+
+    def test_dynamic_modality_enum_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            response_properties={
+                "output_modalities": {
+                    "items": {
+                        "enum": ["audio", "image", "text", "tts", "video"],
+                        "type": "string",
+                        "x-speakeasy-unknown-values": "allow",
+                    },
+                    "type": "array",
+                }
+            }
+        )
+        candidate = build_spec(
+            response_properties={
+                "output_modalities": {
+                    "items": {
+                        "enum": ["audio", "image", "speech", "text", "video"],
+                        "type": "string",
+                        "x-speakeasy-unknown-values": "allow",
+                    },
+                    "type": "array",
+                }
+            }
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["dynamic output modality enum"],
+        )
+
+    def test_provider_options_map_drift_is_classified_as_already_supported(self):
+        provider_option = {
+            "additionalProperties": {"nullable": True},
+            "type": "object",
+        }
+        baseline = build_spec(
+            response_properties={
+                "provider": {
+                    "properties": {
+                        "anthropic": provider_option,
+                        "google-vertex": provider_option,
+                        "openai": provider_option,
+                    },
+                    "type": "object",
+                }
+            }
+        )
+        candidate = build_spec(
+            response_properties={
+                "provider": {
+                    "properties": {
+                        "anthropic": provider_option,
+                        "google-vertex": provider_option,
+                        "nex-agi": provider_option,
+                        "openai": provider_option,
+                    },
+                    "type": "object",
+                }
+            }
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["provider-specific options map"],
+        )
+
+    def test_responses_nullable_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            response_properties={
+                "top_logprobs": {"nullable": True, "type": "integer"},
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            response_properties={
+                "top_logprobs": {"type": "integer"},
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Responses flexible nullable fields"],
+        )
+
+    def test_non_responses_nullable_drift_remains_actionable(self):
+        baseline = build_spec(
+            response_properties={
+                "top_logprobs": {"nullable": True, "type": "integer"},
+            },
+        )
+        candidate = build_spec(
+            response_properties={
+                "top_logprobs": {"type": "integer"},
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- Classifies #197 dynamic provider/modality enums, provider option maps, Responses nullable drift, and request-metadata drift as already supported when the SDK already covers them with flexible types/header handling.
- Refreshes the 2026-04-23 OpenAPI baseline and endpoint matrix notes.

Testing
- just quality
- just openapi-drift-check
- python3 -m unittest discover -s tests -p 'test_openapi_drift.py'

Closes #197