### PR TITLE
fix: address PR 201 review feedback

### DIFF
--- a/crates/openrouter-cli/src/main.rs
+++ b/crates/openrouter-cli/src/main.rs
@@ -685,12 +685,12 @@ async fn run(cli: Cli) -> Result<()> {
                         builder.reset_interval(reset_interval);
                     }
                     if args.clear_allowed_providers {
-                        builder.allowed_providers(Vec::<String>::new());
+                        builder.clear_allowed_providers();
                     } else if !args.allowed_providers.is_empty() {
                         builder.allowed_providers(args.allowed_providers);
                     }
                     if args.clear_allowed_models {
-                        builder.allowed_models(Vec::<String>::new());
+                        builder.clear_allowed_models();
                     } else if !args.allowed_models.is_empty() {
                         builder.allowed_models(args.allowed_models);
                     }

--- a/crates/openrouter-cli/tests/management_commands.rs
+++ b/crates/openrouter-cli/tests/management_commands.rs
@@ -726,18 +726,8 @@ fn test_guardrails_update_can_clear_allowlists() {
     );
     let body: Value =
         serde_json::from_str(&captured.body_text).expect("request body should be valid json");
-    assert_eq!(
-        body.get("allowed_providers")
-            .and_then(Value::as_array)
-            .map(Vec::len),
-        Some(0)
-    );
-    assert_eq!(
-        body.get("allowed_models")
-            .and_then(Value::as_array)
-            .map(Vec::len),
-        Some(0)
-    );
+    assert_eq!(body.get("allowed_providers"), Some(&Value::Null));
+    assert_eq!(body.get("allowed_models"), Some(&Value::Null));
 
     server.join().expect("server thread should finish");
 }

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -428,6 +428,16 @@ def is_response_schema_property_path(path: tuple[Any, ...], property_name: str) 
     )
 
 
+def schema_has_type(value: Any, schema_type: str) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    value_type = value.get("type")
+    return value_type == schema_type or (
+        isinstance(value_type, list) and schema_type in value_type
+    )
+
+
 def is_repo_supported_flexible_plugin_payload_path(
     operation_key: str,
     path: tuple[Any, ...],
@@ -459,22 +469,62 @@ def is_repo_supported_responses_output_payload_path(
     return operation_key == "POST /responses" and is_response_schema_property_path(path, "output")
 
 
+def is_repo_supported_flexible_plugin_payload(
+    operation_key: str,
+    path: tuple[Any, ...],
+    value: Any,
+) -> bool:
+    return is_repo_supported_flexible_plugin_payload_path(
+        operation_key, path
+    ) and schema_has_type(value, "array")
+
+
+def is_repo_supported_messages_tool_payload(
+    operation_key: str,
+    path: tuple[Any, ...],
+    value: Any,
+) -> bool:
+    return is_repo_supported_messages_tool_payload_path(
+        operation_key, path
+    ) and schema_has_type(value, "array")
+
+
+def is_repo_supported_responses_tool_payload(
+    operation_key: str,
+    path: tuple[Any, ...],
+    value: Any,
+) -> bool:
+    return is_repo_supported_responses_tool_payload_path(
+        operation_key, path
+    ) and schema_has_type(value, "array")
+
+
+def is_repo_supported_responses_output_payload(
+    operation_key: str,
+    path: tuple[Any, ...],
+    value: Any,
+) -> bool:
+    return is_repo_supported_responses_output_payload_path(
+        operation_key, path
+    ) and schema_has_type(value, "array")
+
+
 def strip_repo_supported_schema_details(
     operation_key: str,
     value: Any,
     path: tuple[Any, ...] = (),
 ) -> Any:
     if isinstance(value, dict):
-        if is_repo_supported_flexible_plugin_payload_path(operation_key, path):
+        if is_repo_supported_flexible_plugin_payload(operation_key, path, value):
             return {"<repo-supported-flexible-plugin-payload>": True}
 
-        if is_repo_supported_messages_tool_payload_path(operation_key, path):
+        if is_repo_supported_messages_tool_payload(operation_key, path, value):
             return {"<repo-supported-messages-tool-payload>": True}
 
-        if is_repo_supported_responses_tool_payload_path(operation_key, path):
+        if is_repo_supported_responses_tool_payload(operation_key, path, value):
             return {"<repo-supported-responses-tool-payload>": True}
 
-        if is_repo_supported_responses_output_payload_path(operation_key, path):
+        if is_repo_supported_responses_output_payload(operation_key, path, value):
             return {"<repo-supported-responses-output-payload>": True}
 
         stripped = {
@@ -523,13 +573,13 @@ def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[
                 rules.add("dynamic output modality enum")
             if is_repo_supported_provider_options_map(item):
                 rules.add("provider-specific options map")
-            if is_repo_supported_flexible_plugin_payload_path(operation_key, path):
+            if is_repo_supported_flexible_plugin_payload(operation_key, path, item):
                 rules.add("flexible plugin payload")
-            if is_repo_supported_messages_tool_payload_path(operation_key, path):
+            if is_repo_supported_messages_tool_payload(operation_key, path, item):
                 rules.add("Messages flexible tool payload")
-            if is_repo_supported_responses_tool_payload_path(operation_key, path):
+            if is_repo_supported_responses_tool_payload(operation_key, path, item):
                 rules.add("Responses flexible tool payload")
-            if is_repo_supported_responses_output_payload_path(operation_key, path):
+            if is_repo_supported_responses_output_payload(operation_key, path, item):
                 rules.add("Responses flexible output payload")
             if is_responses_response_payload_path(operation_key, path):
                 properties = item.get("properties")

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -1,6 +1,6 @@
 use derive_builder::Builder;
 use reqwest::Client as HttpClient;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeMap};
 use urlencoding::encode;
 
 use crate::{
@@ -82,49 +82,96 @@ impl CreateGuardrailRequest {
 }
 
 /// Request payload for updating a guardrail (`PATCH /guardrails/{id}`).
-#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[derive(Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 pub struct UpdateGuardrailRequest {
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     limit_usd: Option<f64>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     reset_interval: Option<String>,
     #[builder(setter(custom), default)]
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::utils::serialize_optional_empty_vec_as_null"
-    )]
     allowed_providers: Option<Vec<String>>,
+    #[serde(skip)]
     #[builder(setter(custom), default)]
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::utils::serialize_optional_empty_vec_as_null"
-    )]
+    clear_allowed_providers: bool,
+    #[builder(setter(custom), default)]
     allowed_models: Option<Vec<String>>,
