### PR TITLE
fix: reconcile latest OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
 - Added typed `num_fetches` support on `GET /generation` metadata responses via `GenerationData`.
+- Added typed `response_cache_source_id` support on `GET /generation` metadata responses.
+- Added workspace I/O logging fields on typed workspace responses and create/update requests: `io_logging_api_key_ids` and `io_logging_sampling_rate`.
+- Added `callback_url` support on `VideoGenerationRequest` for video completion webhooks.
 - Added typed SDK support for `GET /workspaces`, `POST /workspaces`, `GET /workspaces/{id}`, `PATCH /workspaces/{id}`, `DELETE /workspaces/{id}`, `POST /workspaces/{id}/members/add`, and `POST /workspaces/{id}/members/remove`, including canonical `client.management()` methods and a runnable `examples/list_workspaces.rs`.
 - Added workspace-aware API-key and guardrail support, including `workspace_id` fields on typed models plus `create_api_key_in_workspace(...)`, `list_api_keys_in_workspace(...)`, and `list_guardrails_in_workspace(...)`.
 - Added `openrouter-cli workspaces ...` commands, plus `--workspace-id` support for `openrouter-cli keys list|create` and `openrouter-cli guardrails list|create`.
@@ -19,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and restored the repository snapshot to `51 / 51` official OpenAPI endpoint coverage.
 - Accepted the 2026-04-22 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
 - Accepted the 2026-04-23 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
+- Accepted the 2026-04-28 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
 - Nightly OpenAPI drift reports now keep the raw upstream diff but separately classify changes already covered by the SDK's global request-metadata handling, dynamic `String` taxonomy fields, provider options maps, and Responses `Option`/`Value` parsing, reducing false-positive follow-up noise.
+- OpenAPI drift classification now also recognizes flexible plugin payloads, Anthropic Messages hosted-tool option payloads, and Responses tool/output `Value` payloads.
 
 ## [0.8.1] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, embeddings, and ZDR endpoints
+- typed generation metadata, workspace I/O logging controls, and video callback URL support
 - management-key workflows for keys, workspace-scoped keys, auth codes, organization members, workspaces, workspace membership, guardrails, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.

--- a/crates/openrouter-cli/tests/management_commands.rs
+++ b/crates/openrouter-cli/tests/management_commands.rs
@@ -331,7 +331,7 @@ fn test_guardrail_key_assignment_assign_happy_path() {
 #[test]
 fn test_workspaces_list_happy_path() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":[{"id":"ws_1","name":"Core","slug":"core","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}],"total_count":1}"#,
+        r#"{"data":[{"id":"ws_1","name":"Core","slug":"core","io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}],"total_count":1}"#,
     );
 
     let mut cmd = base_cmd(&base_url);
@@ -355,6 +355,12 @@ fn test_workspaces_list_happy_path() {
         parsed.pointer("/data/data/0/slug").and_then(Value::as_str),
         Some("core")
     );
+    assert_eq!(
+        parsed
+            .pointer("/data/data/0/io_logging_sampling_rate")
+            .and_then(Value::as_f64),
+        Some(1.0)
+    );
 
     let captured = rx
         .recv_timeout(Duration::from_secs(2))
@@ -370,7 +376,7 @@ fn test_workspaces_list_happy_path() {
 #[test]
 fn test_workspaces_create_happy_path() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","description":"Core team","default_text_model":"openai/gpt-4.1","is_observability_io_logging_enabled":true,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
+        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","description":"Core team","default_text_model":"openai/gpt-4.1","io_logging_api_key_ids":[123],"io_logging_sampling_rate":0.5,"is_observability_io_logging_enabled":true,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
     );
 
     let mut cmd = base_cmd(&base_url);
