### PR TITLE
chore: accept OpenAPI drift 204

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Direct cargo entrypoints:
 
 - Follow the existing commit style: `feat:`, `fix:`, `docs:`, `chore:`.
 - Keep PRs focused and include rationale plus behavior changes.
+- Do not close pull requests automatically unless the user explicitly asks for that action.
 - When API surface changes, update `README.md`, relevant example(s), and `CHANGELOG.md` in the same change.
 - Before opening a PR, run `just quality`.
 - If you touched CLI behavior, migration docs, or CI-aligned release/test surfaces, also run `just quality-ci`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added typed OpenRouter chat-completion usage cost fields via `ResponseUsage::cost`, `ResponseUsage::cost_details`, `ResponseUsage::is_byok`, and `ResponseCostDetails`.
+
+### Changed
+- Accepted the 2026-04-29 OpenAPI drift review, including `stt` generation origins and chat usage cost metadata, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
+
 ## [0.9.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The current repo snapshot implements `51 / 51` official OpenAPI method/path entr
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
+- Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
 - Discovery, rerank, audio speech, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-28
+Snapshot date: 2026-04-29
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Nightly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -22,6 +22,7 @@ Drift review note:
 - Upstream refreshed dynamic taxonomy details (`OutputModality` now uses `speech` instead of `tts`, provider lists now include `Nex AGI`, and Responses result nullable annotations were narrowed). The SDK already carries those surfaces through flexible `String`, `Value`, `HashMap`, and `Option` fields, so no public API migration is required.
 - Upstream added `response_cache_source_id` to generation metadata, workspace I/O logging key filters and sampling rate fields, and `callback_url` for video generation requests. The SDK now exposes those typed fields, and the 2026-04-28 baseline refresh keeps the accepted endpoint snapshot at `51 / 51`.
 - Upstream refreshed web-search, provider, and Responses output schemas. Existing OpenRouter plugin passthrough, Anthropic hosted-tool extras, provider option maps, and Responses `Value` payloads carry those schema details without a public API migration.
+- Upstream added `stt` as a generation origin and chat-completion usage cost metadata. `GenerationData::origin` remains a flexible `String`, and `ResponseUsage` now exposes typed `cost`, `cost_details`, and `is_byok` fields. The 2026-04-29 baseline refresh keeps the accepted endpoint snapshot at `51 / 51`.
 
 Legend:
 

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -6409,6 +6409,13 @@
           "completion_tokens_details": {
             "reasoning_tokens": 5
           },
+          "cost": 0.0012,
+          "cost_details": {
+            "upstream_inference_completions_cost": 0.0004,
+            "upstream_inference_cost": null,
+            "upstream_inference_prompt_cost": 0.0008
+          },
+          "is_byok": false,
           "prompt_tokens": 10,
           "prompt_tokens_details": {
             "cached_tokens": 2
@@ -6446,6 +6453,19 @@
               }
             },
             "type": "object"
+          },
+          "cost": {
+            "description": "Cost of the completion",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "cost_details": {
+            "$ref": "#/components/schemas/CostDetails"
+          },
+          "is_byok": {
+            "description": "Whether a request was made using a Bring Your Own Key configuration",
+            "type": "boolean"
           },
           "prompt_tokens": {
             "description": "Number of tokens in the prompt",
@@ -7076,6 +7096,35 @@
         },
         "required": [
           "id"
+        ],
+        "type": "object"
+      },
+      "CostDetails": {
+        "description": "Breakdown of upstream inference costs",
+        "example": {
+          "upstream_inference_completions_cost": 0.0004,
+          "upstream_inference_cost": null,
+          "upstream_inference_prompt_cost": 0.0008
+        },
+        "nullable": true,
+        "properties": {
+          "upstream_inference_completions_cost": {
+            "format": "double",
+            "type": "number"
+          },
+          "upstream_inference_cost": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "upstream_inference_prompt_cost": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "upstream_inference_prompt_cost",
+          "upstream_inference_completions_cost"
         ],
         "type": "object"
       },
@@ -8569,6 +8618,7 @@
                   "embeddings",
                   "rerank",
                   "tts",
+                  "stt",
                   "video",
                   null
                 ],
