### PR TITLE
chore: prepare 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed SDK support for `GET /workspaces`, `POST /workspaces`, `GET /workspaces/{id}`, `PATCH /workspaces/{id}`, `DELETE /workspaces/{id}`, `POST /workspaces/{id}/members/add`, and `POST /workspaces/{id}/members/remove`, including canonical `client.management()` methods and a runnable `examples/list_workspaces.rs`.
 - Added workspace-aware API-key and guardrail support, including `workspace_id` fields on typed models plus `create_api_key_in_workspace(...)`, `list_api_keys_in_workspace(...)`, and `list_guardrails_in_workspace(...)`.
 - Added `openrouter-cli workspaces ...` commands, plus `--workspace-id` support for `openrouter-cli keys list|create` and `openrouter-cli guardrails list|create`.
+- Added `openrouter-cli workspaces create|update --io-logging-api-key-id`, `--io-logging-sampling-rate`, and `workspaces update --clear-io-logging-api-key-ids` so CLI workspace I/O logging controls match the SDK request surface.
+- Added the canonical SDK audio speech surface: `api::audio::{SpeechRequest, SpeechResponseFormat, SpeechProviderOptions}`, `api::audio::create_speech(...)`, and `client.audio().speech().create(...)`.
 
 ### Changed
-- `client.tts().create(...)` now targets the official `POST /audio/speech` endpoint and falls back to legacy `POST /tts` only for route-unavailable signals, including generic plain-text `404/405` status pages, so request-level `404/405` errors on the official endpoint are still preserved.
+- Breaking: `client.tts().create(...)`, `api::tts::TtsRequest`, `api::tts::TtsResponseFormat`, and `api::tts::create_tts(...)` are now deprecated compatibility aliases; new code should use the canonical `client.audio().speech().create(...)` and `api::audio` names.
+- Breaking: newly added and high-churn public request/response types for audio speech, workspace management, workspace-aware keys, generation metadata/content, and video generation are marked `#[non_exhaustive]` where appropriate; use builders for request construction instead of public struct literals.
+- The canonical audio speech path targets official `POST /audio/speech` and falls back to legacy `POST /tts` only for route-unavailable signals, including generic plain-text `404/405` status pages, so request-level `404/405` errors on the official endpoint are still preserved.
 - Accepted the 2026-04-21 OpenAPI drift review, refreshed the tracked compatibility surfaces, and restored the repository snapshot to `51 / 51` official OpenAPI endpoint coverage.
 - Accepted the 2026-04-22 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
 - Accepted the 2026-04-23 OpenAPI drift review, refreshed the tracked baseline, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-28
+
 ### Added
 - Added typed SDK support for `GET /generation/content`, including `client.get_generation_content(...)` and `client.management().get_generation_content(...)`.
 - Added typed `num_fetches` support on `GET /generation` metadata responses via `GenerationData`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openrouter-cli"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,11 +1,119 @@
-# Migration Guide: 0.5.x -> 0.6.0
+# Migration Guide
 
-This document keeps the historical `0.5.x -> 0.6.0` migration guide intact because the repo still smoke-tests that older domain/naming transition.
+This document keeps historical migration guides intact because the repo still smoke-tests older domain/naming transitions.
 
-> Latest breaking release: `0.7.x -> 0.8.0`.
-> `0.8.0` completes the HTTP transport migration to `reqwest + rustls` and removes the remaining `surf`-shaped public helpers from the SDK surface.
+> Latest breaking release target: `0.8.x -> 0.9.0`.
+> `0.9.0` makes `/audio/speech` the canonical SDK naming surface and future-proofs high-churn request/response structs.
 
-## Latest: 0.7.x -> 0.8.0
+## Latest: 0.8.x -> 0.9.0
+
+If you use the new workspace, generation metadata, video generation, or audio speech surfaces, prefer request builders and the canonical domain clients. Compatibility aliases remain for the old `tts` names, but new code should use `audio`.
+
+### Quick Checklist For 0.9.0
+
+- Replace `client.tts().create(...)` with `client.audio().speech().create(...)`.
+- Replace `api::tts::TtsRequest` with `api::audio::SpeechRequest`.
+- Replace `api::tts::TtsResponseFormat` with `api::audio::SpeechResponseFormat`.
+- Replace direct struct literals for newly added/high-churn request types with their builders, especially workspace and video-generation requests.
+- For CLI workspace I/O logging controls, use `workspaces create|update --io-logging-api-key-id`, `--io-logging-sampling-rate`, and `workspaces update --clear-io-logging-api-key-ids`.
+
+### Breaking-Change Mapping For 0.9.0
+
+| Area | Old Usage (`0.8.x`) | New Usage (`0.9.0`) |
+| --- | --- | --- |
+| Audio speech domain | `client.tts().create(&request)` | `client.audio().speech().create(&request)` |
+| Audio speech imports | `api::tts::{TtsRequest, TtsResponseFormat}` | `api::audio::{SpeechRequest, SpeechResponseFormat}` |
+| Audio speech flat helper | `api::tts::create_tts(...)` | `api::audio::create_speech(...)` |
+| High-churn request construction | `UpdateWorkspaceRequest { ... }` | `UpdateWorkspaceRequest::builder().name(...).build()?` |
+| Workspace CLI key filters | Not exposed | `workspaces create|update --io-logging-api-key-id 101` |
+| Workspace CLI sampling rate | Not exposed | `workspaces create|update --io-logging-sampling-rate 0.25` |
+| Workspace CLI clear key filters | SDK-only wrapper | `workspaces update ws_123 --clear-io-logging-api-key-ids` |
+
+### Example: audio speech rename
+
+Before:
+
+```rust
+use openrouter_rs::{
+    api::tts::{TtsRequest, TtsResponseFormat},
+    OpenRouterClient,
+};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let client = OpenRouterClient::builder().api_key("sk-or-v1-...").build()?;
+let request = TtsRequest::builder()
+    .model("elevenlabs/eleven-turbo-v2")
+    .input("Hello")
+    .voice("alloy")
+    .response_format(TtsResponseFormat::Mp3)
+    .build()?;
+let audio = client.tts().create(&request).await?;
+# let _ = audio;
+# Ok(())
+# }
+```
+
+After:
+
+```rust
+use openrouter_rs::{
+    api::audio::{SpeechRequest, SpeechResponseFormat},
+    OpenRouterClient,
+};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let client = OpenRouterClient::builder().api_key("sk-or-v1-...").build()?;
+let request = SpeechRequest::builder()
+    .model("elevenlabs/eleven-turbo-v2")
+    .input("Hello")
+    .voice("alloy")
+    .response_format(SpeechResponseFormat::Mp3)
+    .build()?;
+let audio = client.audio().speech().create(&request).await?;
+# let _ = audio;
+# Ok(())
+# }
+```
+
+### Example: builder-first workspace updates
+
+Before:
+
+```rust
+use openrouter_rs::api::workspaces::UpdateWorkspaceRequest;
+
+let request = UpdateWorkspaceRequest {
+    name: Some("Platform".to_string()),
+    slug: None,
+    description: None,
+    default_text_model: None,
+    default_image_model: None,
+    default_provider_sort: None,
+    io_logging_api_key_ids: Some(vec![101]),
+    io_logging_sampling_rate: Some(0.25),
+    is_data_discount_logging_enabled: None,
+    is_observability_broadcast_enabled: None,
+    is_observability_io_logging_enabled: None,
+};
+```
+
+After:
+
+```rust
+use openrouter_rs::api::workspaces::UpdateWorkspaceRequest;
+
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let request = UpdateWorkspaceRequest::builder()
+    .name("Platform")
+    .io_logging_api_key_ids(vec![101])
+    .io_logging_sampling_rate(0.25)
+    .build()?;
+# let _ = request;
+# Ok(())
+# }
+```
+
+## Previous: 0.7.x -> 0.8.0
 
 If you already use the canonical domain clients (`chat()`, `responses()`, `messages()`, `models()`, `management()`, and opt-in `legacy()`), this upgrade is usually just a version bump plus a recompile. The breaking changes mainly affect callers that coupled themselves to the old transport-facing error and utility surface.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The current repo snapshot implements `51 / 51` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.8.1"