@@ -393,6 +399,12 @@ fn test_workspaces_create_happy_path() {
     assert_eq!(
         parsed.pointer("/data/id").and_then(Value::as_str),
         Some("ws_1")
+    );
+    assert_eq!(
+        parsed
+            .pointer("/data/io_logging_api_key_ids/0")
+            .and_then(Value::as_u64),
+        Some(123)
     );
 
     let captured = rx
@@ -433,7 +445,7 @@ fn test_workspaces_create_happy_path() {
 #[test]
 fn test_workspaces_get_happy_path() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
+        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
     );
 
     let mut cmd = base_cmd(&base_url);
@@ -443,6 +455,12 @@ fn test_workspaces_get_happy_path() {
     assert_eq!(
         parsed.pointer("/data/slug").and_then(Value::as_str),
         Some("core")
+    );
+    assert_eq!(
+        parsed
+            .pointer("/data/io_logging_sampling_rate")
+            .and_then(Value::as_f64),
+        Some(1.0)
     );
 
     let captured = rx
@@ -459,7 +477,7 @@ fn test_workspaces_get_happy_path() {
 #[test]
 fn test_workspaces_update_happy_path() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"ws_1","name":"Core Updated","slug":"core","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z","updated_at":"2026-03-02T00:00:00.000Z"}}"#,
+        r#"{"data":{"id":"ws_1","name":"Core Updated","slug":"core","io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z","updated_at":"2026-03-02T00:00:00.000Z"}}"#,
     );
 
     let mut cmd = base_cmd(&base_url);
@@ -474,6 +492,12 @@ fn test_workspaces_update_happy_path() {
     assert_eq!(
         parsed.pointer("/data/name").and_then(Value::as_str),
         Some("Core Updated")
+    );
+    assert_eq!(
+        parsed
+            .pointer("/data/io_logging_sampling_rate")
+            .and_then(Value::as_f64),
+        Some(1.0)
     );
 
     let captured = rx

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-23
+Snapshot date: 2026-04-28
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -20,6 +20,8 @@ Drift review note:
 - Upstream now exposes request metadata through generator globals (`HTTP-Referer`, `X-Title`) instead of repeating path-level metadata parameters. The SDK already applies `HTTP-Referer`, `X-Title`, `X-OpenRouter-Title`, and optional `X-OpenRouter-Categories` through the client builder.
 - Upstream added `num_fetches` to generation metadata responses. The typed `GenerationData` surface now deserializes it.
 - Upstream refreshed dynamic taxonomy details (`OutputModality` now uses `speech` instead of `tts`, provider lists now include `Nex AGI`, and Responses result nullable annotations were narrowed). The SDK already carries those surfaces through flexible `String`, `Value`, `HashMap`, and `Option` fields, so no public API migration is required.
+- Upstream added `response_cache_source_id` to generation metadata, workspace I/O logging key filters and sampling rate fields, and `callback_url` for video generation requests. The SDK now exposes those typed fields, and the 2026-04-28 baseline refresh keeps the accepted endpoint snapshot at `51 / 51`.
+- Upstream refreshed web-search, provider, and Responses output schemas. Existing OpenRouter plugin passthrough, Anthropic hosted-tool extras, provider option maps, and Responses `Value` payloads carry those schema details without a public API migration.
 
 Legend:
 

--- a/docs/operations/openapi-drift-reporting.md
+++ b/docs/operations/openapi-drift-reporting.md
@@ -46,6 +46,9 @@ surfaces:
 - global request metadata headers (`X-OpenRouter-Title`, `X-Title`, `HTTP-Referer`, and `X-OpenRouter-Categories`)
 - dynamic provider-name and output-modality enums surfaced as `String` values by the SDK
 - provider-specific passthrough options surfaced as `HashMap<String, Value>`
+- flexible plugin payloads surfaced as `Plugin` configuration maps
+- Anthropic Messages hosted-tool options surfaced through `AnthropicTool::extra`
+- Responses tool and output payloads surfaced as `Value`
 - Responses result nullable annotations covered by `Option`/`Value` response parsing
 
 This lets the report separate:

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -71,6 +71,13 @@ REPO_RESPONSES_FLEXIBLE_NULLABILITY_FIELDS = frozenset(
         "top_logprobs",
     }
 )