@@ -12211,27 +12261,7 @@
                         "type": "number"
                       },
                       "cost_details": {
-                        "nullable": true,
-                        "properties": {
-                          "upstream_inference_completions_cost": {
-                            "format": "double",
-                            "type": "number"
-                          },
-                          "upstream_inference_cost": {
-                            "format": "double",
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "upstream_inference_prompt_cost": {
-                            "format": "double",
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "upstream_inference_prompt_cost",
-                          "upstream_inference_completions_cost"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/CostDetails"
                       },
                       "is_byok": {
                         "type": "boolean"
@@ -15176,7 +15206,8 @@
           "audio",
           "video",
           "rerank",
-          "speech"
+          "speech",
+          "transcription"
         ],
         "example": "text",
         "type": "string",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-28T06:34:58+00:00",
+  "captured_at": "2026-04-29T07:05:54+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f9245e7ad764aaf0",
+      "fingerprint": "dd243a0e87c9d573",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ba099f80d16f9c0c",
+      "fingerprint": "d6afb8ddc3f2def3",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6c89b5d549bc33a9",
+      "fingerprint": "05c136e1dd21a680",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4c77c4b4c9a82e2a",
+      "fingerprint": "0fe1c297d2f1f250",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "15e473cb11f97766",
+      "fingerprint": "6545cb7dfeff2040",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4974cef56be35025",
+      "fingerprint": "4aae24f2458bd5da",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -41,6 +41,17 @@ impl ReasoningDetail {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ResponseCostDetails {
+    /// Upstream provider cost attributed to completion tokens.
+    pub upstream_inference_completions_cost: f64,
+    /// Upstream provider cost attributed to prompt tokens.
+    pub upstream_inference_prompt_cost: f64,
+    /// Total upstream inference cost when provided separately by OpenRouter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_inference_cost: Option<f64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResponseUsage {
     /// Including images and tools if any
     pub prompt_tokens: u32,
@@ -48,6 +59,15 @@ pub struct ResponseUsage {
     pub completion_tokens: u32,
     /// Sum of the above two fields
     pub total_tokens: u32,
+    /// Total OpenRouter request cost when returned by the API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
+    /// Provider-level cost breakdown when returned by the API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_details: Option<ResponseCostDetails>,
+    /// Whether the request was billed through BYOK provider credentials.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_byok: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/tests/unit/completion.rs
+++ b/tests/unit/completion.rs
@@ -239,6 +239,47 @@ fn test_gemini_tool_call_response() {
     assert!(result.is_ok(), "Failed: {:?}", result.err());
 }
 
+#[test]
+fn test_usage_deserializes_openrouter_cost_fields() {
+    let json = r#"{
+        "id": "gen-usage-cost",
+        "choices": [{
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Hello"
+            }
+        }],
+        "created": 1700000000,
+        "model": "openai/gpt-4o-mini",
+        "object": "chat.completion",
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 10,
+            "total_tokens": 110,
+            "cost": 0.00025,
+            "cost_details": {
+                "upstream_inference_prompt_cost": 0.0001,
+                "upstream_inference_completions_cost": 0.00015,
+                "upstream_inference_cost": null
+            },
+            "is_byok": false
+        }
+    }"#;
+
+    let response: CompletionsResponse =
+        serde_json::from_str(json).expect("response should deserialize");
+    let usage = response.usage.expect("usage should be present");
+    let cost_details = usage.cost_details.expect("cost details should be present");
+
+    assert_eq!(usage.cost, Some(0.00025));
+    assert_eq!(usage.is_byok, Some(false));
+    assert_eq!(cost_details.upstream_inference_prompt_cost, 0.0001);
+    assert_eq!(cost_details.upstream_inference_completions_cost, 0.00015);
+    assert_eq!(cost_details.upstream_inference_cost, None);
+}
+
 /// Test deserialization of multimodal assistant content parts
 #[test]
 fn test_response_with_multimodal_content_parts() {

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -159,3 +159,24 @@ fn test_generation_response_deserializes_num_fetches() {
         Some("gen_original")
     );
 }
+
+#[test]
+fn test_generation_response_accepts_stt_origin() {
+    let raw = r#"{
+        "data": {
+            "id": "gen_stt",
+            "total_cost": 0.02,
+            "created_at": "2026-04-29T00:00:00Z",
+            "model": "openai/whisper-1",
+            "origin": "stt",
+            "usage": 12.0,
+            "is_byok": false
+        }
+    }"#;
+
+    let parsed: ApiResponse<generation::GenerationData> =
+        serde_json::from_str(raw).expect("generation response should deserialize");
+
+    assert_eq!(parsed.data.id, "gen_stt");
+    assert_eq!(parsed.data.origin, "stt");
+}

--- a/tests/unit/stream.rs
+++ b/tests/unit/stream.rs
@@ -373,6 +373,9 @@ async fn test_tool_aware_stream_single_tool_call() {
                 prompt_tokens: 100,
                 completion_tokens: 20,
                 total_tokens: 120,
+                cost: None,
+                cost_details: None,
+                is_byok: None,
             }),
         )),
     ];

--- a/tests/unit/unified_stream.rs
+++ b/tests/unit/unified_stream.rs
@@ -104,6 +104,9 @@ async fn test_unified_chat_stream_mixed_sequence() {
                 prompt_tokens: 5,
                 completion_tokens: 7,
                 total_tokens: 12,
+                cost: None,
+                cost_details: None,
+                is_byok: None,
             }),
         )),
     ];


### PR DESCRIPTION
## Summary
- Add typed chat-completion usage cost metadata on `ResponseUsage`.
- Accept the 2026-04-29 OpenAPI baseline drift and document `stt` generation-origin handling.
- Document that PRs should not be closed automatically unless the user explicitly asks.

## Test Plan
- [x] `just quality`
- [x] `just openapi-drift-check`

Closes #204