+openrouter-rs = "0.9.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -45,7 +45,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.8.1", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.9.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -302,7 +302,13 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ## 📈 Release History
 
-### Version 0.8.1 *(Latest)*
+### Version 0.9.0 *(Latest)*
+
+- Added the canonical `audio().speech()` SDK surface for official `/audio/speech`, with deprecated `tts()` compatibility aliases.
+- Expanded workspace, workspace-scoped keys/guardrails, workspace I/O logging, generation content/metadata, and video callback coverage while keeping the endpoint snapshot at `51 / 51`.
+- Marked high-churn public types as builder-first/future-proof and documented the `0.8.x -> 0.9.0` migration path.
+
+### Version 0.8.1
 
 - Added typed `POST /tts` support with the canonical `tts()` client surface and a runnable example.
 - Added live smoke coverage for `POST /rerank` and `GET /organization/members`, and restored the repo snapshot to `43 / 43` accepted OpenAPI endpoints.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 </div>
 
-`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, text-to-speech, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
 The current repo snapshot implements `51 / 51` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
-- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
+- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
 - Typed request/response models with builder-style ergonomics
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
-- Discovery, rerank, text-to-speech, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Discovery, rerank, audio speech, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -93,7 +93,7 @@ The SDK keeps setup intentionally narrow: configure runtime values on `OpenRoute
 
 ## API Surface
 
-The canonical public surface in `0.8.x` is domain-oriented:
+The canonical public surface is domain-oriented:
 
 | Domain | Canonical methods | Primary endpoints | Auth note |
 | --- | --- | --- | --- |
@@ -101,7 +101,7 @@ The canonical public surface in `0.8.x` is domain-oriented:
 | `responses()` | `create`, `stream`, `stream_unified` | `/responses` | API key |
 | `messages()` | `create`, `stream`, `stream_unified` | `/messages` | API key |
 | `rerank()` | `create` | `/rerank` | API key |
-| `tts()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
+| `audio().speech()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/endpoints/zdr`, `/embeddings*` | API key |
 | `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
@@ -121,7 +121,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 `openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:
 
 - chat completions, responses, and Anthropic-compatible messages
-- rerank, text-to-speech, and video generation polling/content retrieval
+- rerank, audio speech generation, and video generation polling/content retrieval
 - unified streaming across chat, responses, and messages
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
@@ -161,7 +161,7 @@ The repo includes runnable examples for the highest-value workflows:
 | [`examples/create_response.rs`](examples/create_response.rs) | `responses()` create |
 | [`examples/create_message.rs`](examples/create_message.rs) | `messages()` create |
 | [`examples/create_rerank.rs`](examples/create_rerank.rs) | `rerank().create(...)` |
-| [`examples/create_tts.rs`](examples/create_tts.rs) | `tts().create(...)` |
+| [`examples/create_speech.rs`](examples/create_speech.rs) | `audio().speech().create(...)` |
 | [`examples/create_video_generation.rs`](examples/create_video_generation.rs) | `videos().create(...)` |
 | [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
 | [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
@@ -183,6 +183,7 @@ cargo run --example typed_tool_calling
 cargo run --example create_response
 cargo run --example create_message
 cargo run --example create_rerank
+cargo run --example create_speech
 cargo run --example create_embedding
 ```
 
@@ -212,8 +213,16 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 - Canonical docs and examples prefer the domain clients over older flat helpers
 - Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`51 / 51`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
-- Migration guidance for the `0.7.x -> 0.8.0` transport/error-surface release, plus the archived `0.5.x -> 0.6.x` naming guide, lives in [`MIGRATION.md`](MIGRATION.md)
+- Migration guidance for the `0.8.x -> 0.9.0` audio speech/future-proofing release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
+
+### 🔁 0.9 Audio Speech Migration
+
+- `client.tts().create(...)` -> `client.audio().speech().create(...)`
+- `api::tts::TtsRequest` -> `api::audio::SpeechRequest`
+- `api::tts::TtsResponseFormat` -> `api::audio::SpeechResponseFormat`
+- `api::tts` remains as a deprecated compatibility module, but new examples and docs use `api::audio`
+- Newly added and high-churn public request/response structs use builder construction and may be marked `#[non_exhaustive]`; prefer request builders over struct literals
 
 ### 🔁 0.8 Transport/Error Migration
 
@@ -222,7 +231,7 @@ Full migration guide: [`MIGRATION.md`](MIGRATION.md)
 - `OpenRouterError::HttpRequest(surf::Error)` -> `OpenRouterError::HttpRequest(HttpRequestError)`
 - `ApiErrorContext.status: surf::StatusCode` -> `ApiErrorContext.status: http::StatusCode`
 - `openrouter_rs::utils::{with_bearer_auth, with_request_metadata, with_client_request_headers, handle_error}` -> caller-owned transport helpers or direct use of the canonical domain clients
-- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and `legacy()`
+- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `models()`, `management()`, and `legacy()`
 
 ### 🔁 0.6 Naming/Pagination Migration
 

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-cli"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI for OpenRouter account and SDK workflows"
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.8.1", path = "../.." }
+openrouter-rs = { version = "0.9.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -9,7 +9,7 @@ It currently focuses on four areas:
 - API-key, workspace, organization, and guardrail management
 - credits, billing, and usage activity
 
-The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.1.3`.
+The implementation lives in [`crates/openrouter-cli/src`](./src), and the crate currently publishes as `0.2.0`.
 
 Copyable shell and CI recipes live in [`../../docs/operations/cli-automation-workflows.md`](../../docs/operations/cli-automation-workflows.md).
 
@@ -30,7 +30,7 @@ cargo install --path crates/openrouter-cli --locked
 Prebuilt GitHub release archives follow the `openrouter-cli-v<version>` tag naming:
 
 ```bash
-VERSION=0.1.3
+VERSION=0.2.0
 curl -L -o openrouter-cli.tar.gz \
   "https://github.com/realmorrisliu/openrouter-rs/releases/download/openrouter-cli-v${VERSION}/openrouter-cli-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
 curl -L -o SHA256SUMS \

--- a/crates/openrouter-cli/README.md
+++ b/crates/openrouter-cli/README.md
@@ -244,6 +244,8 @@ openrouter-cli \
   --name "platform" \
   --slug "platform" \
   --default-text-model openai/gpt-4.1 \
+  --io-logging-api-key-id 101 \
+  --io-logging-sampling-rate 0.25 \
   --enable-observability-broadcast
 
 # Update a workspace
@@ -251,6 +253,7 @@ openrouter-cli \
   --management-key "$OPENROUTER_MANAGEMENT_KEY" \
   workspaces update ws_123 \
   --description "Platform engineering" \
+  --clear-io-logging-api-key-ids \
   --disable-data-discount-logging
 
 # Add members to a workspace

--- a/crates/openrouter-cli/src/cli.rs
+++ b/crates/openrouter-cli/src/cli.rs
@@ -546,6 +546,14 @@ pub struct WorkspacesCreateArgs {
     #[arg(long)]
     pub default_provider_sort: Option<String>,
 
+    /// Restrict observability IO logging to a key ID. Repeat to allow multiple keys.
+    #[arg(long = "io-logging-api-key-id", value_name = "KEY_ID")]
+    pub io_logging_api_key_ids: Vec<u64>,
+
+    /// Set observability IO logging sampling rate.
+    #[arg(long)]
+    pub io_logging_sampling_rate: Option<f64>,
+
     /// Set data discount logging enabled.
     #[arg(
         long = "enable-data-discount-logging",
@@ -617,6 +625,25 @@ pub struct WorkspacesUpdateArgs {
     /// Optional new default provider sort.
     #[arg(long)]
     pub default_provider_sort: Option<String>,
+
+    /// Restrict observability IO logging to a key ID. Repeat to allow multiple keys.
+    #[arg(
+        long = "io-logging-api-key-id",
+        value_name = "KEY_ID",
+        conflicts_with = "clear_io_logging_api_key_ids"
+    )]
+    pub io_logging_api_key_ids: Vec<u64>,
+
+    /// Clear observability IO logging key restrictions.
+    #[arg(
+        long = "clear-io-logging-api-key-ids",
+        conflicts_with = "io_logging_api_key_ids"
+    )]
+    pub clear_io_logging_api_key_ids: bool,
+
+    /// Set observability IO logging sampling rate.
+    #[arg(long)]
+    pub io_logging_sampling_rate: Option<f64>,
 
     /// Set data discount logging enabled.
     #[arg(