+REPO_FLEXIBLE_PLUGIN_OPERATION_KEYS = frozenset(
+    {
+        "POST /chat/completions",
+        "POST /messages",
+        "POST /responses",
+    }
+)
 BASELINE_TOP_LEVEL_FIELDS = (
     "components",
     "info",
@@ -405,12 +412,71 @@ def is_responses_response_payload_path(operation_key: str, path: tuple[Any, ...]
     return operation_key == "POST /responses" and bool(path) and path[0] == "responses"
 
 
+def is_request_schema_property_path(path: tuple[Any, ...], property_name: str) -> bool:
+    return (
+        "requestBody" in path
+        and len(path) >= 2
+        and path[-2:] == ("properties", property_name)
+    )
+
+
+def is_response_schema_property_path(path: tuple[Any, ...], property_name: str) -> bool:
+    return (
+        "responses" in path
+        and len(path) >= 2
+        and path[-2:] == ("properties", property_name)
+    )
+
+
+def is_repo_supported_flexible_plugin_payload_path(
+    operation_key: str,
+    path: tuple[Any, ...],
+) -> bool:
+    return (
+        operation_key in REPO_FLEXIBLE_PLUGIN_OPERATION_KEYS
+        and is_request_schema_property_path(path, "plugins")
+    )
+
+
+def is_repo_supported_messages_tool_payload_path(
+    operation_key: str,
+    path: tuple[Any, ...],
+) -> bool:
+    return operation_key == "POST /messages" and is_request_schema_property_path(path, "tools")
+
+
+def is_repo_supported_responses_tool_payload_path(
+    operation_key: str,
+    path: tuple[Any, ...],
+) -> bool:
+    return operation_key == "POST /responses" and is_request_schema_property_path(path, "tools")
+
+
+def is_repo_supported_responses_output_payload_path(
+    operation_key: str,
+    path: tuple[Any, ...],
+) -> bool:
+    return operation_key == "POST /responses" and is_response_schema_property_path(path, "output")
+
+
 def strip_repo_supported_schema_details(
     operation_key: str,
     value: Any,
     path: tuple[Any, ...] = (),
 ) -> Any:
     if isinstance(value, dict):
+        if is_repo_supported_flexible_plugin_payload_path(operation_key, path):
+            return {"<repo-supported-flexible-plugin-payload>": True}
+
+        if is_repo_supported_messages_tool_payload_path(operation_key, path):
+            return {"<repo-supported-messages-tool-payload>": True}
+
+        if is_repo_supported_responses_tool_payload_path(operation_key, path):
+            return {"<repo-supported-responses-tool-payload>": True}
+
+        if is_repo_supported_responses_output_payload_path(operation_key, path):
+            return {"<repo-supported-responses-output-payload>": True}
+
         stripped = {
             key: strip_repo_supported_schema_details(operation_key, item, path + (key,))
             for key, item in value.items()
@@ -457,6 +523,14 @@ def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[
                 rules.add("dynamic output modality enum")
             if is_repo_supported_provider_options_map(item):
                 rules.add("provider-specific options map")
+            if is_repo_supported_flexible_plugin_payload_path(operation_key, path):
+                rules.add("flexible plugin payload")
+            if is_repo_supported_messages_tool_payload_path(operation_key, path):
+                rules.add("Messages flexible tool payload")
+            if is_repo_supported_responses_tool_payload_path(operation_key, path):
+                rules.add("Responses flexible tool payload")
+            if is_repo_supported_responses_output_payload_path(operation_key, path):
+                rules.add("Responses flexible output payload")
             if is_responses_response_payload_path(operation_key, path):
                 properties = item.get("properties")
                 if isinstance(properties, dict):

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -7264,6 +7264,21 @@
             "nullable": true,
             "type": "string"
           },
+          "io_logging_api_key_ids": {
+            "description": "Optional array of API key IDs to filter I/O logging",
+            "example": null,
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "io_logging_sampling_rate": {
+            "description": "Sampling rate for I/O logging (0.0001-1)",
+            "example": 1,
+            "format": "double",
+            "type": "number"
+          },
           "is_data_discount_logging_enabled": {
             "description": "Whether data discount logging is enabled",
             "example": true,
@@ -7311,6 +7326,8 @@
             "default_text_model": "openai/gpt-4o",
             "description": "Production environment workspace",
             "id": "550e8400-e29b-41d4-a716-446655440000",
+            "io_logging_api_key_ids": null,
+            "io_logging_sampling_rate": 1,
             "is_data_discount_logging_enabled": true,
             "is_observability_broadcast_enabled": false,
             "is_observability_io_logging_enabled": false,
@@ -8727,6 +8744,11 @@
                 "nullable": true,
                 "type": "string"
               },
+              "response_cache_source_id": {
+                "description": "If this generation was served from response cache, contains the original generation ID. Null otherwise.",
+                "nullable": true,
+                "type": "string"
+              },
               "router": {
                 "description": "Router used for the request (e.g., openrouter/auto)",
                 "example": "openrouter/auto",
@@ -8890,6 +8912,8 @@
             "default_text_model": "openai/gpt-4o",
             "description": "Production environment workspace",
             "id": "550e8400-e29b-41d4-a716-446655440000",
+            "io_logging_api_key_ids": null,
+            "io_logging_sampling_rate": 1,
             "is_data_discount_logging_enabled": true,
             "is_observability_broadcast_enabled": false,
             "is_observability_io_logging_enabled": false,
@@ -9860,10 +9884,52 @@
                   "$ref": "#/components/schemas/OutputImageGenerationCallItem"
                 },
                 {
+                  "$ref": "#/components/schemas/OutputCodeInterpreterCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputComputerCallItem"
+                },
+                {
                   "$ref": "#/components/schemas/OutputDatetimeItem"
                 },
                 {
                   "$ref": "#/components/schemas/OutputWebSearchServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputCodeInterpreterServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputFileSearchServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputImageGenerationServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputBrowserUseServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputBashServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputTextEditorServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputApplyPatchServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputWebFetchServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputToolSearchServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputMemoryServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputMcpServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputSearchModelsServerToolItem"
                 }
               ]
             },
@@ -10368,6 +10434,8 @@
               "default_text_model": "openai/gpt-4o",
               "description": "Production environment workspace",
               "id": "550e8400-e29b-41d4-a716-446655440000",
+              "io_logging_api_key_ids": null,
+              "io_logging_sampling_rate": 1,
               "is_data_discount_logging_enabled": true,
               "is_observability_broadcast_enabled": false,
               "is_observability_io_logging_enabled": false,
@@ -12355,6 +12423,7 @@
                   "OpenAI",
                   "OpenInference",
                   "Parasail",
+                  "Poolside",
                   "Perplexity",
                   "Phala",
                   "Recraft",
@@ -15891,6 +15960,7 @@
           "OpenAI",
           "OpenInference",
           "Parasail",
+          "Poolside",
           "Perplexity",
           "Phala",
           "Recraft",
@@ -16273,6 +16343,7 @@
               "OpenAI",
               "OpenInference",
               "Parasail",
+              "Poolside",
               "Perplexity",
               "Phala",
               "Recraft",
@@ -18442,6 +18513,12 @@
                     },
                     "type": "object"
                   },