+    #[serde(skip)]
+    #[builder(setter(custom), default)]
+    clear_allowed_models: bool,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     enforce_zdr: Option<bool>,
 }
 
+impl Serialize for UpdateGuardrailRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        if let Some(value) = &self.name {
+            map.serialize_entry("name", value)?;
+        }
+        if let Some(value) = &self.description {
+            map.serialize_entry("description", value)?;
+        }
+        if let Some(value) = &self.limit_usd {
+            map.serialize_entry("limit_usd", value)?;
+        }
+        if let Some(value) = &self.reset_interval {
+            map.serialize_entry("reset_interval", value)?;
+        }
+        if self.clear_allowed_providers {
+            map.serialize_entry("allowed_providers", &Option::<Vec<String>>::None)?;
+        } else if let Some(value) = &self.allowed_providers {
+            map.serialize_entry("allowed_providers", value)?;
+        }
+        if self.clear_allowed_models {
+            map.serialize_entry("allowed_models", &Option::<Vec<String>>::None)?;
+        } else if let Some(value) = &self.allowed_models {
+            map.serialize_entry("allowed_models", value)?;
+        }
+        if let Some(value) = &self.enforce_zdr {
+            map.serialize_entry("enforce_zdr", value)?;
+        }
+        map.end()
+    }
+}
+
 impl UpdateGuardrailRequestBuilder {
-    strip_option_vec_setter!(allowed_providers, String);
-    strip_option_vec_setter!(allowed_models, String);
+    pub fn allowed_providers<T, S>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.allowed_providers = Some(Some(items.into_iter().map(Into::into).collect()));
+        self.clear_allowed_providers = Some(false);
+        self
+    }
+
+    pub fn allowed_models<T, S>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.allowed_models = Some(Some(items.into_iter().map(Into::into).collect()));
+        self.clear_allowed_models = Some(false);
+        self
+    }
 
     pub fn clear_allowed_providers(&mut self) -> &mut Self {
-        self.allowed_providers = Some(Some(Vec::new()));
+        self.allowed_providers = Some(None);
+        self.clear_allowed_providers = Some(true);
         self
     }
 
     pub fn clear_allowed_models(&mut self) -> &mut Self {
-        self.allowed_models = Some(Some(Vec::new()));
+        self.allowed_models = Some(None);
+        self.clear_allowed_models = Some(true);
         self
     }
 }

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -98,10 +98,16 @@ pub struct UpdateGuardrailRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     reset_interval: Option<String>,
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::utils::serialize_optional_empty_vec_as_null"
+    )]
     allowed_providers: Option<Vec<String>>,
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::utils::serialize_optional_empty_vec_as_null"
+    )]
     allowed_models: Option<Vec<String>>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -111,6 +117,16 @@ pub struct UpdateGuardrailRequest {
 impl UpdateGuardrailRequestBuilder {
     strip_option_vec_setter!(allowed_providers, String);
     strip_option_vec_setter!(allowed_models, String);
+
+    pub fn clear_allowed_providers(&mut self) -> &mut Self {
+        self.allowed_providers = Some(Some(Vec::new()));
+        self
+    }
+
+    pub fn clear_allowed_models(&mut self) -> &mut Self {
+        self.allowed_models = Some(Some(Vec::new()));
+        self
+    }
 }
 
 impl UpdateGuardrailRequest {

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1,6 +1,6 @@
 use derive_builder::Builder;
 use reqwest::Client as HttpClient;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeMap};
 use urlencoding::encode;
 
 use crate::{
@@ -92,45 +92,79 @@ impl CreateWorkspaceRequest {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[derive(Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 pub struct UpdateWorkspaceRequest {
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_text_model: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_image_model: Option<String>,
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider_sort: Option<String>,
-    #[builder(setter(strip_option), default)]
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::utils::serialize_optional_empty_vec_as_null"
-    )]
+    #[builder(setter(custom), default)]
     pub io_logging_api_key_ids: Option<Vec<u64>>,
+    #[serde(skip)]
+    #[builder(setter(custom), default)]
+    clear_io_logging_api_key_ids: bool,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub io_logging_sampling_rate: Option<f64>,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_data_discount_logging_enabled: Option<bool>,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_observability_broadcast_enabled: Option<bool>,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_observability_io_logging_enabled: Option<bool>,
+}
+
+impl Serialize for UpdateWorkspaceRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        if let Some(value) = &self.name {
+            map.serialize_entry("name", value)?;
+        }
+        if let Some(value) = &self.slug {
+            map.serialize_entry("slug", value)?;
+        }
+        if let Some(value) = &self.description {
+            map.serialize_entry("description", value)?;
+        }
+        if let Some(value) = &self.default_text_model {
+            map.serialize_entry("default_text_model", value)?;
+        }
+        if let Some(value) = &self.default_image_model {
+            map.serialize_entry("default_image_model", value)?;
+        }
+        if let Some(value) = &self.default_provider_sort {
+            map.serialize_entry("default_provider_sort", value)?;
+        }
+        if self.clear_io_logging_api_key_ids {
+            map.serialize_entry("io_logging_api_key_ids", &Option::<Vec<u64>>::None)?;
+        } else if let Some(value) = &self.io_logging_api_key_ids {
+            map.serialize_entry("io_logging_api_key_ids", value)?;
+        }
+        if let Some(value) = &self.io_logging_sampling_rate {
+            map.serialize_entry("io_logging_sampling_rate", value)?;
+        }
+        if let Some(value) = &self.is_data_discount_logging_enabled {
+            map.serialize_entry("is_data_discount_logging_enabled", value)?;
+        }
+        if let Some(value) = &self.is_observability_broadcast_enabled {
+            map.serialize_entry("is_observability_broadcast_enabled", value)?;
+        }
+        if let Some(value) = &self.is_observability_io_logging_enabled {
+            map.serialize_entry("is_observability_io_logging_enabled", value)?;
+        }
+        map.end()
+    }
 }
 
 impl UpdateWorkspaceRequest {
@@ -140,8 +174,18 @@ impl UpdateWorkspaceRequest {
 }
 
 impl UpdateWorkspaceRequestBuilder {
+    pub fn io_logging_api_key_ids<T>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = u64>,
+    {
+        self.io_logging_api_key_ids = Some(Some(items.into_iter().collect()));
+        self.clear_io_logging_api_key_ids = Some(false);
+        self
+    }
+
     pub fn clear_io_logging_api_key_ids(&mut self) -> &mut Self {
-        self.io_logging_api_key_ids = Some(Some(Vec::new()));
+        self.io_logging_api_key_ids = Some(None);
+        self.clear_io_logging_api_key_ids = Some(true);
         self
     }
 }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -92,75 +92,84 @@ impl CreateWorkspaceRequest {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Builder)]
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 pub struct UpdateWorkspaceRequest {
     #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
     #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_text_model: Option<String>,
     #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_image_model: Option<String>,
     #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider_sort: Option<String>,
-    #[builder(setter(custom), default)]
-    pub io_logging_api_key_ids: Option<Vec<u64>>,
-    #[serde(skip)]
-    #[builder(setter(custom), default)]
-    clear_io_logging_api_key_ids: bool,
     #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_logging_api_key_ids: Option<Vec<u64>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub io_logging_sampling_rate: Option<f64>,
     #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_data_discount_logging_enabled: Option<bool>,
     #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_observability_broadcast_enabled: Option<bool>,
     #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_observability_io_logging_enabled: Option<bool>,
 }
 
-impl Serialize for UpdateWorkspaceRequest {
+#[derive(Debug, Clone, Copy)]
+pub struct UpdateWorkspaceRequestWithClearedIoLoggingApiKeyIds<'a> {
+    request: &'a UpdateWorkspaceRequest,
+}
+
+impl Serialize for UpdateWorkspaceRequestWithClearedIoLoggingApiKeyIds<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut map = serializer.serialize_map(None)?;
-        if let Some(value) = &self.name {
+        if let Some(value) = &self.request.name {
             map.serialize_entry("name", value)?;
         }
-        if let Some(value) = &self.slug {
+        if let Some(value) = &self.request.slug {
             map.serialize_entry("slug", value)?;
         }
-        if let Some(value) = &self.description {
+        if let Some(value) = &self.request.description {
             map.serialize_entry("description", value)?;
         }
-        if let Some(value) = &self.default_text_model {
+        if let Some(value) = &self.request.default_text_model {
             map.serialize_entry("default_text_model", value)?;
         }
-        if let Some(value) = &self.default_image_model {
+        if let Some(value) = &self.request.default_image_model {
             map.serialize_entry("default_image_model", value)?;
         }
-        if let Some(value) = &self.default_provider_sort {
+        if let Some(value) = &self.request.default_provider_sort {
             map.serialize_entry("default_provider_sort", value)?;
         }
-        if self.clear_io_logging_api_key_ids {
-            map.serialize_entry("io_logging_api_key_ids", &Option::<Vec<u64>>::None)?;
-        } else if let Some(value) = &self.io_logging_api_key_ids {
-            map.serialize_entry("io_logging_api_key_ids", value)?;
-        }
-        if let Some(value) = &self.io_logging_sampling_rate {
+        map.serialize_entry("io_logging_api_key_ids", &Option::<Vec<u64>>::None)?;
+        if let Some(value) = &self.request.io_logging_sampling_rate {
             map.serialize_entry("io_logging_sampling_rate", value)?;
         }
-        if let Some(value) = &self.is_data_discount_logging_enabled {
+        if let Some(value) = &self.request.is_data_discount_logging_enabled {
             map.serialize_entry("is_data_discount_logging_enabled", value)?;
         }
-        if let Some(value) = &self.is_observability_broadcast_enabled {
+        if let Some(value) = &self.request.is_observability_broadcast_enabled {
             map.serialize_entry("is_observability_broadcast_enabled", value)?;
         }
-        if let Some(value) = &self.is_observability_io_logging_enabled {
+        if let Some(value) = &self.request.is_observability_io_logging_enabled {
             map.serialize_entry("is_observability_io_logging_enabled", value)?;
         }
         map.end()
@@ -171,22 +180,11 @@ impl UpdateWorkspaceRequest {
     pub fn builder() -> UpdateWorkspaceRequestBuilder {
         UpdateWorkspaceRequestBuilder::default()
     }
-}
 
-impl UpdateWorkspaceRequestBuilder {
-    pub fn io_logging_api_key_ids<T>(&mut self, items: T) -> &mut Self
-    where
-        T: IntoIterator<Item = u64>,
-    {
-        self.io_logging_api_key_ids = Some(Some(items.into_iter().collect()));
-        self.clear_io_logging_api_key_ids = Some(false);
-        self
-    }
-
-    pub fn clear_io_logging_api_key_ids(&mut self) -> &mut Self {
-        self.io_logging_api_key_ids = Some(None);
-        self.clear_io_logging_api_key_ids = Some(true);
-        self
+    pub fn with_cleared_io_logging_api_key_ids(
+        &self,
+    ) -> UpdateWorkspaceRequestWithClearedIoLoggingApiKeyIds<'_> {
+        UpdateWorkspaceRequestWithClearedIoLoggingApiKeyIds { request: self }
     }
 }
 
@@ -342,12 +340,50 @@ pub async fn update_workspace(
     update_workspace_with_client(&http_client, base_url, management_key, id, request).await
 }
 
+pub async fn update_workspace_with_cleared_io_logging_api_key_ids(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    update_workspace_with_cleared_io_logging_api_key_ids_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        request,
+    )
+    .await
+}
+
 pub(crate) async fn update_workspace_with_client(
     http_client: &HttpClient,
     base_url: &str,
     management_key: &str,
     id: &str,
     request: &UpdateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    update_workspace_payload_with_client(http_client, base_url, management_key, id, request).await
+}
+
+pub(crate) async fn update_workspace_with_cleared_io_logging_api_key_ids_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateWorkspaceRequest,
+) -> Result<Workspace, OpenRouterError> {
+    let request = request.with_cleared_io_logging_api_key_ids();
+    update_workspace_payload_with_client(http_client, base_url, management_key, id, &request).await
+}
+
+async fn update_workspace_payload_with_client<T: Serialize + ?Sized>(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &T,
 ) -> Result<Workspace, OpenRouterError> {
     let url = format!("{base_url}/workspaces/{}", encode(id));
     let response = transport_request::with_bearer_auth(

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -114,7 +114,10 @@ pub struct UpdateWorkspaceRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider_sort: Option<String>,
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::utils::serialize_optional_empty_vec_as_null"
+    )]
     pub io_logging_api_key_ids: Option<Vec<u64>>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -133,6 +136,13 @@ pub struct UpdateWorkspaceRequest {
 impl UpdateWorkspaceRequest {
     pub fn builder() -> UpdateWorkspaceRequestBuilder {
         UpdateWorkspaceRequestBuilder::default()
+    }
+}
+
+impl UpdateWorkspaceRequestBuilder {
+    pub fn clear_io_logging_api_key_ids(&mut self) -> &mut Self {
+        self.io_logging_api_key_ids = Some(Some(Vec::new()));
+        self
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1650,6 +1650,26 @@ impl OpenRouterClient {
         }
     }
 
+    /// Update a workspace and clear I/O logging API key filters (`PATCH /workspaces/{id}`).
+    pub async fn update_workspace_with_cleared_io_logging_api_key_ids(
+        &self,
+        id: &str,
+        request: &workspaces::UpdateWorkspaceRequest,
+    ) -> Result<workspaces::Workspace, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::update_workspace_with_cleared_io_logging_api_key_ids_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Delete a workspace (`DELETE /workspaces/{id}`).
     pub async fn delete_workspace(&self, id: &str) -> Result<bool, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
@@ -2259,6 +2279,17 @@ impl<'a> ManagementClient<'a> {
         request: &workspaces::UpdateWorkspaceRequest,
     ) -> Result<workspaces::Workspace, OpenRouterError> {
         self.client.update_workspace(id, request).await
+    }
+
+    /// Update a workspace and clear I/O logging API key filters (`PATCH /workspaces/{id}`).
+    pub async fn update_workspace_with_cleared_io_logging_api_key_ids(
+        &self,
+        id: &str,
+        request: &workspaces::UpdateWorkspaceRequest,
+    ) -> Result<workspaces::Workspace, OpenRouterError> {
+        self.client
+            .update_workspace_with_cleared_io_logging_api_key_ids(id, request)
+            .await
     }
 
     /// Delete a workspace (`DELETE /workspaces/{id}`).

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use futures_util::{Stream, StreamExt, stream, stream::BoxStream};
+use serde::{Serialize, Serializer};
 
 use crate::error::OpenRouterError;
 
@@ -34,6 +35,21 @@ macro_rules! strip_option_map_setter {
             self
         }
     };
+}
+
+pub(crate) fn serialize_optional_empty_vec_as_null<T, S>(
+    value: &Option<Vec<T>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: Serialize,
+    S: Serializer,
+{
+    match value {
+        Some(items) if items.is_empty() => serializer.serialize_none(),
+        Some(items) => items.serialize(serializer),
+        None => serializer.serialize_none(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,4 @@
 use futures_util::{Stream, StreamExt, stream, stream::BoxStream};
-use serde::{Serialize, Serializer};
 
 use crate::error::OpenRouterError;
 
@@ -35,21 +34,6 @@ macro_rules! strip_option_map_setter {
             self
         }
     };
-}
-
-pub(crate) fn serialize_optional_empty_vec_as_null<T, S>(
-    value: &Option<Vec<T>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    T: Serialize,
-    S: Serializer,
-{
-    match value {
-        Some(items) if items.is_empty() => serializer.serialize_none(),
-        Some(items) => items.serialize(serializer),
-        None => serializer.serialize_none(),
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -526,6 +526,61 @@ class OpenApiDriftReportTests(unittest.TestCase):
             ["flexible plugin payload"],
         )
 
+    def test_flexible_plugin_container_type_change_remains_actionable(self):
+        baseline = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "plugins": {
+                    "items": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "id": {"enum": ["web"], "type": "string"},
+                                },
+                                "required": ["id"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "plugins": {
+                    "properties": {
+                        "id": {"enum": ["web"], "type": "string"},
+                    },
+                    "type": "object",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["flexible plugin payload"],
+        )
+
     def test_responses_value_tool_and_output_drift_is_classified_as_already_supported(self):
         baseline = build_spec(
             method="post",
@@ -642,6 +697,86 @@ class OpenApiDriftReportTests(unittest.TestCase):
             ["Responses flexible output payload", "Responses flexible tool payload"],
         )
 
+    def test_responses_flexible_container_type_changes_remain_actionable(self):
+        baseline = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+            response_properties={
+                "output": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "type": {"enum": ["message"], "type": "string"},
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/responses",
+            operation_id="createResponses",
+            request_properties={
+                "tools": {
+                    "properties": {
+                        "type": {"enum": ["function"], "type": "string"},
+                    },
+                    "type": "object",
+                }
+            },
+            response_properties={
+                "output": {
+                    "properties": {
+                        "type": {"enum": ["message"], "type": "string"},
+                    },
+                    "type": "object",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Responses flexible output payload", "Responses flexible tool payload"],
+        )
+
     def test_messages_flexible_tool_option_drift_is_classified_as_already_supported(self):
         baseline = build_spec(
             method="post",
@@ -718,6 +853,69 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
         self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Messages flexible tool payload"],
+        )
+
+    def test_messages_flexible_tool_container_type_change_remains_actionable(self):
+        baseline = build_spec(
+            method="post",
+            path="/messages",
+            operation_id="createMessages",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"enum": ["web_search"], "type": "string"},
+                                    "type": {
+                                        "enum": ["web_search_20250305"],
+                                        "type": "string",
+                                    },
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/messages",
+            operation_id="createMessages",
+            request_properties={
+                "tools": {
+                    "properties": {
+                        "name": {"enum": ["web_search"], "type": "string"},
+                        "type": {
+                            "enum": ["web_search_20250305"],
+                            "type": "string",
+                        },
+                    },
+                    "type": "object",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
         self.assertEqual(
             report["changed"][0]["repo_impact"]["schema_rules"],
             ["Messages flexible tool payload"],

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -671,6 +671,16 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(
+        client
+            .management()
+            .update_workspace_with_cleared_io_logging_api_key_ids(
+                "ws_123",
+                &update_workspace_request
+            )
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
         client.management().delete_workspace("ws_123").await,
         Err(OpenRouterError::KeyNotConfigured)
     ));

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -149,6 +149,22 @@ fn test_update_guardrail_request_serialization() {
 }
 
 #[test]
+fn test_update_guardrail_request_can_clear_nullable_allowlists() {
+    let request = UpdateGuardrailRequest::builder()
+        .clear_allowed_providers()
+        .clear_allowed_models()
+        .build()
+        .expect("update guardrail request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(
+        value.get("allowed_providers"),
+        Some(&serde_json::Value::Null)
+    );
+    assert_eq!(value.get("allowed_models"), Some(&serde_json::Value::Null));
+}
+
+#[test]
 fn test_guardrail_response_deserialization() {
     let raw = r#"{
         "data": {

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -165,6 +165,55 @@ fn test_update_guardrail_request_can_clear_nullable_allowlists() {
 }
 
 #[test]
+fn test_update_guardrail_request_preserves_empty_nullable_allowlists() {
+    let request = UpdateGuardrailRequest::builder()
+        .allowed_providers(Vec::<String>::new())
+        .allowed_models(Vec::<String>::new())
+        .build()
+        .expect("update guardrail request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value.get("allowed_providers"), Some(&serde_json::json!([])));
+    assert_eq!(value.get("allowed_models"), Some(&serde_json::json!([])));
+
+    let value_after_clear = UpdateGuardrailRequest::builder()
+        .clear_allowed_providers()
+        .clear_allowed_models()
+        .allowed_providers(["openai"])
+        .allowed_models(["openai/gpt-4.1"])
+        .build()
+        .expect("update guardrail request should build");
+    let value_after_clear_json =
+        serde_json::to_value(&value_after_clear).expect("request should serialize");
+    assert_eq!(
+        value_after_clear_json.get("allowed_providers"),
+        Some(&serde_json::json!(["openai"]))
+    );
+    assert_eq!(
+        value_after_clear_json.get("allowed_models"),
+        Some(&serde_json::json!(["openai/gpt-4.1"]))
+    );
+
+    let clear_after_value = UpdateGuardrailRequest::builder()
+        .allowed_providers(["openai"])
+        .allowed_models(["openai/gpt-4.1"])
+        .clear_allowed_providers()
+        .clear_allowed_models()
+        .build()
+        .expect("update guardrail request should build");
+    let clear_after_value_json =
+        serde_json::to_value(&clear_after_value).expect("request should serialize");
+    assert_eq!(
+        clear_after_value_json.get("allowed_providers"),
+        Some(&serde_json::Value::Null)
+    );
+    assert_eq!(
+        clear_after_value_json.get("allowed_models"),
+        Some(&serde_json::Value::Null)
+    );
+}
+
+#[test]
 fn test_guardrail_response_deserialization() {
     let raw = r#"{
         "data": {

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -143,7 +143,7 @@ fn test_update_workspace_request_serialization() {
         .name("Updated")
         .slug("updated")
         .is_data_discount_logging_enabled(false)
-        .io_logging_api_key_ids(Vec::<u64>::new())
+        .io_logging_api_key_ids(vec![101, 202])
         .io_logging_sampling_rate(1.0)
         .build()
         .expect("update workspace request should build");
@@ -152,9 +152,32 @@ fn test_update_workspace_request_serialization() {
     assert_eq!(value["name"], "Updated");
     assert_eq!(value["slug"], "updated");
     assert_eq!(value["is_data_discount_logging_enabled"], false);
-    assert_eq!(value["io_logging_api_key_ids"], serde_json::json!([]));
+    assert_eq!(
+        value["io_logging_api_key_ids"],
+        serde_json::json!([101, 202])
+    );
     assert_eq!(value["io_logging_sampling_rate"], 1.0);
     assert!(value.get("description").is_none());
+}
+
+#[test]
+fn test_update_workspace_request_can_clear_io_logging_api_key_filters() {
+    let omitted = UpdateWorkspaceRequest::builder()
+        .name("Updated")
+        .build()
+        .expect("update workspace request should build");
+    let omitted_value = serde_json::to_value(&omitted).expect("request should serialize");
+    assert!(omitted_value.get("io_logging_api_key_ids").is_none());
+
+    let cleared = UpdateWorkspaceRequest::builder()
+        .clear_io_logging_api_key_ids()
+        .build()
+        .expect("update workspace request should build");
+    let cleared_value = serde_json::to_value(&cleared).expect("request should serialize");
+    assert_eq!(
+        cleared_value.get("io_logging_api_key_ids"),
+        Some(&serde_json::Value::Null)
+    );
 }
 
 #[test]

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -178,6 +178,40 @@ fn test_update_workspace_request_can_clear_io_logging_api_key_filters() {
         cleared_value.get("io_logging_api_key_ids"),
         Some(&serde_json::Value::Null)
     );
+
+    let empty_filter = UpdateWorkspaceRequest::builder()
+        .io_logging_api_key_ids(Vec::<u64>::new())
+        .build()
+        .expect("update workspace request should build");
+    let empty_filter_value = serde_json::to_value(&empty_filter).expect("request should serialize");
+    assert_eq!(
+        empty_filter_value.get("io_logging_api_key_ids"),
+        Some(&serde_json::json!([]))
+    );
+
+    let value_after_clear = UpdateWorkspaceRequest::builder()
+        .clear_io_logging_api_key_ids()
+        .io_logging_api_key_ids(vec![101])
+        .build()
+        .expect("update workspace request should build");
+    let value_after_clear_json =
+        serde_json::to_value(&value_after_clear).expect("request should serialize");
+    assert_eq!(
+        value_after_clear_json.get("io_logging_api_key_ids"),
+        Some(&serde_json::json!([101]))
+    );
+
+    let clear_after_value = UpdateWorkspaceRequest::builder()
+        .io_logging_api_key_ids(vec![101])
+        .clear_io_logging_api_key_ids()
+        .build()
+        .expect("update workspace request should build");
+    let clear_after_value_json =
+        serde_json::to_value(&clear_after_value).expect("request should serialize");
+    assert_eq!(
+        clear_after_value_json.get("io_logging_api_key_ids"),
+        Some(&serde_json::Value::Null)
+    );
 }
 
 #[test]

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -161,7 +161,28 @@ fn test_update_workspace_request_serialization() {
 }
 
 #[test]
-fn test_update_workspace_request_can_clear_io_logging_api_key_filters() {
+fn test_update_workspace_request_struct_literal_still_supported() {
+    let request = UpdateWorkspaceRequest {
+        name: Some("Updated".to_string()),
+        slug: None,
+        description: None,
+        default_text_model: None,
+        default_image_model: None,
+        default_provider_sort: None,
+        io_logging_api_key_ids: Some(Vec::new()),
+        io_logging_sampling_rate: None,
+        is_data_discount_logging_enabled: None,
+        is_observability_broadcast_enabled: None,
+        is_observability_io_logging_enabled: None,
+    };
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["name"], "Updated");
+    assert_eq!(value["io_logging_api_key_ids"], serde_json::json!([]));
+}
+
+#[test]
+fn test_update_workspace_request_clear_wrapper_serialization() {
     let omitted = UpdateWorkspaceRequest::builder()
         .name("Updated")
         .build()
@@ -169,11 +190,8 @@ fn test_update_workspace_request_can_clear_io_logging_api_key_filters() {
     let omitted_value = serde_json::to_value(&omitted).expect("request should serialize");
     assert!(omitted_value.get("io_logging_api_key_ids").is_none());
 
-    let cleared = UpdateWorkspaceRequest::builder()
-        .clear_io_logging_api_key_ids()
-        .build()
-        .expect("update workspace request should build");
-    let cleared_value = serde_json::to_value(&cleared).expect("request should serialize");
+    let cleared_value = serde_json::to_value(omitted.with_cleared_io_logging_api_key_ids())
+        .expect("request should serialize");
     assert_eq!(
         cleared_value.get("io_logging_api_key_ids"),
         Some(&serde_json::Value::Null)
@@ -189,27 +207,20 @@ fn test_update_workspace_request_can_clear_io_logging_api_key_filters() {
         Some(&serde_json::json!([]))
     );
 
-    let value_after_clear = UpdateWorkspaceRequest::builder()
-        .clear_io_logging_api_key_ids()
+    let valued_filter = UpdateWorkspaceRequest::builder()
+        .name("Updated")
         .io_logging_api_key_ids(vec![101])
         .build()
         .expect("update workspace request should build");
     let value_after_clear_json =
-        serde_json::to_value(&value_after_clear).expect("request should serialize");
+        serde_json::to_value(valued_filter.with_cleared_io_logging_api_key_ids())
+            .expect("request should serialize");
+    assert_eq!(
+        value_after_clear_json.get("name"),
+        Some(&serde_json::json!("Updated"))
+    );
     assert_eq!(
         value_after_clear_json.get("io_logging_api_key_ids"),
-        Some(&serde_json::json!([101]))
-    );
-
-    let clear_after_value = UpdateWorkspaceRequest::builder()
-        .io_logging_api_key_ids(vec![101])
-        .clear_io_logging_api_key_ids()
-        .build()
-        .expect("update workspace request should build");
-    let clear_after_value_json =
-        serde_json::to_value(&clear_after_value).expect("request should serialize");
-    assert_eq!(
-        clear_after_value_json.get("io_logging_api_key_ids"),
         Some(&serde_json::Value::Null)
     );
 }
@@ -402,6 +413,45 @@ async fn test_update_workspace_encodes_id_and_sends_body() {
     let body: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("body should be valid json");
     assert_eq!(body["name"], "Updated");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_update_workspace_can_clear_io_logging_api_key_filters() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_123","name":"Updated","slug":"updated","description":null,"default_text_model":null,"default_image_model":null,"default_provider_sort":null,"io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2025-01-01T00:00:00.000Z","updated_at":"2025-01-02T00:00:00.000Z","created_by":"user_123"}}"#,
+    );
+    let request = UpdateWorkspaceRequest::builder()
+        .name("Updated")
+        .io_logging_api_key_ids(vec![101])
+        .build()
+        .expect("request should build");
+
+    let response = workspaces::update_workspace_with_cleared_io_logging_api_key_ids(
+        &base_url,
+        "mgmt-key",
+        "team/prod 1",
+        &request,
+    )
+    .await
+    .expect("update workspace should succeed");
+    assert_eq!(response.name, "Updated");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "PATCH /api/v1/workspaces/team%2Fprod%201 HTTP/1.1"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body["name"], "Updated");
+    assert_eq!(
+        body.get("io_logging_api_key_ids"),
+        Some(&serde_json::Value::Null)
+    );
 
     server.join().expect("server thread should finish");
 }


### PR DESCRIPTION
Follow-up for review comments on #201.

Changes:
- Keep flexible OpenAPI plugin/tool/output drift actionable when the container schema stops being an array.
- Add explicit null-clear helpers for workspace I/O logging key filters.
- Apply the same nullable-array clear behavior to guardrail allowlists and update the CLI clear flags to send JSON null.

Verification:
- python3 -m unittest tests.test_openapi_drift
- just quality
- just quality-ci