--- a/crates/openrouter-cli/src/main.rs
+++ b/crates/openrouter-cli/src/main.rs
@@ -846,6 +846,12 @@ async fn run(cli: Cli) -> Result<()> {
                     if let Some(default_provider_sort) = args.default_provider_sort {
                         builder.default_provider_sort(default_provider_sort);
                     }
+                    if !args.io_logging_api_key_ids.is_empty() {
+                        builder.io_logging_api_key_ids(args.io_logging_api_key_ids);
+                    }
+                    if let Some(io_logging_sampling_rate) = args.io_logging_sampling_rate {
+                        builder.io_logging_sampling_rate(io_logging_sampling_rate);
+                    }
                     if let Some(enabled) = data_discount_logging {
                         builder.is_data_discount_logging_enabled(enabled);
                     }
@@ -884,6 +890,9 @@ async fn run(cli: Cli) -> Result<()> {
                         && args.default_text_model.is_none()
                         && args.default_image_model.is_none()
                         && args.default_provider_sort.is_none()
+                        && args.io_logging_api_key_ids.is_empty()
+                        && !args.clear_io_logging_api_key_ids
+                        && args.io_logging_sampling_rate.is_none()
                         && data_discount_logging.is_none()
                         && observability_broadcast.is_none()
                         && observability_io_logging.is_none()
@@ -910,6 +919,12 @@ async fn run(cli: Cli) -> Result<()> {
                     if let Some(default_provider_sort) = args.default_provider_sort {
                         builder.default_provider_sort(default_provider_sort);
                     }
+                    if !args.io_logging_api_key_ids.is_empty() {
+                        builder.io_logging_api_key_ids(args.io_logging_api_key_ids);
+                    }
+                    if let Some(io_logging_sampling_rate) = args.io_logging_sampling_rate {
+                        builder.io_logging_sampling_rate(io_logging_sampling_rate);
+                    }
                     if let Some(enabled) = data_discount_logging {
                         builder.is_data_discount_logging_enabled(enabled);
                     }
@@ -921,7 +936,15 @@ async fn run(cli: Cli) -> Result<()> {
                     }
 
                     let request = builder.build()?;
-                    let response = management.update_workspace(&args.id, &request).await?;
+                    let response = if args.clear_io_logging_api_key_ids {
+                        management
+                            .update_workspace_with_cleared_io_logging_api_key_ids(
+                                &args.id, &request,
+                            )
+                            .await?
+                    } else {
+                        management.update_workspace(&args.id, &request).await?
+                    };
                     print_value(&response, cli.global.output)?;
                 }
                 WorkspacesCommands::Delete(args) => {

--- a/crates/openrouter-cli/tests/management_commands.rs
+++ b/crates/openrouter-cli/tests/management_commands.rs
@@ -443,6 +443,42 @@ fn test_workspaces_create_happy_path() {
 }
 
 #[test]
+fn test_workspaces_create_sends_io_logging_filters() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","io_logging_api_key_ids":[101,202],"io_logging_sampling_rate":0.25,"is_observability_io_logging_enabled":true,"is_observability_broadcast_enabled":false,"is_data_discount_logging_enabled":true,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("create")
+        .arg("--name")
+        .arg("Core")
+        .arg("--io-logging-api-key-id")
+        .arg("101")
+        .arg("--io-logging-api-key-id")
+        .arg("202")
+        .arg("--io-logging-sampling-rate")
+        .arg("0.25");
+    cmd.assert().success();
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(
+        body.get("io_logging_api_key_ids"),
+        Some(&serde_json::json!([101, 202]))
+    );
+    assert_eq!(
+        body.get("io_logging_sampling_rate").and_then(Value::as_f64),
+        Some(0.25)
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
 fn test_workspaces_get_happy_path() {
     let (base_url, rx, server) = spawn_json_server(
         r#"{"data":{"id":"ws_1","name":"Core","slug":"core","io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z"}}"#,
@@ -518,6 +554,29 @@ fn test_workspaces_update_happy_path() {
             .and_then(Value::as_bool),
         Some(false)
     );
+
+    server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_workspaces_update_can_clear_io_logging_filters() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"ws_1","name":"Core","slug":"core","io_logging_api_key_ids":null,"io_logging_sampling_rate":1.0,"is_observability_io_logging_enabled":false,"is_observability_broadcast_enabled":true,"is_data_discount_logging_enabled":false,"created_at":"2026-03-01T00:00:00.000Z","updated_at":"2026-03-02T00:00:00.000Z"}}"#,
+    );
+
+    let mut cmd = base_cmd(&base_url);
+    cmd.arg("workspaces")
+        .arg("update")
+        .arg("ws_1")
+        .arg("--clear-io-logging-api-key-ids");
+    cmd.assert().success();
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    let body: Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid json");
+    assert_eq!(body.get("io_logging_api_key_ids"), Some(&Value::Null));
 
     server.join().expect("server thread should finish");
 }

--- a/docs/design/generated-core-architecture.md
+++ b/docs/design/generated-core-architecture.md
@@ -21,7 +21,7 @@ If the project wants to stay aligned with a spec-driven SDK direction, it needs 
 
 ## Goals
 
-- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and `legacy()`
+- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`, and `legacy()`
 - Introduce a generated low-level layer that can follow the upstream OpenAPI more mechanically
 - Separate drift detection inputs from generation inputs so review workflows stay useful
 - Preserve streaming, typed tools, builder ergonomics, and unified abstractions as handwritten Rust-first surfaces

--- a/docs/design/http-transport-migration.md
+++ b/docs/design/http-transport-migration.md
@@ -30,7 +30,7 @@ The key issue is not that every layer is dead. The issue is that the public SDK 
 
 - Remove the default dependency chain on runtime `libcurl` / `curl`
 - Move the SDK onto a Tokio-native and actively maintained client stack
-- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`, and `legacy()`
+- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`, and `legacy()`
 - Preserve current behavior for JSON requests, auth headers, query encoding, and SSE streaming
 - Reduce coupling between public error types and a specific HTTP client implementation
 - Make the migration reviewable in a small number of focused PRs instead of one rewrite

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -14,7 +14,7 @@ Nightly drift workflow: `.github/workflows/openapi-drift.yml`
 
 Drift review note:
 
-- Official text-to-speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.tts().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
+- Official audio speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.audio().speech().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
 - Upstream added `GET /generation/content`, now exposed as `client.get_generation_content(...)` / `client.management().get_generation_content(...)`.
 - Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK and CLI now expose them; live management-key validation remains pending.
 - Upstream now exposes request metadata through generator globals (`HTTP-Referer`, `X-Title`) instead of repeating path-level metadata parameters. The SDK already applies `HTTP-Referer`, `X-Title`, `X-OpenRouter-Title`, and optional `X-OpenRouter-Categories` through the client builder.
@@ -26,7 +26,7 @@ Drift review note:
 Legend:
 
 - `SDK`: endpoint implemented in `openrouter-rs`.
-- Canonical surface note: the `0.7.x` docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
+- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
 - `Unit`: unit coverage depth.
   - `Path` = test asserts HTTP method/path (often with header/body checks).
   - `Contract` = serde/request-shape/parser coverage only.
@@ -79,7 +79,7 @@ Legend:
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
-| `POST /audio/speech` | `client.tts().create(...)` | Yes | Path | No | P1 |
+| `POST /audio/speech` | `client.audio().speech().create(...)` | Yes | Path | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
 | `POST /workspaces` | `client.management().create_workspace(...)` | Yes | Path | No | P1 |
 | `POST /workspaces/{id}/members/add` | `client.management().add_workspace_members(...)` | Yes | Path | No | P1 |
@@ -97,7 +97,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 | Endpoint | SDK surface | Notes |
 | --- | --- | --- |
 | `POST /completions` | `client.legacy().completions().create(...)` (feature `legacy-completions`) | Migration-only surface toward `chat`/`responses` |
-| `POST /tts` | `client.tts().create(...)` | Compatibility fallback while upstream rolls out `POST /audio/speech` everywhere |
+| `POST /tts` | `client.audio().speech().create(...)` | Compatibility fallback while upstream rolls out `POST /audio/speech` everywhere |
 
 ## Incremental Test Plan
 

--- a/examples/create_speech.rs
+++ b/examples/create_speech.rs
@@ -1,6 +1,6 @@
 use openrouter_rs::{
     OpenRouterClient,
-    api::tts::{TtsRequest, TtsResponseFormat},
+    api::audio::{SpeechRequest, SpeechResponseFormat},
 };
 
 #[tokio::main]
@@ -8,16 +8,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
     let client = OpenRouterClient::builder().api_key(api_key).build()?;
 
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello from openrouter-rs")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .build()?;
 
-    let audio = client.tts().create(&request).await?;
-    std::fs::write("tts-output.mp3", &audio)?;
-    println!("wrote {} bytes to tts-output.mp3", audio.len());
+    let audio = client.audio().speech().create(&request).await?;
+    std::fs::write("speech-output.mp3", &audio)?;
+    println!("wrote {} bytes to speech-output.mp3", audio.len());
 
     Ok(())
 }

--- a/scripts/check_migration_docs.sh
+++ b/scripts/check_migration_docs.sh
@@ -27,7 +27,15 @@ if [[ ! -f "$README_PATH" ]]; then
   exit 1
 fi
 
-# README must keep the migration-entry section and core rename mappings.
+# README must keep the current migration-entry section and core rename mappings.
+require_pattern "### 🔁 0.9 Audio Speech Migration" "$README_PATH"
+require_pattern "client.tts().create(...)" "$README_PATH"
+require_pattern "client.audio().speech().create(...)" "$README_PATH"
+require_pattern "api::tts::TtsRequest" "$README_PATH"
+require_pattern "api::audio::SpeechRequest" "$README_PATH"
+
+# README must also keep historical migration-entry mappings while those
+# historical sections remain part of the public upgrade docs.
 require_pattern "### 🔁 0.6 Naming/Pagination Migration" "$README_PATH"
 require_pattern "models().count()" "$README_PATH"
 require_pattern "models().get_model_count()" "$README_PATH"
@@ -36,9 +44,15 @@ require_pattern "models().list_user_models()" "$README_PATH"
 require_pattern "management().exchange_code_for_api_key(...)" "$README_PATH"
 require_pattern "management().create_api_key_from_auth_code(...)" "$README_PATH"
 
-# If MIGRATION.md exists (OR-25 and later), validate key structure and snippets.
+# If MIGRATION.md exists (OR-25 and later), validate current and historical key structure.
 if [[ -f "$MIGRATION_PATH" ]]; then
-  require_pattern "# Migration Guide: 0.5.x -> 0.6.0" "$MIGRATION_PATH"
+  require_pattern "# Migration Guide" "$MIGRATION_PATH"
+  require_pattern "## Latest: 0.8.x -> 0.9.0" "$MIGRATION_PATH"
+  require_pattern "## Previous: 0.7.x -> 0.8.0" "$MIGRATION_PATH"
+  require_pattern "## Historical: 0.5.x -> 0.6.0" "$MIGRATION_PATH"
+  require_pattern "client.audio().speech().create" "$MIGRATION_PATH"
+  require_pattern "api::audio::{SpeechRequest, SpeechResponseFormat}" "$MIGRATION_PATH"
+  require_pattern "UpdateWorkspaceRequest::builder()" "$MIGRATION_PATH"
   require_pattern "## Breaking-Change Mapping" "$MIGRATION_PATH"
   require_pattern "## Top 10 Before/After Recipes" "$MIGRATION_PATH"
   require_pattern "OpenRouterClientBuilder::management_key" "$MIGRATION_PATH"

--- a/src/api/api_keys.rs
+++ b/src/api/api_keys.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct ApiKey {
     pub name: Option<String>,
     pub label: Option<String>,
@@ -22,6 +23,7 @@ pub struct ApiKey {
 }
 
 #[derive(Serialize, Debug)]
+#[non_exhaustive]
 pub struct ApiKeyDetails {
     pub label: String,
     pub usage: f64,
@@ -68,6 +70,7 @@ impl<'de> Deserialize<'de> for ApiKeyDetails {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct RateLimit {
     pub requests: f64,
     pub interval: String,

--- a/src/api/audio.rs
+++ b/src/api/audio.rs
@@ -1,0 +1,190 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use reqwest::{Client as HttpClient, StatusCode};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
+};
+
+const OFFICIAL_SPEECH_PATH: &str = "/audio/speech";
+const LEGACY_TTS_PATH: &str = "/tts";
+
+/// Supported audio output formats for `POST /audio/speech`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SpeechResponseFormat {
+    Mp3,
+    Pcm,
+}
+
+/// Provider-specific passthrough options for speech requests.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct SpeechProviderOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Request payload for `POST /audio/speech`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct SpeechRequest {
+    #[builder(setter(into))]
+    pub input: String,
+    #[builder(setter(into))]
+    pub model: String,
+    #[builder(setter(into))]
+    pub voice: String,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<SpeechProviderOptions>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<SpeechResponseFormat>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f64>,
+}
+
+impl SpeechRequest {
+    pub fn builder() -> SpeechRequestBuilder {
+        SpeechRequestBuilder::default()
+    }
+}
+
+/// Submit a speech request and return raw audio bytes.
+pub async fn create_speech(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &SpeechRequest,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_speech_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_speech_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &SpeechRequest,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let request_metadata = (x_title, http_referer, app_categories);
+    let official_response = send_speech_request(
+        http_client,
+        base_url,
+        api_key,
+        request_metadata,
+        request,
+        OFFICIAL_SPEECH_PATH,
+    )
+    .await?;
+
+    if official_response.status().is_success() {
+        return Ok(official_response.bytes().await?.to_vec());
+    }
+
+    let official_error = transport_response::error_from_response(official_response).await;
+
+    // Keep a narrow legacy fallback while upstream finishes the `/tts` -> `/audio/speech`
+    // transition without masking request-level failures from the official route.
+    if should_retry_legacy_tts(&official_error) {
+        let legacy_response = send_speech_request(
+            http_client,
+            base_url,
+            api_key,
+            request_metadata,
+            request,
+            LEGACY_TTS_PATH,
+        )
+        .await?;
+
+        if legacy_response.status().is_success() {
+            return Ok(legacy_response.bytes().await?.to_vec());
+        }
+
+        transport_response::handle_error(legacy_response).await?;
+    }
+
+    Err(official_error)
+}
+
+async fn send_speech_request(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    request_metadata: (&Option<String>, &Option<String>, &Option<Vec<String>>),
+    request: &SpeechRequest,
+    endpoint_path: &str,
+) -> Result<reqwest::Response, OpenRouterError> {
+    let url = format!("{base_url}{endpoint_path}");
+    Ok(transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        request_metadata.0,
+        request_metadata.1,
+        request_metadata.2,
+    )?
+    .json(request)
+    .send()
+    .await?)
+}
+
+fn should_retry_legacy_tts(error: &OpenRouterError) -> bool {
+    let OpenRouterError::Api(api_error) = error else {
+        return false;
+    };
+
+    let message = api_error.message.trim().to_ascii_lowercase();
+    match api_error.status {
+        StatusCode::NOT_FOUND => {
+            is_generic_status_page(&message, "404", "not found")
+                || is_path_specific_route_error(&message)
+        }
+        StatusCode::METHOD_NOT_ALLOWED => {
+            is_generic_status_page(&message, "405", "method not allowed")
+                || is_path_specific_route_error(&message)
+        }
+        _ => false,
+    }
+}
+
+fn is_generic_status_page(message: &str, code: &str, reason_phrase: &str) -> bool {
+    let message = message.trim_end_matches(['.', '!', '?', ';']);
+    let bare_reason_phrase = matches!(message, "not found" | "method not allowed");
+    let exact_status_page = message == format!("{code} page {reason_phrase}")
+        || message == format!("{code} {reason_phrase}")
+        || message == format!("http/1.1 {code} {reason_phrase}")
+        || message == format!("http/2 {code} {reason_phrase}");
+
+    bare_reason_phrase || exact_status_page
+}
+
+fn is_path_specific_route_error(message: &str) -> bool {
+    let route_unavailable_signal = message.contains("cannot post")
+        || message.contains("cannot get")
+        || message.contains("route")
+        || message.contains("endpoint")
+        || message.contains("path")
+        || message.contains("method not allowed");
+
+    route_unavailable_signal && message.contains(OFFICIAL_SPEECH_PATH)
+}

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct GenerationData {
     pub id: String,
     pub total_cost: f64,
@@ -44,6 +45,7 @@ pub struct GenerationData {
 
 /// Stored prompt/input and completion/output content returned by `GET /generation/content`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct GenerationContentData {
     #[serde(default)]
     pub input: HashMap<String, Value>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,7 +9,7 @@
 //! - `client.responses()` -> [`responses`]
 //! - `client.messages()` -> [`messages`]
 //! - `client.rerank()` -> [`rerank`]
-//! - `client.tts()` -> [`tts`]
+//! - `client.audio().speech()` -> [`audio`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
 //! - `client.management()` -> [`api_keys`], [`auth`], [`credits`], [`generation`], [`guardrails`], [`organization`], [`workspaces`]
@@ -21,7 +21,7 @@
 //! - Responses API
 //! - Anthropic-compatible Messages API
 //! - rerank
-//! - text-to-speech
+//! - audio speech generation
 //! - video generation and polling
 //! - model discovery, providers, user model filters, model counts, and ZDR endpoints
 //! - embeddings
@@ -114,6 +114,7 @@
 //! ```
 
 pub mod api_keys;
+pub mod audio;
 pub mod auth;
 pub mod chat;
 pub mod credits;
@@ -127,6 +128,7 @@ pub mod models;
 pub mod organization;
 pub mod rerank;
 pub mod responses;
+#[deprecated(note = "use api::audio for the canonical /audio/speech surface")]
 pub mod tts;
 pub mod videos;
 pub mod workspaces;

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -1,71 +1,32 @@
-use std::collections::HashMap;
+//! Deprecated compatibility layer for the pre-0.9 text-to-speech API names.
+//!
+//! Use [`crate::api::audio`] for the canonical `/audio/speech` surface.
 
-use derive_builder::Builder;
-use reqwest::{Client as HttpClient, StatusCode};
-use serde::{Deserialize, Serialize};
+use crate::{api::audio, error::OpenRouterError};
 
-use crate::{
-    error::OpenRouterError,
-    transport::{request as transport_request, response as transport_response},
-};
+#[deprecated(note = "use api::audio::SpeechResponseFormat")]
+pub type TtsResponseFormat = audio::SpeechResponseFormat;
 
-const OFFICIAL_TTS_PATH: &str = "/audio/speech";
-const LEGACY_TTS_PATH: &str = "/tts";
+#[deprecated(note = "use api::audio::SpeechProviderOptions")]
+pub type TtsProviderOptions = audio::SpeechProviderOptions;
 
-/// Supported audio output formats for `POST /audio/speech`.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum TtsResponseFormat {
-    Mp3,
-    Pcm,
-}
+#[deprecated(note = "use api::audio::SpeechRequest")]
+pub type TtsRequest = audio::SpeechRequest;
 
-/// Provider-specific passthrough options for text-to-speech requests.
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct TtsProviderOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<HashMap<String, serde_json::Value>>,
-}
+#[deprecated(note = "use api::audio::SpeechRequestBuilder")]
+pub type TtsRequestBuilder = audio::SpeechRequestBuilder;
 