+                  "poolside": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
                   "recraft": {
                     "additionalProperties": {
                       "nullable": true
@@ -19642,6 +19719,21 @@
             "nullable": true,
             "type": "string"
           },
+          "io_logging_api_key_ids": {
+            "description": "Optional array of API key IDs to filter I/O logging",
+            "example": null,
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "io_logging_sampling_rate": {
+            "description": "Sampling rate for I/O logging (0.0001-1)",
+            "example": 1,
+            "format": "double",
+            "type": "number"
+          },
           "is_data_discount_logging_enabled": {
             "description": "Whether data discount logging is enabled",
             "example": true,
@@ -19685,6 +19777,8 @@
             "default_text_model": "openai/gpt-4o",
             "description": "Production environment workspace",
             "id": "550e8400-e29b-41d4-a716-446655440000",
+            "io_logging_api_key_ids": null,
+            "io_logging_sampling_rate": 1,
             "is_data_discount_logging_enabled": true,
             "is_observability_broadcast_enabled": false,
             "is_observability_io_logging_enabled": false,
@@ -19796,6 +19890,12 @@
             "example": "16:9",
             "type": "string",
             "x-speakeasy-unknown-values": "allow"
+          },
+          "callback_url": {
+            "description": "URL to receive a webhook notification when the video generation job completes. Overrides the workspace-level default callback URL if set. Must be HTTPS.",
+            "example": "https://example.com/webhook",
+            "format": "uri",
+            "type": "string"
           },
           "duration": {
             "description": "Duration of the generated video in seconds",
@@ -20328,6 +20428,12 @@
                     "type": "object"
                   },
                   "phala": {
+                    "additionalProperties": {
+                      "nullable": true
+                    },
+                    "type": "object"
+                  },
+                  "poolside": {
                     "additionalProperties": {
                       "nullable": true
                     },
@@ -21109,8 +21215,32 @@
           "max_results": {
             "type": "integer"
           },
+          "max_uses": {
+            "description": "Maximum number of times the model can invoke web search in a single turn. Passed through to native providers that support it (e.g. Anthropic).",
+            "type": "integer"
+          },
           "search_prompt": {
             "type": "string"
+          },
+          "user_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WebSearchUserLocation"
+              },
+              {
+                "description": "Approximate user location for location-biased search results. Passed through to native providers that support it (e.g. Anthropic).",
+                "example": {
+                  "city": "San Francisco",
+                  "country": "US",
+                  "region": "California",
+                  "timezone": "America/Los_Angeles",
+                  "type": "approximate"
+                },
+                "required": [
+                  "type"
+                ]
+              }
+            ]
           }
         },
         "required": [
@@ -21275,15 +21405,19 @@
         },
         "properties": {
           "city": {
+            "nullable": true,
             "type": "string"
           },
           "country": {
+            "nullable": true,
             "type": "string"
           },
           "region": {
+            "nullable": true,
             "type": "string"
           },
           "timezone": {
+            "nullable": true,
             "type": "string"
           },
           "type": {
@@ -21304,6 +21438,8 @@
           "default_text_model": "openai/gpt-4o",
           "description": "Production environment workspace",
           "id": "550e8400-e29b-41d4-a716-446655440000",
+          "io_logging_api_key_ids": null,
+          "io_logging_sampling_rate": 1,
           "is_data_discount_logging_enabled": true,
           "is_observability_broadcast_enabled": false,
           "is_observability_io_logging_enabled": false,
@@ -21353,6 +21489,21 @@
             "format": "uuid",
             "type": "string"
           },
+          "io_logging_api_key_ids": {
+            "description": "Optional array of API key IDs to filter I/O logging. Null means all keys are logged.",
+            "example": null,
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "io_logging_sampling_rate": {
+            "description": "Sampling rate for I/O logging (0.0001-1). 1 means 100% of requests are logged.",
+            "example": 1,
+            "format": "double",
+            "type": "number"
+          },
           "is_data_discount_logging_enabled": {
             "description": "Whether data discount logging is enabled for this workspace",
             "example": true,
@@ -21396,6 +21547,8 @@
           "is_observability_io_logging_enabled",
           "is_observability_broadcast_enabled",
           "is_data_discount_logging_enabled",
+          "io_logging_sampling_rate",
+          "io_logging_api_key_ids",
           "created_at",
           "updated_at",
           "created_by"
@@ -21663,7 +21816,7 @@
             "content": {
               "audio/*": {
                 "schema": {
-                  "description": "Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/L16 for pcm).",
+                  "description": "Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/pcm for pcm \u2014 16-bit little-endian).",
                   "example": "<binary audio data>",
                   "format": "binary",
                   "type": "string"
@@ -30029,6 +30182,8 @@
                       "default_text_model": "openai/gpt-4o",
                       "description": "Production environment workspace",
                       "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "io_logging_api_key_ids": null,
+                      "io_logging_sampling_rate": 1,
                       "is_data_discount_logging_enabled": true,
                       "is_observability_broadcast_enabled": false,
                       "is_observability_io_logging_enabled": false,
@@ -30137,6 +30292,8 @@
                     "default_text_model": "openai/gpt-4o",
                     "description": "Production environment workspace",
                     "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "io_logging_api_key_ids": null,
+                    "io_logging_sampling_rate": 1,
                     "is_data_discount_logging_enabled": true,
                     "is_observability_broadcast_enabled": false,
                     "is_observability_io_logging_enabled": false,
@@ -30373,6 +30530,8 @@
                     "default_text_model": "openai/gpt-4o",
                     "description": "Production environment workspace",
                     "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "io_logging_api_key_ids": null,
+                    "io_logging_sampling_rate": 1,
                     "is_data_discount_logging_enabled": true,
                     "is_observability_broadcast_enabled": false,
                     "is_observability_io_logging_enabled": false,
@@ -30487,6 +30646,8 @@
                     "default_text_model": "openai/gpt-4o",
                     "description": "Production environment workspace",
                     "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "io_logging_api_key_ids": null,
+                    "io_logging_sampling_rate": 1,
                     "is_data_discount_logging_enabled": true,
                     "is_observability_broadcast_enabled": false,
                     "is_observability_io_logging_enabled": false,

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-23T04:35:16+00:00",
+  "captured_at": "2026-04-28T06:34:58+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2b64539bdea63842",
+      "fingerprint": "9c99e9bec1b7a449",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "47828cc6e721062e",
+      "fingerprint": "ba099f80d16f9c0c",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "06aa57cbae9f7f82",
+      "fingerprint": "15e473cb11f97766",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "884dec04861b659d",
+      "fingerprint": "b0afcba279847c18",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5e33269f90dfab34",
+      "fingerprint": "44a48065dd2d673d",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ac1cb8e84c7edadf",
+      "fingerprint": "65f48e9d0833fc3a",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3accdcf44d289173",
+      "fingerprint": "ba5f39f18353bf5f",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0e7bdf1d47712c06",
+      "fingerprint": "4974cef56be35025",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e91b05a24b6c789c",
+      "fingerprint": "3abf52828889b69d",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -502,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "22fcb0e38708b304",
+      "fingerprint": "1faacb2f462abb75",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -513,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "081bd95b8cb9101b",
+      "fingerprint": "dbf5cfac17d684c4",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -524,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a1f95f0feef3f81b",
+      "fingerprint": "4c2837ade6b8b03b",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -535,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b0c72b4a38bf99da",
+      "fingerprint": "3002492824810c79",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -546,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4206e4a1e2d22238",
+      "fingerprint": "5862d59faefd93a2",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -39,6 +39,7 @@ pub struct GenerationData {
     pub num_media_prompt: Option<u32>,
     pub num_media_completion: Option<u32>,
     pub num_search_results: Option<u32>,
+    pub response_cache_source_id: Option<String>,
 }
 
 /// Stored prompt/input and completion/output content returned by `GET /generation/content`.

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -70,6 +70,9 @@ pub struct VideoGenerationRequest {
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aspect_ratio: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub callback_url: Option<String>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -30,6 +30,9 @@ pub struct Workspace {
     pub default_image_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider_sort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_logging_api_key_ids: Option<Vec<u64>>,
+    pub io_logging_sampling_rate: f64,
     pub is_observability_io_logging_enabled: bool,
     pub is_observability_broadcast_enabled: bool,
     pub is_data_discount_logging_enabled: bool,
@@ -68,6 +71,12 @@ pub struct CreateWorkspaceRequest {
     pub default_provider_sort: Option<String>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_logging_api_key_ids: Option<Vec<u64>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_logging_sampling_rate: Option<f64>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_data_discount_logging_enabled: Option<bool>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -104,6 +113,12 @@ pub struct UpdateWorkspaceRequest {
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider_sort: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_logging_api_key_ids: Option<Vec<u64>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_logging_sampling_rate: Option<f64>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_data_discount_logging_enabled: Option<bool>,

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -460,6 +460,269 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
 
+    def test_flexible_plugin_property_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "plugins": {
+                    "items": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "id": {"enum": ["web"], "type": "string"},
+                                    "max_results": {"type": "integer"},
+                                },
+                                "required": ["id"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "plugins": {
+                    "items": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "id": {"enum": ["web"], "type": "string"},
+                                    "max_results": {"type": "integer"},
+                                    "max_uses": {"type": "integer"},
+                                },
+                                "required": ["id"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["flexible plugin payload"],
+        )
+
+    def test_responses_value_tool_and_output_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+            response_properties={
+                "output": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "type": {"enum": ["message"], "type": "string"},
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            },
+                            {
+                                "properties": {
+                                    "type": {"enum": ["web_search_preview"], "type": "string"},
+                                    "max_results": {"type": "integer"},
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            },
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+            response_properties={
+                "output": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "type": {"enum": ["message"], "type": "string"},
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            },
+                            {
+                                "properties": {
+                                    "type": {"enum": ["code_interpreter_call"], "type": "string"},
+                                    "outputs": {
+                                        "items": {"type": "object"},
+                                        "type": "array",
+                                    },
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            },
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Responses flexible output payload", "Responses flexible tool payload"],
+        )
+
+    def test_messages_flexible_tool_option_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            method="post",
+            path="/messages",
+            operation_id="createMessages",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"enum": ["web_search"], "type": "string"},
+                                    "type": {
+                                        "enum": ["web_search_20250305"],
+                                        "type": "string",
+                                    },
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/messages",
+            operation_id="createMessages",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "max_uses": {"nullable": True, "type": "integer"},
+                                    "name": {"enum": ["web_search"], "type": "string"},
+                                    "type": {
+                                        "enum": ["web_search_20250305"],
+                                        "type": "string",
+                                    },
+                                    "user_location": {
+                                        "properties": {
+                                            "type": {
+                                                "enum": ["approximate"],
+                                                "type": "string",
+                                            }
+                                        },
+                                        "type": "object",
+                                    },
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Messages flexible tool payload"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -143,7 +143,8 @@ fn test_generation_response_deserializes_num_fetches() {
             "usage": 42.0,
             "is_byok": false,
             "native_tokens_reasoning": 8,
-            "num_fetches": 3
+            "num_fetches": 3,
+            "response_cache_source_id": "gen_original"
         }
     }"#;
 
@@ -153,4 +154,8 @@ fn test_generation_response_deserializes_num_fetches() {
     assert_eq!(parsed.data.id, "gen_123");
     assert_eq!(parsed.data.native_tokens_reasoning, Some(8));
     assert_eq!(parsed.data.num_fetches, Some(3));
+    assert_eq!(
+        parsed.data.response_cache_source_id.as_deref(),
+        Some("gen_original")
+    );
 }

--- a/tests/unit/videos.rs
+++ b/tests/unit/videos.rs
@@ -30,6 +30,7 @@ fn test_video_generation_request_serialization() {
         .aspect_ratio("16:9")
         .duration(8)
         .resolution("720p")
+        .callback_url("https://example.com/webhooks/video")
         .generate_audio(true)
         .frame_images(vec![VideoFrameImage::new(
             "https://example.com/first.png",
@@ -48,6 +49,7 @@ fn test_video_generation_request_serialization() {
     assert_eq!(value["model"], "google/veo-3.1");
     assert_eq!(value["prompt"], "A serene mountain landscape at sunset");
     assert_eq!(value["aspect_ratio"], "16:9");
+    assert_eq!(value["callback_url"], "https://example.com/webhooks/video");
     assert_eq!(value["frame_images"][0]["frame_type"], "first_frame");
     assert_eq!(
         value["input_references"][0]["image_url"]["url"],

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -115,6 +115,8 @@ fn test_create_workspace_request_serialization() {
         .is_data_discount_logging_enabled(true)
         .is_observability_broadcast_enabled(false)
         .is_observability_io_logging_enabled(false)
+        .io_logging_api_key_ids(vec![101, 202])
+        .io_logging_sampling_rate(0.25)
         .build()
         .expect("create workspace request should build");
 
@@ -128,6 +130,11 @@ fn test_create_workspace_request_serialization() {
     assert_eq!(value["is_data_discount_logging_enabled"], true);
     assert_eq!(value["is_observability_broadcast_enabled"], false);
     assert_eq!(value["is_observability_io_logging_enabled"], false);
+    assert_eq!(
+        value["io_logging_api_key_ids"],
+        serde_json::json!([101, 202])
+    );
+    assert_eq!(value["io_logging_sampling_rate"], 0.25);
 }
 
 #[test]
@@ -136,6 +143,8 @@ fn test_update_workspace_request_serialization() {
         .name("Updated")
         .slug("updated")
         .is_data_discount_logging_enabled(false)
+        .io_logging_api_key_ids(Vec::<u64>::new())
+        .io_logging_sampling_rate(1.0)
         .build()
         .expect("update workspace request should build");
 
@@ -143,6 +152,8 @@ fn test_update_workspace_request_serialization() {
     assert_eq!(value["name"], "Updated");
     assert_eq!(value["slug"], "updated");
     assert_eq!(value["is_data_discount_logging_enabled"], false);
+    assert_eq!(value["io_logging_api_key_ids"], serde_json::json!([]));
+    assert_eq!(value["io_logging_sampling_rate"], 1.0);
     assert!(value.get("description").is_none());
 }
 
@@ -157,6 +168,8 @@ fn test_workspace_response_deserialization() {
             "default_text_model": "openai/gpt-4o",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
+            "io_logging_api_key_ids": [101, 202],
+            "io_logging_sampling_rate": 0.5,
             "is_observability_io_logging_enabled": false,
             "is_observability_broadcast_enabled": false,
             "is_data_discount_logging_enabled": true,
@@ -171,6 +184,8 @@ fn test_workspace_response_deserialization() {
     assert_eq!(parsed.data.id, "ws_123");
     assert_eq!(parsed.data.slug, "production");
     assert_eq!(parsed.data.created_by.as_deref(), Some("user_123"));
+    assert_eq!(parsed.data.io_logging_api_key_ids, Some(vec![101, 202]));
+    assert_eq!(parsed.data.io_logging_sampling_rate, 0.5);
 }
 
 #[test]
@@ -184,6 +199,8 @@ fn test_workspace_list_and_member_response_deserialization() {
             "default_text_model": "openai/gpt-4o",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
+            "io_logging_api_key_ids": null,
+            "io_logging_sampling_rate": 1.0,
             "is_observability_io_logging_enabled": false,
             "is_observability_broadcast_enabled": false,
             "is_data_discount_logging_enabled": true,
@@ -215,6 +232,8 @@ fn test_workspace_list_and_member_response_deserialization() {
         serde_json::from_str(remove_raw).expect("workspace member remove should deserialize");
 
     assert_eq!(list.total_count, 1.0);
+    assert_eq!(list.data[0].io_logging_api_key_ids, None);
+    assert_eq!(list.data[0].io_logging_sampling_rate, 1.0);
     assert_eq!(add.added_count, 1.0);
     assert_eq!(add.data[0].workspace_id, "ws_123");
     assert_eq!(remove.removed_count, 2.0);
@@ -254,7 +273,7 @@ async fn test_list_workspaces_path_pagination_and_auth_header() {
 #[tokio::test]
 async fn test_create_workspace_posts_body_and_auth_header() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"ws_123","name":"Production","slug":"production","description":"Production","default_text_model":"openai/gpt-4o","default_image_model":"openai/dall-e-3","default_provider_sort":"price","is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":null,"created_by":"user_123"}}"#,
+        r#"{"data":{"id":"ws_123","name":"Production","slug":"production","description":"Production","default_text_model":"openai/gpt-4o","default_image_model":"openai/dall-e-3","default_provider_sort":"price","io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":null,"created_by":"user_123"}}"#,
     );
     let request = CreateWorkspaceRequest::builder()
         .name("Production")
@@ -282,7 +301,7 @@ async fn test_create_workspace_posts_body_and_auth_header() {
 #[tokio::test]
 async fn test_get_workspace_encodes_id_path() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"ws_123","name":"Production","slug":"production","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":null,"created_by":"user_123"}}"#,
+        r#"{"data":{"id":"ws_123","name":"Production","slug":"production","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":null,"created_by":"user_123"}}"#,
     );
 
     let response = workspaces::get_workspace(&base_url, "mgmt-key", "team/prod 1")
@@ -304,7 +323,7 @@ async fn test_get_workspace_encodes_id_path() {
 #[tokio::test]
 async fn test_update_workspace_encodes_id_and_sends_body() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"ws_123","name":"Updated","slug":"updated","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":"2025-01-02T00:00:00.000Z","created_by":"user_123"}}"#,
+        r#"{"data":{"id":"ws_123","name":"Updated","slug":"updated","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":"2025-01-02T00:00:00.000Z","created_by":"user_123"}}"#,
     );
     let request = UpdateWorkspaceRequest::builder()
         .name("Updated")


### PR DESCRIPTION
## Summary
- add typed support for latest upstream drift fields: generation `response_cache_source_id`, workspace I/O logging fields, and video `callback_url`
- refresh the tracked OpenAPI baseline to the 2026-04-28 upstream spec
- extend drift classification for flexible plugin, Messages hosted-tool, and Responses Value payloads
- update drift docs, endpoint matrix, README, and changelog

Closes #199

## Verification
- `python3 -m unittest tests/test_openapi_drift.py`
- `cargo test --test unit`
- `just openapi-drift-check`
- `just quality`