-/// Request payload for `POST /audio/speech`.
-#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
-#[builder(build_fn(error = "OpenRouterError"))]
-pub struct TtsRequest {
-    #[builder(setter(into))]
-    pub input: String,
-    #[builder(setter(into))]
-    pub model: String,
-    #[builder(setter(into))]
-    pub voice: String,
-    #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<TtsProviderOptions>,
-    #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_format: Option<TtsResponseFormat>,
-    #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub speed: Option<f64>,
-}
-
-impl TtsRequest {
-    pub fn builder() -> TtsRequestBuilder {
-        TtsRequestBuilder::default()
-    }
-}
-
-/// Submit a text-to-speech request and return raw audio bytes.
+/// Submit a speech request and return raw audio bytes.
+#[deprecated(note = "use api::audio::create_speech")]
 pub async fn create_tts(
     base_url: &str,
     api_key: &str,
     x_title: &Option<String>,
     http_referer: &Option<String>,
     app_categories: &Option<Vec<String>>,
-    request: &TtsRequest,
+    request: &audio::SpeechRequest,
 ) -> Result<Vec<u8>, OpenRouterError> {
-    let http_client = crate::transport::new_client()?;
-    create_tts_with_client(
-        &http_client,
+    audio::create_speech(
         base_url,
         api_key,
         x_title,
@@ -74,116 +35,4 @@ pub async fn create_tts(
         request,
     )
     .await
-}
-
-pub(crate) async fn create_tts_with_client(
-    http_client: &HttpClient,
-    base_url: &str,
-    api_key: &str,
-    x_title: &Option<String>,
-    http_referer: &Option<String>,
-    app_categories: &Option<Vec<String>>,
-    request: &TtsRequest,
-) -> Result<Vec<u8>, OpenRouterError> {
-    let request_metadata = (x_title, http_referer, app_categories);
-    let official_response = send_tts_request(
-        http_client,
-        base_url,
-        api_key,
-        request_metadata,
-        request,
-        OFFICIAL_TTS_PATH,
-    )
-    .await?;
-
-    if official_response.status().is_success() {
-        return Ok(official_response.bytes().await?.to_vec());
-    }
-
-    let official_error = transport_response::error_from_response(official_response).await;
-
-    // Keep a narrow legacy fallback while upstream finishes the `/tts` -> `/audio/speech`
-    // transition so the canonical `client.tts()` surface continues to work across both paths
-    // without masking request-level failures from the official route.
-    if should_retry_legacy_tts(&official_error) {
-        let legacy_response = send_tts_request(
-            http_client,
-            base_url,
-            api_key,
-            request_metadata,
-            request,
-            LEGACY_TTS_PATH,
-        )
-        .await?;
-
-        if legacy_response.status().is_success() {
-            return Ok(legacy_response.bytes().await?.to_vec());
-        }
-
-        transport_response::handle_error(legacy_response).await?;
-    }
-
-    Err(official_error)
-}
-
-async fn send_tts_request(
-    http_client: &HttpClient,
-    base_url: &str,
-    api_key: &str,
-    request_metadata: (&Option<String>, &Option<String>, &Option<Vec<String>>),
-    request: &TtsRequest,
-    endpoint_path: &str,
-) -> Result<reqwest::Response, OpenRouterError> {
-    let url = format!("{base_url}{endpoint_path}");
-    Ok(transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        request_metadata.0,
-        request_metadata.1,
-        request_metadata.2,
-    )?
-    .json(request)
-    .send()
-    .await?)
-}
-
-fn should_retry_legacy_tts(error: &OpenRouterError) -> bool {
-    let OpenRouterError::Api(api_error) = error else {
-        return false;
-    };
-
-    let message = api_error.message.trim().to_ascii_lowercase();
-    match api_error.status {
-        StatusCode::NOT_FOUND => {
-            is_generic_status_page(&message, "404", "not found")
-                || is_path_specific_route_error(&message)
-        }
-        StatusCode::METHOD_NOT_ALLOWED => {
-            is_generic_status_page(&message, "405", "method not allowed")
-                || is_path_specific_route_error(&message)
-        }
-        _ => false,
-    }
-}
-
-fn is_generic_status_page(message: &str, code: &str, reason_phrase: &str) -> bool {
-    let message = message.trim_end_matches(['.', '!', '?', ';']);
-    let bare_reason_phrase = matches!(message, "not found" | "method not allowed");
-    let exact_status_page = message == format!("{code} page {reason_phrase}")
-        || message == format!("{code} {reason_phrase}")
-        || message == format!("http/1.1 {code} {reason_phrase}")
-        || message == format!("http/2 {code} {reason_phrase}");
-
-    bare_reason_phrase || exact_status_page
-}
-
-fn is_path_specific_route_error(message: &str) -> bool {
-    let route_unavailable_signal = message.contains("cannot post")
-        || message.contains("cannot get")
-        || message.contains("route")
-        || message.contains("endpoint")
-        || message.contains("path")
-        || message.contains("method not allowed");
-
-    route_unavailable_signal && message.contains(OFFICIAL_TTS_PATH)
 }

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -62,6 +62,7 @@ pub struct VideoProviderOptions {
 /// Request payload for `POST /videos`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct VideoGenerationRequest {
     #[builder(setter(into))]
     pub prompt: String,
@@ -107,6 +108,7 @@ impl VideoGenerationRequest {
 
 /// Usage payload returned by video generation status responses.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoGenerationUsage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
@@ -116,6 +118,7 @@ pub struct VideoGenerationUsage {
 
 /// Response payload returned by `POST /videos` and `GET /videos/{jobId}`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoGenerationResponse {
     pub id: String,
     pub polling_url: String,
@@ -132,6 +135,7 @@ pub struct VideoGenerationResponse {
 
 /// Video model metadata returned by `GET /videos/models`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoModel {
     pub id: String,
     pub canonical_slug: String,

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -18,6 +18,7 @@ struct ListWorkspacesQuery {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Workspace {
     pub id: String,
     pub name: String,
@@ -44,6 +45,7 @@ pub struct Workspace {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct WorkspaceListResponse {
     pub data: Vec<Workspace>,
     pub total_count: f64,
@@ -51,6 +53,7 @@ pub struct WorkspaceListResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct CreateWorkspaceRequest {
     #[builder(setter(into))]
     pub name: String,
@@ -94,6 +97,7 @@ impl CreateWorkspaceRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct UpdateWorkspaceRequest {
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -194,6 +198,7 @@ struct DeleteWorkspaceResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct WorkspaceMember {
     pub id: String,
     pub workspace_id: String,
@@ -204,6 +209,7 @@ pub struct WorkspaceMember {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct WorkspaceMembersRequest {
     pub user_ids: Vec<String>,
 }
@@ -215,12 +221,14 @@ impl WorkspaceMembersRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct WorkspaceMembersAddResponse {
     pub added_count: f64,
     pub data: Vec<WorkspaceMember>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct WorkspaceMembersRemoveResponse {
     pub removed_count: f64,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,8 +5,8 @@ use futures_util::stream::BoxStream;
 use crate::api::legacy::completion;
 use crate::{
     api::{
-        api_keys, auth, chat, credits, discovery, embeddings, generation, guardrails, messages,
-        models, organization, rerank, responses, tts, videos, workspaces,
+        api_keys, audio, auth, chat, credits, discovery, embeddings, generation, guardrails,
+        messages, models, organization, rerank, responses, videos, workspaces,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -135,9 +135,15 @@ impl OpenRouterClient {
         RerankClient { client: self }
     }
 
+    /// Domain client for audio operations.
+    pub fn audio(&self) -> AudioClient<'_> {
+        AudioClient { client: self }
+    }
+
     /// Domain client for text-to-speech operations.
-    pub fn tts(&self) -> TtsClient<'_> {
-        TtsClient { client: self }
+    #[deprecated(note = "use client.audio().speech()")]
+    pub fn tts(&self) -> SpeechClient<'_> {
+        self.audio().speech()
     }
 
     /// Domain client for video generation operations.
@@ -1107,10 +1113,13 @@ impl OpenRouterClient {
         }
     }
 
-    /// Submit a text-to-speech request and return raw audio bytes.
-    pub async fn create_tts(&self, request: &tts::TtsRequest) -> Result<Vec<u8>, OpenRouterError> {
+    /// Submit a speech request and return raw audio bytes.
+    pub async fn create_speech(
+        &self,
+        request: &audio::SpeechRequest,
+    ) -> Result<Vec<u8>, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
-            tts::create_tts_with_client(
+            audio::create_speech_with_client(
                 self.http_client(),
                 &self.base_url,
                 api_key,
@@ -1123,6 +1132,15 @@ impl OpenRouterClient {
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
+    }
+
+    /// Submit a text-to-speech request and return raw audio bytes.
+    #[deprecated(note = "use create_speech")]
+    pub async fn create_tts(
+        &self,
+        request: &audio::SpeechRequest,
+    ) -> Result<Vec<u8>, OpenRouterError> {
+        self.create_speech(request).await
     }
 
     /// Submit a video generation request.
@@ -1853,18 +1871,36 @@ impl<'a> RerankClient<'a> {
     }
 }
 
-/// Domain client for text-to-speech endpoints.
+/// Domain client for audio endpoints.
 #[derive(Debug, Clone, Copy)]
-pub struct TtsClient<'a> {
+pub struct AudioClient<'a> {
     client: &'a OpenRouterClient,
 }
 
-impl<'a> TtsClient<'a> {
-    /// Create speech audio bytes (`POST /audio/speech`).
-    pub async fn create(&self, request: &tts::TtsRequest) -> Result<Vec<u8>, OpenRouterError> {
-        self.client.create_tts(request).await
+impl<'a> AudioClient<'a> {
+    /// Domain client for speech generation operations.
+    pub fn speech(&self) -> SpeechClient<'a> {
+        SpeechClient {
+            client: self.client,
+        }
     }
 }
+
+/// Domain client for audio speech endpoints.
+#[derive(Debug, Clone, Copy)]
+pub struct SpeechClient<'a> {
+    client: &'a OpenRouterClient,
+}
+
+impl<'a> SpeechClient<'a> {
+    /// Create speech audio bytes (`POST /audio/speech`).
+    pub async fn create(&self, request: &audio::SpeechRequest) -> Result<Vec<u8>, OpenRouterError> {
+        self.client.create_speech(request).await
+    }
+}
+
+#[deprecated(note = "use SpeechClient")]
+pub type TtsClient<'a> = SpeechClient<'a>;
 
 /// Domain client for video generation endpoints.
 #[derive(Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.8.1"
+//! openrouter-rs = "0.9.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # OpenRouter Rust SDK
 //!
 //! `openrouter-rs` is a type-safe, async Rust SDK for the [OpenRouter API](https://openrouter.ai/),
-//! providing typed access to chat, responses, messages, rerank, text-to-speech, video generation,
+//! providing typed access to chat, responses, messages, rerank, audio speech, video generation,
 //! discovery, embeddings, and management endpoints.
 //!
 //! ## ✨ Key Features
@@ -9,7 +9,7 @@
 //! - **🔒 Type Safety**: Leverages Rust's type system for compile-time error prevention
 //! - **⚡ Async/Await**: Built on `tokio` for high-performance async operations  
 //! - **🏗️ Builder Pattern**: Ergonomic client and request construction
-//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `tts()`, `videos()`, `models()`, `management()`
+//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`
 //! - **📡 Streaming Support**: Real-time response streaming with `futures`
 //! - **🧩 Unified Streaming Events**: Shared stream event model across chat/responses/messages
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
@@ -145,7 +145,7 @@
 //! | Domain-Oriented Client API | ✅ | [`client::OpenRouterClient`] |
 //! | Chat Completions | ✅ | [`api::chat`] |
 //! | Rerank | ✅ | [`api::rerank`] |
-//! | Text-to-Speech | ✅ | [`api::tts`] |
+//! | Audio Speech | ✅ | [`api::audio`] |
 //! | Video Generation | ✅ | [`api::videos`] |
 //! | Legacy Text Completions (`legacy-completions`) | ✅ | `api::legacy::completion` |
 //! | Model Information | ✅ | [`api::models`] |

--- a/tests/unit/audio.rs
+++ b/tests/unit/audio.rs
@@ -8,10 +8,10 @@ use std::{
 };
 
 use http::StatusCode;
-use openrouter_rs::api::tts::{self, TtsProviderOptions, TtsRequest, TtsResponseFormat};
+use openrouter_rs::api::audio::{self, SpeechProviderOptions, SpeechRequest, SpeechResponseFormat};
 
 #[test]
-fn test_tts_request_serialization() {
+fn test_speech_request_serialization() {
     let mut provider_options = HashMap::new();
     provider_options.insert(
         "openai".to_string(),
@@ -20,19 +20,19 @@ fn test_tts_request_serialization() {
         }),
     );
 
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .speed(1.1)
-        .provider(TtsProviderOptions {
+        .provider(SpeechProviderOptions {
             options: Some(provider_options),
         })
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let value = serde_json::to_value(&request).expect("tts request should serialize");
+    let value = serde_json::to_value(&request).expect("speech request should serialize");
     assert_eq!(value["model"], "elevenlabs/eleven-turbo-v2");
     assert_eq!(value["input"], "Hello world");
     assert_eq!(value["voice"], "alloy");
@@ -45,7 +45,7 @@ fn test_tts_request_serialization() {
 }
 
 #[tokio::test]
-async fn test_create_tts_path_body_headers_and_binary_response() {
+async fn test_create_speech_path_body_headers_and_binary_response() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()
@@ -117,16 +117,16 @@ async fn test_create_tts_path_body_headers_and_binary_response() {
     });
 
     let base_url = format!("http://{addr}/api/v1");
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .speed(1.0)
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let response = tts::create_tts(
+    let response = audio::create_speech(
         &base_url,
         "api-key",
         &Some("openrouter-rs".to_string()),
@@ -135,7 +135,7 @@ async fn test_create_tts_path_body_headers_and_binary_response() {
         &request,
     )
     .await
-    .expect("tts request should succeed");
+    .expect("speech request should succeed");
     assert_eq!(response, b"ID3fake-audio-data");
 
     let (request_line, request_text, body_text) = rx
@@ -181,7 +181,7 @@ async fn test_create_tts_path_body_headers_and_binary_response() {
 }
 
 #[tokio::test]
-async fn test_create_tts_falls_back_to_legacy_path_when_official_path_is_missing() {
+async fn test_create_speech_falls_back_to_legacy_path_when_official_path_is_missing() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()
@@ -237,17 +237,17 @@ async fn test_create_tts_falls_back_to_legacy_path_when_official_path_is_missing
     });
 
     let base_url = format!("http://{addr}/api/v1");
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let response = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+    let response = audio::create_speech(&base_url, "api-key", &None, &None, &None, &request)
         .await
-        .expect("tts request should fall back and succeed");
+        .expect("speech request should fall back and succeed");
     assert_eq!(response, b"ID3legacy-fallback");
 
     let first_request_line = rx
@@ -263,7 +263,7 @@ async fn test_create_tts_falls_back_to_legacy_path_when_official_path_is_missing
 }
 
 #[tokio::test]
-async fn test_create_tts_does_not_fall_back_for_request_level_404() {
+async fn test_create_speech_does_not_fall_back_for_request_level_404() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()
@@ -303,17 +303,17 @@ async fn test_create_tts_does_not_fall_back_for_request_level_404() {
     });
 
     let base_url = format!("http://{addr}/api/v1");
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let error = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+    let error = audio::create_speech(&base_url, "api-key", &None, &None, &None, &request)
         .await
-        .expect_err("tts request should surface the official error");
+        .expect_err("speech request should surface the official error");
 
     match error {
         openrouter_rs::error::OpenRouterError::Api(api_error) => {
@@ -336,7 +336,7 @@ async fn test_create_tts_does_not_fall_back_for_request_level_404() {
 }
 
 #[tokio::test]
-async fn test_create_tts_does_not_fall_back_for_plain_text_request_level_404() {
+async fn test_create_speech_does_not_fall_back_for_plain_text_request_level_404() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()
@@ -376,17 +376,17 @@ async fn test_create_tts_does_not_fall_back_for_plain_text_request_level_404() {
     });
 
     let base_url = format!("http://{addr}/api/v1");
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let error = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+    let error = audio::create_speech(&base_url, "api-key", &None, &None, &None, &request)
         .await
-        .expect_err("tts request should surface the official error");
+        .expect_err("speech request should surface the official error");
 
     match error {
         openrouter_rs::error::OpenRouterError::Api(api_error) => {
@@ -409,7 +409,7 @@ async fn test_create_tts_does_not_fall_back_for_plain_text_request_level_404() {
 }
 
 #[tokio::test]
-async fn test_create_tts_falls_back_for_plain_text_404_page_not_found() {
+async fn test_create_speech_falls_back_for_plain_text_404_page_not_found() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()
@@ -465,17 +465,17 @@ async fn test_create_tts_falls_back_for_plain_text_404_page_not_found() {
     });
 
     let base_url = format!("http://{addr}/api/v1");
-    let request = TtsRequest::builder()
+    let request = SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(TtsResponseFormat::Mp3)
+        .response_format(SpeechResponseFormat::Mp3)
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let response = tts::create_tts(&base_url, "api-key", &None, &None, &None, &request)
+    let response = audio::create_speech(&base_url, "api-key", &None, &None, &None, &request)
         .await
-        .expect("tts request should fall back and succeed");
+        .expect("speech request should fall back and succeed");
     assert_eq!(response, b"ID3plain-text-fallback");
 
     let first_request_line = rx

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -9,7 +9,7 @@ use std::{
 use openrouter_rs::{
     OpenRouterClient,
     api::{
-        auth, chat, credits, embeddings, guardrails, messages, rerank, responses, tts, videos,
+        audio, auth, chat, credits, embeddings, guardrails, messages, rerank, responses, videos,
         workspaces,
     },
     error::OpenRouterError,
@@ -373,18 +373,18 @@ async fn test_rerank_domain_requires_api_key() {
 }
 
 #[tokio::test]
-async fn test_tts_domain_requires_api_key() {
+async fn test_audio_speech_domain_requires_api_key() {
     let client = OpenRouterClient::builder()
         .build()
         .expect("client should build");
-    let request = tts::TtsRequest::builder()
+    let request = audio::SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("hello")
         .voice("alloy")
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
-    let result = client.tts().create(&request).await;
+    let result = client.audio().speech().create(&request).await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
 }
 
@@ -804,26 +804,27 @@ async fn test_rerank_domain_create_delegates_to_api_module() {
 }
 
 #[tokio::test]
-async fn test_tts_domain_create_delegates_to_api_module() {
+async fn test_audio_speech_domain_create_delegates_to_api_module() {
     let (base_url, rx, server) = spawn_binary_server(b"ID3tts-audio", "audio/mpeg");
     let client = OpenRouterClient::builder()
         .base_url(base_url)
         .api_key("api-key")
         .build()
         .expect("client should build");
-    let request = tts::TtsRequest::builder()
+    let request = audio::SpeechRequest::builder()
         .model("elevenlabs/eleven-turbo-v2")
         .input("Hello world")
         .voice("alloy")
-        .response_format(tts::TtsResponseFormat::Mp3)
+        .response_format(audio::SpeechResponseFormat::Mp3)
         .build()
-        .expect("tts request should build");
+        .expect("speech request should build");
 
     let response = client
-        .tts()
+        .audio()
+        .speech()
         .create(&request)
         .await
-        .expect("tts should succeed");
+        .expect("speech should succeed");
     assert_eq!(response, b"ID3tts-audio");
 
     let captured = rx

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -4,6 +4,7 @@ fn dummy_test() {
 }
 
 pub mod api_keys;
+pub mod audio;
 pub mod auth;
 pub mod chat_api;
 pub mod chat_request;
@@ -29,7 +30,6 @@ pub mod response_format;
 pub mod responses;
 pub mod stream;
 pub mod tool_builder;
-pub mod tts;
 pub mod unified_stream;
 pub mod videos;
 pub mod workspaces;

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -161,20 +161,12 @@ fn test_update_workspace_request_serialization() {
 }
 
 #[test]
-fn test_update_workspace_request_struct_literal_still_supported() {
-    let request = UpdateWorkspaceRequest {
-        name: Some("Updated".to_string()),
-        slug: None,
-        description: None,
-        default_text_model: None,
-        default_image_model: None,
-        default_provider_sort: None,
-        io_logging_api_key_ids: Some(Vec::new()),
-        io_logging_sampling_rate: None,
-        is_data_discount_logging_enabled: None,
-        is_observability_broadcast_enabled: None,
-        is_observability_io_logging_enabled: None,
-    };
+fn test_update_workspace_request_builder_supports_empty_io_logging_filter() {
+    let request = UpdateWorkspaceRequest::builder()
+        .name("Updated")
+        .io_logging_api_key_ids(Vec::<u64>::new())
+        .build()
+        .expect("update workspace request should build");
 
     let value = serde_json::to_value(&request).expect("request should serialize");
     assert_eq!(value["name"], "Updated");


### PR DESCRIPTION
## Summary
- prepare openrouter-rs 0.9.0 and openrouter-cli 0.2.0
- add canonical audio speech SDK surface and deprecate tts aliases
- update changelog, README release history, migration/release sync docs, and workspace CLI coverage

## Validation
- just quality-ci
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.9.0
- cargo package --locked --allow-dirty