### PR TITLE
feat: mark public API models non-exhaustive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - `tests/unit/` contains fast serde/config/domain tests.
 - `tests/integration/` contains live API tests plus shared helpers in `test_utils.rs`.
 - `examples/` contains runnable usage samples. Prefer the domain-oriented examples when updating docs.
+- `openspec/` contains OpenSpec-managed proposals, spec deltas, designs, and task lists for planned requirements.
 
 ## Build, Test, And Development Commands
 
@@ -54,6 +55,7 @@ Direct cargo entrypoints:
 - `OPENROUTER_API_KEY=... cargo test --test integration -- --nocapture`
 - `cargo run --example domain_chat_completion`
 - `cargo run -p openrouter-cli -- --help`
+- `openspec validate <change-name>`
 
 ## Coding Style And Naming Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added typed OpenRouter chat-completion usage cost fields via `ResponseUsage::cost`, `ResponseUsage::cost_details`, `ResponseUsage::is_byok`, and `ResponseCostDetails`.
+- Added ergonomic constructors for non-exhaustive helper types such as `ResponseUsage::new`, `ToolCall::new`, `FunctionCall::new`, `JsonSchemaConfig::new`, embedding multimodal parts, and provider-options wrappers.
 
 ### Changed
+- Breaking (0.10.0 target): Marked high-churn public SDK request, response, metadata, usage, pricing, discovery, streaming, and upstream taxonomy types as `#[non_exhaustive]`; construct affected request/configuration types through builders, constructors, or helpers, and include wildcard arms when matching affected public enums outside the crate.
 - Accepted the 2026-04-29 OpenAPI drift review, including `stt` generation origins and chat usage cost metadata, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
 
 ## [0.9.0] - 2026-04-28

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,10 +2,89 @@
 
 This document keeps historical migration guides intact because the repo still smoke-tests older domain/naming transitions.
 
-> Latest breaking release target: `0.8.x -> 0.9.0`.
-> `0.9.0` makes `/audio/speech` the canonical SDK naming surface and future-proofs high-churn request/response structs.
+> Latest breaking release target: `0.9.x -> 0.10.0`.
+> `0.10.0` makes high-churn public SDK model types non-exhaustive so additive upstream OpenRouter fields and taxonomy values do not keep causing accidental source breaks.
 
-## Latest: 0.8.x -> 0.9.0
+## Latest: 0.9.x -> 0.10.0
+
+This release intentionally future-proofs public SDK model types that mirror upstream request, response, metadata, usage, pricing, discovery, streaming, and taxonomy shapes. The runtime JSON behavior is unchanged, but Rust source that constructed affected public structs with literals or matched affected public enums exhaustively may need small edits.
+
+### Quick Checklist For 0.10.0
+
+- Replace direct struct literals for affected SDK model types with builders, constructors, helpers, or serde deserialization.
+- Add a wildcard arm (`_ => ...`) when matching affected public enums such as stream events, choices, provider taxonomies, finish reasons, and embedding vector variants outside the crate.
+- Prefer request builders for caller-built request types: `ChatCompletionRequest::builder()`, `ResponsesRequest::builder()`, `AnthropicMessagesRequest::builder()`, `EmbeddingRequest::builder()`, and similar endpoint builders.
+- Use new constructors where direct literals were mainly test/helper code, including `ResponseUsage::new(...)`, `ToolCall::new(...)`, `FunctionCall::new(...)`, `JsonSchemaConfig::new(...)`, `EmbeddingContentPart::text(...)`, `EmbeddingContentPart::image_url(...)`, and provider-options `new(...)` helpers.
+- Keep this migration with the `0.10.0` release boundary; it is broader than the 2026-04-29 `ResponseUsage` cost-field drift.
+
+### Breaking-Change Mapping For 0.10.0
+
+| Area | Old Usage (`0.9.x`) | New Usage (`0.10.0`) |
+| --- | --- | --- |
+| Response usage test data | `ResponseUsage { prompt_tokens, completion_tokens, total_tokens, ... }` | `ResponseUsage::new(prompt_tokens, completion_tokens, total_tokens)` |
+| Tool-call test data | `ToolCall { id, type_, function, index }` | `ToolCall::new(id, name, arguments).with_index(index)` |
+| Request construction | `EmbeddingRequest { model, input, ... }` | `EmbeddingRequest::builder().model(model).input(input).build()?` |
+| Provider preferences | `ProviderPreferences { sort, order, ... }` | `let mut prefs = ProviderPreferences::default(); prefs.sort = Some(...);` |
+| Public enum matching | `match event { StreamEvent::Done { .. } => ..., StreamEvent::Error(e) => ... }` | Add `_ => {}` or another fallback arm |
+| Response fixtures | Public response struct literals | Deserialize JSON fixtures with `serde_json::from_value(...)` or use documented constructors |
+
+### Example: response fixture construction
+
+Before:
+
+```rust
+use openrouter_rs::types::completion::ResponseUsage;
+
+let usage = ResponseUsage {
+    prompt_tokens: 5,
+    completion_tokens: 7,
+    total_tokens: 12,
+    cost: None,
+    cost_details: None,
+    is_byok: None,
+};
+```
+
+After:
+
+```rust
+use openrouter_rs::types::completion::ResponseUsage;
+
+let usage = ResponseUsage::new(5, 7, 12);
+```
+
+### Example: non-exhaustive enum matching
+
+Before:
+
+```rust
+use openrouter_rs::types::stream::StreamEvent;
+
+fn handle(event: StreamEvent) {
+    match event {
+        StreamEvent::ContentDelta(text) => print!("{text}"),
+        StreamEvent::Done { .. } => println!("done"),
+        StreamEvent::Error(error) => eprintln!("{error}"),
+    }
+}
+```
+
+After:
+
+```rust
+use openrouter_rs::types::stream::StreamEvent;
+
+fn handle(event: StreamEvent) {
+    match event {
+        StreamEvent::ContentDelta(text) => print!("{text}"),
+        StreamEvent::Done { .. } => println!("done"),
+        StreamEvent::Error(error) => eprintln!("{error}"),
+        _ => {}
+    }
+}
+```
+
+## Previous: 0.8.x -> 0.9.0
 
 If you use the new workspace, generation metadata, video generation, or audio speech surfaces, prefer request builders and the canonical domain clients. Compatibility aliases remain for the old `tts` names, but new code should use `audio`.
 
@@ -113,7 +192,7 @@ let request = UpdateWorkspaceRequest::builder()
 # }
 ```
 
-## Previous: 0.7.x -> 0.8.0
+## Earlier: 0.7.x -> 0.8.0
 
 If you already use the canonical domain clients (`chat()`, `responses()`, `messages()`, `models()`, `management()`, and opt-in `legacy()`), this upgrade is usually just a version bump plus a recompile. The breaking changes mainly affect callers that coupled themselves to the old transport-facing error and utility surface.
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,18 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 - Canonical docs and examples prefer the domain clients over older flat helpers
 - Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`51 / 51`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
-- Migration guidance for the `0.8.x -> 0.9.0` audio speech/future-proofing release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
+- Migration guidance for the planned `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
+
+### 🔁 0.10 Public Model Migration
+
+Full migration guide: [`MIGRATION.md`](MIGRATION.md)
+
+- High-churn public SDK request, response, metadata, usage, pricing, discovery, streaming, and upstream taxonomy types are `#[non_exhaustive]`
+- Replace affected struct literals with builders, constructors, helpers, or serde deserialization
+- Add wildcard arms when matching affected public enums outside the crate
+- Use constructors such as `ResponseUsage::new(...)`, `ToolCall::new(...)`, `FunctionCall::new(...)`, and `JsonSchemaConfig::new(...)` for small helper/test fixtures
+- This source-level break is held for `0.10.0`
 
 ### 🔁 0.9 Audio Speech Migration
 

--- a/examples/stream_chat_with_tools.rs
+++ b/examples/stream_chat_with_tools.rs
@@ -153,6 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             StreamEvent::Error(e) => {
                 eprintln!("\nStream error: {}", e);
             }
+            _ => {}
         }
     }
 

--- a/openspec/changes/mark-public-response-types-non-exhaustive/.openspec.yaml
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/mark-public-response-types-non-exhaustive/README.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/README.md
@@ -1,0 +1,3 @@
+# mark-public-response-types-non-exhaustive
+
+Plan a 0.10.0-compatible audit that marks high-churn public API request and response types as #[non_exhaustive] where callers should not rely on exhaustive struct or enum literals.

--- a/openspec/changes/mark-public-response-types-non-exhaustive/design.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`openrouter-rs` has grown from chat-only usage into a domain SDK that tracks upstream OpenRouter OpenAPI drift. Several newer high-churn types are already marked `#[non_exhaustive]`, including audio, video, workspace, API-key, and generation models, but older public models remain fully exhaustive.
+
+PR #205 showed the risk: adding typed optional fields to `ResponseUsage` is semantically additive for serde, but source-breaking for users who instantiate the public struct with literals. Since the project is already holding this for `0.10.0`, the next step should be a deliberate public API audit instead of piecemeal attributes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Identify public structs and enums under `src/api/` and `src/types/` that represent upstream API shapes likely to change.
+- Mark those high-churn types `#[non_exhaustive]` in a 0.10.0 change.
+- Keep caller construction ergonomic for request/configuration types through builders, constructors, or helpers.
+- Update tests, examples, and migration docs so the source break is explicit and reviewable.
+
+**Non-Goals:**
+
+- Do not change endpoint behavior, JSON field names, request semantics, or runtime compatibility.
+- Do not rewrite all models into private fields or generated code as part of this change.
+- Do not mark private wire structs or intentionally stable helper types unless they are part of the public API risk.
+- Do not release this as a 0.9.x patch.
+
+## Decisions
+
+1. Audit by public API category, not by file age.
+
+   Classify each `pub struct` and `pub enum` in `src/api/` and `src/types/` as request/configuration, response/data, stream event, upstream taxonomy, builder/helper, or internal wire type. This avoids missing older types such as chat completion, embeddings, discovery, models, messages, tools, provider preferences, and stream events.
+
+2. Prefer non-exhaustive for upstream schema mirrors.
+
+   Public models that mirror OpenRouter/OpenAI/Anthropic request or response JSON should default to `#[non_exhaustive]` unless the audit records a specific reason to keep them exhaustive. These shapes are where additive upstream fields and variants are most likely.
+
+3. Preserve construction paths before adding attributes.
+
+   For caller-built request and configuration types, add or verify builders before marking them non-exhaustive. Response-only types can rely on serde deserialization and do not need public constructors unless tests or examples currently create them manually.
+
+4. Treat enum exhaustiveness as an API promise.
+
+   Upstream taxonomy enums should be marked non-exhaustive when new wire values are plausible. Stable SDK-owned enums can remain exhaustive if exhaustive matching is intended and the type does not mirror upstream drift.
+
+5. Make migration docs part of the implementation, not a follow-up.
+
+   Because this is intentionally source-breaking, `MIGRATION.md`, `CHANGELOG.md`, and examples must be updated in the same change. The docs should call out direct struct literals and exhaustive matches as the two main migration cases.
+
+## Risks / Trade-offs
+
+- Source break is broader than the immediate `ResponseUsage` issue -> Mitigate by targeting 0.10.0 and documenting migration paths clearly.
+- Over-applying `#[non_exhaustive]` can make tests and examples noisier -> Mitigate by using builders/helpers where construction is legitimate and keeping intentionally stable helper types exhaustive.
+- Under-applying it leaves future OpenAPI drift source-breaking -> Mitigate with an inventory checklist and review every public type in `src/api/` and `src/types/`.
+- Enum non-exhaustiveness can frustrate callers who prefer exhaustive matches -> Mitigate by limiting it to upstream taxonomies where new wire values are plausible and documenting wildcard matching.
+
+## Migration Plan
+
+1. Implement on a 0.10.0 branch after the public type inventory is reviewed.
+2. Update local tests and examples to use builders/helpers or add wildcard match arms where needed.
+3. Run `just quality`, `just check-migration-docs`, and `cargo test --test migration_smoke --all-features`.
+4. Include the migration note in the 0.10.0 release notes.
+5. If the change proves too broad during implementation, split into response/data types first and request/configuration types second, but keep both under the 0.10.0 release boundary.
+
+## Open Questions
+
+- Should `Tool`, `FunctionDefinition`, and related SDK-owned typed-tool helpers remain exhaustive for caller ergonomics, or should they follow the same future-proofing rule as upstream schema mirrors?
+- Should streaming event enums be marked non-exhaustive even when they are SDK-normalized abstractions rather than raw upstream taxonomies?
+- Should this change also add a lightweight public type inventory document under `docs/design/` or keep the inventory in the PR description?

--- a/openspec/changes/mark-public-response-types-non-exhaustive/design.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/design.md
@@ -57,8 +57,12 @@ PR #205 showed the risk: adding typed optional fields to `ResponseUsage` is sema
 4. Include the migration note in the 0.10.0 release notes.
 5. If the change proves too broad during implementation, split into response/data types first and request/configuration types second, but keep both under the 0.10.0 release boundary.
 
+## Implementation Audit Outcome
+
+- `Tool`, `FunctionDefinition`, and related tool-choice structs follow the upstream-schema rule because their serialized shape mirrors chat-completions tool payloads and can gain fields over time. Construction remains ergonomic through `Tool::function(...)`, `ToolBuilder`, `ToolChoice` helpers, and `create_tool(...)`.
+- SDK-normalized streaming event enums are marked `#[non_exhaustive]` because adding normalized event categories should not source-break callers that match stream events.
+- The public type inventory is recorded in `inventory.md` for review, while stable SDK-owned helpers with private fields remain exhaustive there with explicit rationale.
+
 ## Open Questions
 
-- Should `Tool`, `FunctionDefinition`, and related SDK-owned typed-tool helpers remain exhaustive for caller ergonomics, or should they follow the same future-proofing rule as upstream schema mirrors?
-- Should streaming event enums be marked non-exhaustive even when they are SDK-normalized abstractions rather than raw upstream taxonomies?
-- Should this change also add a lightweight public type inventory document under `docs/design/` or keep the inventory in the PR description?
+- None after implementation audit.

--- a/openspec/changes/mark-public-response-types-non-exhaustive/inventory.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/inventory.md
@@ -1,0 +1,50 @@
+## Public Type Inventory
+
+Audit command:
+
+```bash
+rg '^pub (struct|enum) ' src/api src/types -n
+```
+
+## Marked Non-Exhaustive
+
+These public types mirror upstream OpenRouter/OpenAI/Anthropic request, response, metadata, usage, pricing, discovery, streaming, or taxonomy shapes. They are intentionally `#[non_exhaustive]`.
+
+| Module | Types |
+| --- | --- |
+| `src/api/audio.rs` | `SpeechResponseFormat`, `SpeechProviderOptions`, `SpeechRequest` |
+| `src/api/auth.rs` | `AuthRequest`, `CodeChallengeMethod`, `AuthResponse`, `UsageLimitType`, `CreateAuthCodeRequest`, `AuthCodeData` |
+| `src/api/api_keys.rs` | `ApiKey`, `ApiKeyDetails`, `RateLimit` |
+| `src/api/chat.rs` | `ImageUrl`, `InputAudio`, `VideoUrl`, `FileInput`, `CacheControlType`, `CacheControl`, `ContentPart`, `Content`, `Message`, `Modality`, `DebugOptions`, `StreamOptions`, `TraceOptions`, `Plugin`, `StopSequence`, `ChatCompletionRequest` |
+| `src/api/credits.rs` | `CoinbaseChargeRequest`, `CoinbaseChargeData`, `CreditsData` |
+| `src/api/discovery.rs` | `BigNumber`, `Provider`, `PublicPricing`, `ModelArchitecture`, `TopProviderInfo`, `PerRequestLimits`, `UserModel`, `ModelsCountData`, `PercentileStats`, `PublicEndpoint`, `ActivityItem` |
+| `src/api/embeddings.rs` | `EmbeddingEncodingFormat`, `EmbeddingImageUrl`, `EmbeddingContentPart`, `EmbeddingMultimodalInput`, `EmbeddingInput`, `EmbeddingRequest`, `EmbeddingVector`, `EmbeddingData`, `EmbeddingPromptTokensDetails`, `EmbeddingUsage`, `EmbeddingResponse` |
+| `src/api/generation.rs` | `GenerationData`, `GenerationContentData` |
+| `src/api/guardrails.rs` | `Guardrail`, `GuardrailListResponse`, `CreateGuardrailRequest`, `UpdateGuardrailRequest`, `GuardrailKeyAssignment`, `GuardrailMemberAssignment`, `GuardrailKeyAssignmentsResponse`, `GuardrailMemberAssignmentsResponse`, `BulkKeyAssignmentRequest`, `BulkMemberAssignmentRequest`, `AssignedCountResponse`, `UnassignedCountResponse` |
+| `src/api/legacy/completion.rs` | `CompletionRequest` |
+| `src/api/messages.rs` | `AnthropicRole`, `AnthropicSystemTextBlock`, `AnthropicSystemTextBlockType`, `AnthropicSystemPrompt`, `AnthropicMessageContent`, `AnthropicContentPart`, `AnthropicMessage`, `AnthropicMessagesMetadata`, `AnthropicTool`, `AnthropicToolChoice`, `AnthropicThinking`, `AnthropicOutputEffort`, `AnthropicOutputConfig`, `AnthropicMessagesRequest`, `AnthropicMessagesUsage`, `AnthropicMessagesResponse`, `AnthropicMessagesStreamEvent`, `AnthropicMessagesSseEvent` |
+| `src/api/models.rs` | `Model`, `Architecture`, `TopProvider`, `Pricing`, `Endpoint`, `EndpointPricing`, `EndpointData`, `EndpointArchitecture` |
+| `src/api/organization.rs` | `OrganizationMember`, `OrganizationMembersResponse` |
+| `src/api/rerank.rs` | `RerankRequest`, `RerankDocument`, `RerankResult`, `RerankUsage`, `RerankResponse` |
+| `src/api/responses.rs` | `ResponsesRequest`, `ResponsesResponse`, `ResponsesStreamEvent` |
+| `src/api/videos.rs` | `VideoImageUrl`, `VideoInputReference`, `VideoFrameImage`, `VideoProviderOptions`, `VideoGenerationRequest`, `VideoGenerationUsage`, `VideoGenerationResponse`, `VideoModel` |
+| `src/api/workspaces.rs` | `Workspace`, `WorkspaceListResponse`, `CreateWorkspaceRequest`, `UpdateWorkspaceRequest`, `WorkspaceMember`, `WorkspaceMembersRequest`, `WorkspaceMembersAddResponse`, `WorkspaceMembersRemoveResponse` |
+| `src/types/completion.rs` | `ReasoningDetail`, `ResponseCostDetails`, `ResponseUsage`, `FunctionCall`, `ToolCall`, `PartialFunctionCall`, `PartialToolCall`, `ErrorResponse`, `Choice`, `FinishReason`, `NonChatChoice`, `NonStreamingChoice`, `StreamingChoice`, `Message`, `Delta`, `ObjectType`, `CompletionsResponse` |
+| `src/types/mod.rs` | `ApiResponse<T>`, `Role`, `Effort`, `ReasoningConfig`, `ModelCategory`, `SupportedParameters` |
+| `src/types/pagination.rs` | `PaginationOptions` |
+| `src/types/provider.rs` | `ProviderSortBy`, `DataCollectionPolicy`, `Quantization`, `PerformancePreference`, `PercentileCutoffs`, `PriceLimit`, `MaxPrice`, `ProviderPreferences` |
+| `src/types/response_format.rs` | `ResponseFormatType`, `JsonSchemaConfig`, `ResponseFormat` |
+| `src/types/stream.rs` | `StreamEvent`, `UnifiedStreamSource`, `UnifiedStreamEvent` |
+| `src/types/tool.rs` | `Tool`, `FunctionDefinition`, `ToolChoice`, `SpecificToolChoice`, `SpecificToolFunction` |
+
+## Kept Exhaustive
+
+These public types are deliberately outside the upstream-schema rule.
+
+| Module | Types | Reason |
+| --- | --- | --- |
+| `src/api/workspaces.rs` | `UpdateWorkspaceRequestWithClearedIoLoggingApiKeyIds<'a>` | Serialization wrapper with private fields, created only by `UpdateWorkspaceRequest::with_cleared_io_logging_api_key_ids()`. External callers cannot construct it with a public literal. |
+| `src/types/tool.rs` | `ToolBuilder` | SDK-owned builder helper with private fields; callers use builder methods and `build()`. |
+| `src/types/stream.rs` | `ToolAwareStream` | SDK-owned stream wrapper with private fields; callers receive it from stream APIs. |
+
+Public client and error types live outside the audited `src/api` and `src/types` OpenAPI model surface and remain governed by their existing SDK-owned API contracts.

--- a/openspec/changes/mark-public-response-types-non-exhaustive/proposal.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The 2026-04-29 OpenAPI drift added optional chat usage fields, and exposing them on `ResponseUsage` was source-breaking because external callers can construct that public struct exhaustively. The SDK needs a planned 0.10.0 pass that makes high-churn public API model types future-proof before more upstream response and request metadata lands.
+
+## What Changes
+
+- **BREAKING**: Mark selected high-churn public SDK request, response, metadata, usage, pricing, discovery, streaming, and upstream taxonomy types with `#[non_exhaustive]`.
+- Preserve ergonomic construction for caller-built request/configuration types by requiring builders or explicit constructors before marking those types non-exhaustive.
+- Audit public structs and enums under `src/api/` and `src/types/` so the decision is systematic rather than limited to the latest drift.
+- Update migration notes, release notes, docs, and examples to steer callers away from direct struct literals and exhaustive enum matches where the API can evolve.
+- Keep deliberately stable internal/private wire types and low-churn helper types exhaustive when exhaustive construction or matching is part of the intended API.
+
+## Capabilities
+
+### New Capabilities
+
+- `sdk-public-type-future-proofing`: Rules for deciding when public SDK model types are non-exhaustive, how callers construct them, and how breaking migration guidance is documented.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: public structs and enums in `src/api/` and `src/types/`, plus examples and tests that use struct literals or exhaustive matches.
+- Affected docs: `CHANGELOG.md`, `MIGRATION.md`, `README.md`, relevant examples, and possibly docs.rs comments.
+- API impact: source-breaking in Rust for external callers that instantiate affected structs with literals or match affected enums without a wildcard arm. Runtime JSON compatibility should remain backward-compatible through serde defaults and optional fields.
+- Release impact: target this work for `0.10.0`, not a `0.9.x` patch release.

--- a/openspec/changes/mark-public-response-types-non-exhaustive/specs/sdk-public-type-future-proofing/spec.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/specs/sdk-public-type-future-proofing/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: High-churn public model types are non-exhaustive
+The SDK SHALL mark public API model structs and enums as `#[non_exhaustive]` when they represent upstream OpenRouter request, response, metadata, usage, pricing, discovery, streaming, or taxonomy shapes that can gain fields or variants over time.
+
+#### Scenario: Upstream adds optional response metadata
+- **WHEN** OpenRouter adds an optional response metadata field to a non-exhaustive public response model
+- **THEN** the SDK can add the typed field in a future minor or patch release without requiring external callers to update exhaustive struct literals
+
+#### Scenario: Upstream adds taxonomy variant
+- **WHEN** OpenRouter adds a new value to an SDK enum that models an upstream taxonomy
+- **THEN** external callers must already use a wildcard arm when matching the enum outside the crate
+
+### Requirement: Caller-built types keep ergonomic construction
+Every public request or configuration type marked `#[non_exhaustive]` that callers are expected to construct SHALL expose a builder, constructor, or documented helper that supports all required fields and optional fields.
+
+#### Scenario: Request type becomes non-exhaustive
+- **WHEN** a public request type is marked `#[non_exhaustive]`
+- **THEN** examples and docs construct it through `builder()`, a constructor, or a helper rather than a public struct literal
+
+#### Scenario: Required field remains available
+- **WHEN** a caller uses the supported builder or constructor for a non-exhaustive request type
+- **THEN** the caller can still set every required request field and every documented optional request field
+
+### Requirement: Stable exhaustive APIs remain intentional
+The SDK SHALL leave a public struct or enum exhaustive only when the audit records that exhaustive construction or matching is a deliberate stable API contract rather than an accidental exposure of an upstream schema.
+
+#### Scenario: Type is intentionally exhaustive
+- **WHEN** the audit keeps a public type exhaustive
+- **THEN** the implementation notes or review checklist identify why future upstream drift is not expected to require additional public fields or variants
+
+### Requirement: Migration guidance documents source breaks
+The SDK SHALL document the 0.10.0 source-level migration for affected direct struct literals and exhaustive enum matches.
+
+#### Scenario: Caller used direct struct literals
+- **WHEN** a caller reads the 0.10.0 migration guidance
+- **THEN** the guidance shows that direct literals for affected non-exhaustive types must be replaced with builders, constructors, helper methods, or deserialization paths
+
+#### Scenario: Caller used exhaustive enum matching
+- **WHEN** a caller reads the 0.10.0 migration guidance
+- **THEN** the guidance explains that affected enum matches need a wildcard arm outside the crate

--- a/openspec/changes/mark-public-response-types-non-exhaustive/tasks.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/tasks.md
@@ -1,36 +1,37 @@
 ## 1. Inventory
 
-- [ ] 1.1 Enumerate all `pub struct` and `pub enum` definitions under `src/api/` and `src/types/`.
-- [ ] 1.2 Classify each public type as request/configuration, response/data, stream event, upstream taxonomy, SDK helper, or internal wire type.
-- [ ] 1.3 Record which public types are already `#[non_exhaustive]` and which high-churn types remain exhaustive.
-- [ ] 1.4 Decide and document any public types that should intentionally remain exhaustive.
+- [x] 1.1 Enumerate all `pub struct` and `pub enum` definitions under `src/api/` and `src/types/`.
+- [x] 1.2 Classify each public type as request/configuration, response/data, stream event, upstream taxonomy, SDK helper, or internal wire type.
+- [x] 1.3 Record which public types are already `#[non_exhaustive]` and which high-churn types remain exhaustive.
+- [x] 1.4 Decide and document any public types that should intentionally remain exhaustive.
 
 ## 2. Construction Paths
 
-- [ ] 2.1 Verify every caller-built request/configuration type selected for `#[non_exhaustive]` has a builder, constructor, or helper.
-- [ ] 2.2 Add builders or constructors where construction is expected but no ergonomic path exists.
-- [ ] 2.3 Update examples and unit tests that currently rely on direct literals for selected caller-built types.
+- [x] 2.1 Verify every caller-built request/configuration type selected for `#[non_exhaustive]` has a builder, constructor, or helper.
+- [x] 2.2 Add builders or constructors where construction is expected but no ergonomic path exists.
+- [x] 2.3 Update examples and unit tests that currently rely on direct literals for selected caller-built types.
 
 ## 3. Non-Exhaustive Implementation
 
-- [ ] 3.1 Add `#[non_exhaustive]` to selected response/data/usage/pricing/discovery model structs.
-- [ ] 3.2 Add `#[non_exhaustive]` to selected request/configuration structs after construction paths are verified.
-- [ ] 3.3 Add `#[non_exhaustive]` to selected upstream taxonomy enums and update internal matches if needed.
-- [ ] 3.4 Keep private wire structs and deliberately stable public helpers exhaustive unless the inventory says otherwise.
+- [x] 3.1 Add `#[non_exhaustive]` to selected response/data/usage/pricing/discovery model structs.
+- [x] 3.2 Add `#[non_exhaustive]` to selected request/configuration structs after construction paths are verified.
+- [x] 3.3 Add `#[non_exhaustive]` to selected upstream taxonomy enums and update internal matches if needed.
+- [x] 3.4 Keep private wire structs and deliberately stable public helpers exhaustive unless the inventory says otherwise.
 
 ## 4. Documentation
 
-- [ ] 4.1 Update `MIGRATION.md` with the 0.10.0 source-level migration guidance for direct struct literals and exhaustive enum matches.
-- [ ] 4.2 Update `CHANGELOG.md` with the breaking API-surface change.
-- [ ] 4.3 Update `README.md` and examples if they show construction patterns affected by the change.
-- [ ] 4.4 Note that this work belongs to `0.10.0`, not a `0.9.x` patch release.
+- [x] 4.1 Update `MIGRATION.md` with the 0.10.0 source-level migration guidance for direct struct literals and exhaustive enum matches.
+- [x] 4.2 Update `CHANGELOG.md` with the breaking API-surface change.
+- [x] 4.3 Update `README.md` and examples if they show construction patterns affected by the change.
+- [x] 4.4 Note that this work belongs to `0.10.0`, not a `0.9.x` patch release.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `cargo fmt --all --check`.
-- [ ] 5.2 Run `cargo check --all-targets`.
-- [ ] 5.3 Run `cargo clippy --all-targets --all-features -- -D warnings`.
-- [ ] 5.4 Run `cargo test --test unit`.
-- [ ] 5.5 Run `cargo test --lib` and `cargo test --doc`.
-- [ ] 5.6 Run `just check-migration-docs`.
-- [ ] 5.7 Run `cargo test --test migration_smoke --all-features`.
+- [x] 5.1 Run `cargo fmt --all --check`.
+- [x] 5.2 Run `cargo check --all-targets`.
+- [x] 5.3 Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] 5.4 Run `cargo test --test unit`.
+- [x] 5.5 Run `cargo test --lib` and `cargo test --doc`.
+- [x] 5.6 Run `just check-migration-docs`.
+- [x] 5.7 Run `cargo test --test migration_smoke --all-features`.
+- [x] 5.8 Run `just quality-ci`.

--- a/openspec/changes/mark-public-response-types-non-exhaustive/tasks.md
+++ b/openspec/changes/mark-public-response-types-non-exhaustive/tasks.md
@@ -1,0 +1,36 @@
+## 1. Inventory
+
+- [ ] 1.1 Enumerate all `pub struct` and `pub enum` definitions under `src/api/` and `src/types/`.
+- [ ] 1.2 Classify each public type as request/configuration, response/data, stream event, upstream taxonomy, SDK helper, or internal wire type.
+- [ ] 1.3 Record which public types are already `#[non_exhaustive]` and which high-churn types remain exhaustive.
+- [ ] 1.4 Decide and document any public types that should intentionally remain exhaustive.
+
+## 2. Construction Paths
+
+- [ ] 2.1 Verify every caller-built request/configuration type selected for `#[non_exhaustive]` has a builder, constructor, or helper.
+- [ ] 2.2 Add builders or constructors where construction is expected but no ergonomic path exists.
+- [ ] 2.3 Update examples and unit tests that currently rely on direct literals for selected caller-built types.
+
+## 3. Non-Exhaustive Implementation
+
+- [ ] 3.1 Add `#[non_exhaustive]` to selected response/data/usage/pricing/discovery model structs.
+- [ ] 3.2 Add `#[non_exhaustive]` to selected request/configuration structs after construction paths are verified.
+- [ ] 3.3 Add `#[non_exhaustive]` to selected upstream taxonomy enums and update internal matches if needed.
+- [ ] 3.4 Keep private wire structs and deliberately stable public helpers exhaustive unless the inventory says otherwise.
+
+## 4. Documentation
+
+- [ ] 4.1 Update `MIGRATION.md` with the 0.10.0 source-level migration guidance for direct struct literals and exhaustive enum matches.
+- [ ] 4.2 Update `CHANGELOG.md` with the breaking API-surface change.
+- [ ] 4.3 Update `README.md` and examples if they show construction patterns affected by the change.
+- [ ] 4.4 Note that this work belongs to `0.10.0`, not a `0.9.x` patch release.
+
+## 5. Verification
+
+- [ ] 5.1 Run `cargo fmt --all --check`.
+- [ ] 5.2 Run `cargo check --all-targets`.
+- [ ] 5.3 Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [ ] 5.4 Run `cargo test --test unit`.
+- [ ] 5.5 Run `cargo test --lib` and `cargo test --doc`.
+- [ ] 5.6 Run `just check-migration-docs`.
+- [ ] 5.7 Run `cargo test --test migration_smoke --all-features`.

--- a/scripts/check_migration_docs.sh
+++ b/scripts/check_migration_docs.sh
@@ -27,7 +27,11 @@ if [[ ! -f "$README_PATH" ]]; then
   exit 1
 fi
 
-# README must keep the current migration-entry section and core rename mappings.
+# README must keep the current migration-entry section plus recent breaking mappings.
+require_pattern "### 🔁 0.10 Public Model Migration" "$README_PATH"
+require_pattern "ResponseUsage::new(...)" "$README_PATH"
+require_pattern "ToolCall::new(...)" "$README_PATH"
+require_pattern "Add wildcard arms when matching affected public enums" "$README_PATH"
 require_pattern "### 🔁 0.9 Audio Speech Migration" "$README_PATH"
 require_pattern "client.tts().create(...)" "$README_PATH"
 require_pattern "client.audio().speech().create(...)" "$README_PATH"
@@ -47,9 +51,13 @@ require_pattern "management().create_api_key_from_auth_code(...)" "$README_PATH"
 # If MIGRATION.md exists (OR-25 and later), validate current and historical key structure.
 if [[ -f "$MIGRATION_PATH" ]]; then
   require_pattern "# Migration Guide" "$MIGRATION_PATH"
-  require_pattern "## Latest: 0.8.x -> 0.9.0" "$MIGRATION_PATH"
-  require_pattern "## Previous: 0.7.x -> 0.8.0" "$MIGRATION_PATH"
+  require_pattern "## Latest: 0.9.x -> 0.10.0" "$MIGRATION_PATH"
+  require_pattern "## Previous: 0.8.x -> 0.9.0" "$MIGRATION_PATH"
+  require_pattern "## Earlier: 0.7.x -> 0.8.0" "$MIGRATION_PATH"
   require_pattern "## Historical: 0.5.x -> 0.6.0" "$MIGRATION_PATH"
+  require_pattern "ResponseUsage::new(prompt_tokens, completion_tokens, total_tokens)" "$MIGRATION_PATH"
+  require_pattern "ToolCall::new(id, name, arguments).with_index(index)" "$MIGRATION_PATH"
+  require_pattern "Add a wildcard arm" "$MIGRATION_PATH"
   require_pattern "client.audio().speech().create" "$MIGRATION_PATH"
   require_pattern "api::audio::{SpeechRequest, SpeechResponseFormat}" "$MIGRATION_PATH"
   require_pattern "UpdateWorkspaceRequest::builder()" "$MIGRATION_PATH"

--- a/src/api/audio.rs
+++ b/src/api/audio.rs
@@ -23,9 +23,18 @@ pub enum SpeechResponseFormat {
 
 /// Provider-specific passthrough options for speech requests.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct SpeechProviderOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl SpeechProviderOptions {
+    pub fn new(options: HashMap<String, serde_json::Value>) -> Self {
+        Self {
+            options: Some(options),
+        }
+    }
 }
 
 /// Request payload for `POST /audio/speech`.

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct AuthRequest {
     code: String,
     code_verifier: Option<String>,
@@ -16,6 +17,7 @@ pub struct AuthRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum CodeChallengeMethod {
     #[serde(rename = "S256")]
@@ -24,12 +26,14 @@ pub enum CodeChallengeMethod {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct AuthResponse {
     pub key: String,
     pub user_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum UsageLimitType {
     Daily,
@@ -40,6 +44,7 @@ pub enum UsageLimitType {
 /// Request payload for `POST /auth/keys/code`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct CreateAuthCodeRequest {
     #[builder(setter(into))]
     callback_url: String,
@@ -77,6 +82,7 @@ impl CreateAuthCodeRequest {
 
 /// Response payload for `POST /auth/keys/code`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct AuthCodeData {
     pub id: String,
     pub app_id: f64,

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -20,6 +20,7 @@ use crate::{
 
 /// Image URL with optional detail level for vision models.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ImageUrl {
     /// URL of the image (can be a web URL or base64 data URI)
     pub url: String,
@@ -46,6 +47,7 @@ impl ImageUrl {
 
 /// Audio input payload for multimodal requests.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct InputAudio {
     /// Base64-encoded audio data.
     pub data: String,
@@ -64,6 +66,7 @@ impl InputAudio {
 
 /// Video URL payload for multimodal requests.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoUrl {
     /// URL of the input video.
     pub url: String,
@@ -77,6 +80,7 @@ impl VideoUrl {
 
 /// File payload for multimodal requests.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct FileInput {
     /// File content as URL or data URL.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -114,6 +118,7 @@ impl FileInput {
 
 /// Cache control type for prompt caching breakpoints.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum CacheControlType {
     Ephemeral,
@@ -121,6 +126,7 @@ pub enum CacheControlType {
 
 /// Cache control settings for text content parts.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct CacheControl {
     #[serde(rename = "type")]
     pub kind: CacheControlType,
@@ -148,6 +154,7 @@ impl CacheControl {
 
 /// A content part in a multi-modal message.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentPart {
     /// Text content
@@ -251,6 +258,7 @@ impl ContentPart {
 
 /// Message content - either a simple string or multi-part content.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum Content {
     /// Simple text content
@@ -278,6 +286,7 @@ impl From<Vec<ContentPart>> for Content {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Message {
     pub role: Role,
     pub content: Content,
@@ -368,6 +377,7 @@ impl Message {
 
 /// Output modality for chat responses.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum Modality {
     Text,
@@ -377,6 +387,7 @@ pub enum Modality {
 
 /// Streaming debug options.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct DebugOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub echo_upstream_body: Option<bool>,
@@ -384,6 +395,7 @@ pub struct DebugOptions {
 
 /// Streaming configuration options.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct StreamOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_usage: Option<bool>,
@@ -391,6 +403,7 @@ pub struct StreamOptions {
 
 /// Trace metadata used for observability.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct TraceOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
@@ -408,6 +421,7 @@ pub struct TraceOptions {
 
 /// Plugin configuration payload.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct Plugin {
     pub id: String,
     #[serde(flatten)]
@@ -430,6 +444,7 @@ impl Plugin {
 
 /// Stop sequence configuration.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum StopSequence {
     Single(String),
@@ -456,6 +471,7 @@ impl From<Vec<String>> for StopSequence {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct ChatCompletionRequest {
     #[builder(setter(into))]
     model: String,

--- a/src/api/credits.rs
+++ b/src/api/credits.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[derive(Serialize, Deserialize, Debug, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct CoinbaseChargeRequest {
     amount: f64,
     #[builder(setter(into))]
@@ -35,6 +36,7 @@ impl CoinbaseChargeRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct CoinbaseChargeData {
     pub addresses: HashMap<String, String>,
     pub calldata: HashMap<String, String>,
@@ -44,6 +46,7 @@ pub struct CoinbaseChargeData {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct CreditsData {
     pub total_credits: f64,
     pub total_usage: f64,

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -12,6 +12,7 @@ use crate::{
 
 /// Number-like value used by OpenRouter pricing fields.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum BigNumber {
     String(String),
@@ -20,6 +21,7 @@ pub enum BigNumber {
 
 /// Public provider metadata returned by `GET /providers`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Provider {
     pub name: String,
     pub slug: String,
@@ -34,6 +36,7 @@ pub struct Provider {
 
 /// Model pricing payload returned by model discovery endpoints.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct PublicPricing {
     pub prompt: BigNumber,
     pub completion: BigNumber,
@@ -65,6 +68,7 @@ pub struct PublicPricing {
 
 /// Model architecture data in model discovery responses.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ModelArchitecture {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tokenizer: Option<String>,
@@ -80,6 +84,7 @@ pub struct ModelArchitecture {
 
 /// Top provider metadata in model discovery responses.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct TopProviderInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_length: Option<f64>,
@@ -90,6 +95,7 @@ pub struct TopProviderInfo {
 
 /// Per-request token limits for a model.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct PerRequestLimits {
     pub prompt_tokens: f64,
     pub completion_tokens: f64,
@@ -97,6 +103,7 @@ pub struct PerRequestLimits {
 
 /// Model payload returned by `GET /models/user`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct UserModel {
     pub id: String,
     pub canonical_slug: String,
@@ -125,12 +132,14 @@ pub struct UserModel {
 
 /// Count payload returned by `GET /models/count`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ModelsCountData {
     pub count: u64,
 }
 
 /// Percentile statistics payload used by endpoint throughput/latency.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct PercentileStats {
     pub p50: f64,
     pub p75: f64,
@@ -140,6 +149,7 @@ pub struct PercentileStats {
 
 /// Public endpoint payload returned by `GET /endpoints/zdr`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct PublicEndpoint {
     pub name: String,
     pub model_id: String,
@@ -171,6 +181,7 @@ pub struct PublicEndpoint {
 
 /// Activity item payload returned by `GET /activity`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ActivityItem {
     pub date: String,
     pub model: String,

--- a/src/api/embeddings.rs
+++ b/src/api/embeddings.rs
@@ -11,6 +11,7 @@ use crate::{
 
 /// Supported embedding encoding formats.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum EmbeddingEncodingFormat {
     Float,
@@ -19,26 +20,54 @@ pub enum EmbeddingEncodingFormat {
 
 /// Image URL content for multimodal embedding input.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct EmbeddingImageUrl {
     pub url: String,
 }
 
+impl EmbeddingImageUrl {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
 /// One multimodal content part for embedding input.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EmbeddingContentPart {
     Text { text: String },
     ImageUrl { image_url: EmbeddingImageUrl },
 }
 
+impl EmbeddingContentPart {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text { text: text.into() }
+    }
+
+    pub fn image_url(url: impl Into<String>) -> Self {
+        Self::ImageUrl {
+            image_url: EmbeddingImageUrl::new(url),
+        }
+    }
+}
+
 /// One multimodal embedding input item.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct EmbeddingMultimodalInput {
     pub content: Vec<EmbeddingContentPart>,
 }
 
+impl EmbeddingMultimodalInput {
+    pub fn new(content: Vec<EmbeddingContentPart>) -> Self {
+        Self { content }
+    }
+}
+
 /// Embedding request input variants.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum EmbeddingInput {
     Text(String),
@@ -87,6 +116,7 @@ impl From<Vec<EmbeddingMultimodalInput>> for EmbeddingInput {
 /// Request body for `POST /embeddings`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct EmbeddingRequest {
     #[builder(setter(into))]
     pub input: EmbeddingInput,
@@ -131,6 +161,7 @@ impl EmbeddingRequest {
 
 /// One embedding vector payload.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum EmbeddingVector {
     Float(Vec<f64>),
@@ -139,6 +170,7 @@ pub enum EmbeddingVector {
 
 /// One embedding item.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct EmbeddingData {
     pub object: String,
     pub embedding: EmbeddingVector,
@@ -148,6 +180,7 @@ pub struct EmbeddingData {
 
 /// Token breakdown details for embedding requests.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct EmbeddingPromptTokensDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_tokens: Option<u32>,
@@ -161,6 +194,7 @@ pub struct EmbeddingPromptTokensDetails {
 
 /// Token/cost usage for embedding request.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct EmbeddingUsage {
     pub prompt_tokens: u32,
     pub total_tokens: u32,
@@ -172,6 +206,7 @@ pub struct EmbeddingUsage {
 
 /// Response body for `POST /embeddings`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct EmbeddingResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -12,6 +12,7 @@ use crate::{
 
 /// Guardrail model.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Guardrail {
     pub id: String,
     pub name: String,
@@ -36,6 +37,7 @@ pub struct Guardrail {
 
 /// Paginated guardrails list response.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct GuardrailListResponse {
     pub data: Vec<Guardrail>,
     pub total_count: f64,
@@ -44,6 +46,7 @@ pub struct GuardrailListResponse {
 /// Request payload for creating a guardrail (`POST /guardrails`).
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct CreateGuardrailRequest {
     #[builder(setter(into))]
     name: String,
@@ -84,6 +87,7 @@ impl CreateGuardrailRequest {
 /// Request payload for updating a guardrail (`PATCH /guardrails/{id}`).
 #[derive(Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct UpdateGuardrailRequest {
     #[builder(setter(into, strip_option), default)]
     name: Option<String>,
@@ -189,6 +193,7 @@ struct DeleteGuardrailResponse {
 
 /// Key assignment model.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct GuardrailKeyAssignment {
     pub id: String,
     pub key_hash: String,
@@ -201,6 +206,7 @@ pub struct GuardrailKeyAssignment {
 
 /// Member assignment model.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct GuardrailMemberAssignment {
     pub id: String,
     pub user_id: String,
@@ -212,6 +218,7 @@ pub struct GuardrailMemberAssignment {
 
 /// Paginated key assignment list response.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct GuardrailKeyAssignmentsResponse {
     pub data: Vec<GuardrailKeyAssignment>,
     pub total_count: f64,
@@ -219,6 +226,7 @@ pub struct GuardrailKeyAssignmentsResponse {
 
 /// Paginated member assignment list response.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct GuardrailMemberAssignmentsResponse {
     pub data: Vec<GuardrailMemberAssignment>,
     pub total_count: f64,
@@ -227,6 +235,7 @@ pub struct GuardrailMemberAssignmentsResponse {
 /// Request payload for key bulk assignment endpoints.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct BulkKeyAssignmentRequest {
     key_hashes: Vec<String>,
 }
@@ -240,6 +249,7 @@ impl BulkKeyAssignmentRequest {
 /// Request payload for member bulk assignment endpoints.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct BulkMemberAssignmentRequest {
     member_user_ids: Vec<String>,
 }
@@ -252,12 +262,14 @@ impl BulkMemberAssignmentRequest {
 
 /// Response payload for assignment endpoints.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct AssignedCountResponse {
     pub assigned_count: f64,
 }
 
 /// Response payload for unassignment endpoints.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct UnassignedCountResponse {
     pub unassigned_count: f64,
 }

--- a/src/api/legacy/completion.rs
+++ b/src/api/legacy/completion.rs
@@ -15,6 +15,7 @@ use crate::{
 
 #[derive(Serialize, Deserialize, Debug, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct CompletionRequest {
     #[builder(setter(into))]
     model: String,

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -19,6 +19,7 @@ use crate::{
 
 /// Role for Anthropic-compatible messages.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum AnthropicRole {
     User,
@@ -27,6 +28,7 @@ pub enum AnthropicRole {
 
 /// Text block for `system` prompts.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct AnthropicSystemTextBlock {
     #[serde(rename = "type")]
     pub block_type: AnthropicSystemTextBlockType,
@@ -53,6 +55,7 @@ impl AnthropicSystemTextBlock {
 
 /// Block type for Anthropic system text blocks.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum AnthropicSystemTextBlockType {
     Text,
@@ -60,6 +63,7 @@ pub enum AnthropicSystemTextBlockType {
 
 /// System prompt format for Anthropic messages.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum AnthropicSystemPrompt {
     Text(String),
@@ -68,6 +72,7 @@ pub enum AnthropicSystemPrompt {
 
 /// Message content for Anthropic messages.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum AnthropicMessageContent {
     Text(String),
@@ -94,6 +99,7 @@ impl From<Vec<AnthropicContentPart>> for AnthropicMessageContent {
 
 /// Multi-modal content part for Anthropic-compatible messages.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicContentPart {
     Text {
@@ -239,6 +245,7 @@ impl AnthropicContentPart {
 
 /// A user/assistant message in Anthropic format.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct AnthropicMessage {
     pub role: AnthropicRole,
     pub content: AnthropicMessageContent,
@@ -270,6 +277,7 @@ impl AnthropicMessage {
 
 /// Anthropic metadata payload.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct AnthropicMessagesMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
@@ -288,6 +296,7 @@ impl AnthropicMessagesMetadata {
 
 /// Tool definition for Anthropic-compatible messages.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct AnthropicTool {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -337,6 +346,7 @@ impl AnthropicTool {
 
 /// Tool choice policy for Anthropic-compatible messages.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicToolChoice {
     Auto {
@@ -382,6 +392,7 @@ impl AnthropicToolChoice {
 
 /// Thinking control for Anthropic-compatible messages.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicThinking {
     Enabled { budget_tokens: u32 },
@@ -405,6 +416,7 @@ impl AnthropicThinking {
 
 /// Output effort level for Anthropic output configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum AnthropicOutputEffort {
     Low,
@@ -415,6 +427,7 @@ pub enum AnthropicOutputEffort {
 
 /// Output config for Anthropic messages.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct AnthropicOutputConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<AnthropicOutputEffort>,
@@ -431,6 +444,7 @@ impl AnthropicOutputConfig {
 /// Request body for `POST /messages`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct AnthropicMessagesRequest {
     #[builder(setter(into))]
     model: String,
@@ -577,6 +591,7 @@ impl AnthropicMessagesRequest {
 
 /// Usage object in Anthropic messages response.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct AnthropicMessagesUsage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_tokens: Option<u64>,
@@ -594,6 +609,7 @@ pub struct AnthropicMessagesUsage {
 
 /// Non-streaming response payload returned by `POST /messages`.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct AnthropicMessagesResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -617,6 +633,7 @@ pub struct AnthropicMessagesResponse {
 
 /// Streaming data event payload for `POST /messages` when `stream=true`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicMessagesStreamEvent {
     MessageStart {
@@ -661,6 +678,7 @@ impl AnthropicMessagesStreamEvent {
 
 /// Streaming SSE envelope returned by `POST /messages`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct AnthropicMessagesSseEvent {
     pub event: String,
     pub data: AnthropicMessagesStreamEvent,

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct Model {
     pub id: String,
     pub name: String,
@@ -22,6 +23,7 @@ pub struct Model {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct Architecture {
     pub modality: String,
     pub tokenizer: String,
@@ -29,6 +31,7 @@ pub struct Architecture {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct TopProvider {
     pub context_length: Option<f64>,
     pub max_completion_tokens: Option<f64>,
@@ -36,6 +39,7 @@ pub struct TopProvider {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct Pricing {
     pub prompt: String,
     pub completion: String,
@@ -48,6 +52,7 @@ pub struct Pricing {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct Endpoint {
     pub name: String,
     pub context_length: f64,
@@ -61,6 +66,7 @@ pub struct Endpoint {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct EndpointPricing {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request: Option<String>,
@@ -71,6 +77,7 @@ pub struct EndpointPricing {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct EndpointData {
     pub id: String,
     pub name: String,
@@ -81,6 +88,7 @@ pub struct EndpointData {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct EndpointArchitecture {
     pub tokenizer: Option<String>,
     pub instruct_type: Option<String>,

--- a/src/api/organization.rs
+++ b/src/api/organization.rs
@@ -9,6 +9,7 @@ use crate::{
 
 /// One organization member returned by `GET /organization/members`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct OrganizationMember {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -21,6 +22,7 @@ pub struct OrganizationMember {
 
 /// Paginated organization member list.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct OrganizationMembersResponse {
     pub data: Vec<OrganizationMember>,
     pub total_count: u64,

--- a/src/api/rerank.rs
+++ b/src/api/rerank.rs
@@ -11,6 +11,7 @@ use crate::{
 /// Request payload for `POST /rerank`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct RerankRequest {
     #[builder(setter(into))]
     pub model: String,
@@ -33,12 +34,14 @@ impl RerankRequest {
 
 /// The original document returned in a rerank result.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct RerankDocument {
     pub text: String,
 }
 
 /// One scored rerank result.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct RerankResult {
     pub index: u64,
     pub relevance_score: f64,
@@ -47,6 +50,7 @@ pub struct RerankResult {
 
 /// Usage statistics returned by rerank providers.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct RerankUsage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
@@ -58,6 +62,7 @@ pub struct RerankUsage {
 
 /// Response payload for `POST /rerank`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct RerankResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -20,6 +20,7 @@ use crate::{
 /// Request body for the OpenRouter Responses API (`POST /responses`).
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct ResponsesRequest {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -198,6 +199,7 @@ impl ResponsesRequest {
 
 /// Non-streaming response payload returned by `POST /responses`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ResponsesResponse {
     pub id: Option<String>,
     #[serde(rename = "object")]
@@ -215,6 +217,7 @@ pub struct ResponsesResponse {
 
 /// Streaming event payload returned by `POST /responses` when `stream=true`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ResponsesStreamEvent {
     #[serde(rename = "type")]
     pub event_type: String,

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -12,12 +12,20 @@ use crate::{
 
 /// One image URL payload used in video generation requests.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoImageUrl {
     pub url: String,
 }
 
+impl VideoImageUrl {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
 /// Reference image used to guide video generation.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoInputReference {
     #[serde(rename = "type")]
     pub content_type: String,
@@ -28,13 +36,14 @@ impl VideoInputReference {
     pub fn new(url: impl Into<String>) -> Self {
         Self {
             content_type: "image_url".to_string(),
-            image_url: VideoImageUrl { url: url.into() },
+            image_url: VideoImageUrl::new(url),
         }
     }
 }
 
 /// Frame image used as the first or last frame of a generated video.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct VideoFrameImage {
     #[serde(rename = "type")]
     pub content_type: String,
@@ -46,7 +55,7 @@ impl VideoFrameImage {
     pub fn new(url: impl Into<String>, frame_type: impl Into<String>) -> Self {
         Self {
             content_type: "image_url".to_string(),
-            image_url: VideoImageUrl { url: url.into() },
+            image_url: VideoImageUrl::new(url),
             frame_type: frame_type.into(),
         }
     }
@@ -54,9 +63,18 @@ impl VideoFrameImage {
 
 /// Provider-specific passthrough options for video generation.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct VideoProviderOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl VideoProviderOptions {
+    pub fn new(options: HashMap<String, serde_json::Value>) -> Self {
+        Self {
+            options: Some(options),
+        }
+    }
 }
 
 /// Request payload for `POST /videos`.

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ReasoningDetail {
     /// The type of reasoning block (e.g., "reasoning.text", "reasoning.encrypted")
     #[serde(rename = "type")]
@@ -41,6 +42,7 @@ impl ReasoningDetail {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ResponseCostDetails {
     /// Upstream provider cost attributed to completion tokens.
     pub upstream_inference_completions_cost: f64,
@@ -51,7 +53,26 @@ pub struct ResponseCostDetails {
     pub upstream_inference_cost: Option<f64>,
 }
 
+/// Token and billing usage reported for chat completion responses.
+///
+/// Response payloads are intentionally constructed by deserialization rather than
+/// by public struct literals, so new upstream usage fields can be typed without
+/// forcing caller source changes.
+///
+/// ```compile_fail
+/// use openrouter_rs::types::completion::ResponseUsage;
+///
+/// let usage = ResponseUsage {
+///     prompt_tokens: 1,
+///     completion_tokens: 2,
+///     total_tokens: 3,
+///     cost: None,
+///     cost_details: None,
+///     is_byok: None,
+/// };
+/// ```
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ResponseUsage {
     /// Including images and tools if any
     pub prompt_tokens: u32,
@@ -70,13 +91,37 @@ pub struct ResponseUsage {
     pub is_byok: Option<bool>,
 }
 
+impl ResponseUsage {
+    pub fn new(prompt_tokens: u32, completion_tokens: u32, total_tokens: u32) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            cost: None,
+            cost_details: None,
+            is_byok: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct FunctionCall {
     pub name: String,
     pub arguments: String,
 }
 
+impl FunctionCall {
+    pub fn new(name: impl Into<String>, arguments: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            arguments: arguments.into(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ToolCall {
     pub id: String,
     #[serde(rename = "type")]
@@ -86,12 +131,33 @@ pub struct ToolCall {
     pub index: Option<u32>,
 }
 
+impl ToolCall {
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        arguments: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            type_: "function".to_string(),
+            function: FunctionCall::new(name, arguments),
+            index: None,
+        }
+    }
+
+    pub fn with_index(mut self, index: u32) -> Self {
+        self.index = Some(index);
+        self
+    }
+}
+
 /// Partial function call data as received in streaming deltas.
 ///
 /// Unlike [`FunctionCall`], all fields are optional because streaming chunks
 /// may only contain fragments of the function call (e.g., just an arguments
 /// fragment without the function name).
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct PartialFunctionCall {
     #[serde(default)]
     pub name: Option<String>,
@@ -110,6 +176,7 @@ pub struct PartialFunctionCall {
 /// automatically accumulate these partial chunks into complete [`ToolCall`]
 /// objects.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct PartialToolCall {
     #[serde(default)]
     pub id: Option<String>,
@@ -127,7 +194,7 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
-    /// use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// use openrouter_rs::types::ToolCall;
     /// use openrouter_rs::types::typed_tool::TypedTool;
     /// use serde::{Deserialize, Serialize};
     /// use schemars::JsonSchema;
@@ -142,15 +209,7 @@ impl ToolCall {
     ///     fn description() -> &'static str { "Get weather" }
     /// }
     ///
-    /// let tool_call = ToolCall {
-    ///     id: "call_123".to_string(),
-    ///     type_: "function".to_string(),
-    ///     function: FunctionCall {
-    ///         name: "get_weather".to_string(),
-    ///         arguments: r#"{"location":"Paris"}"#.to_string(),
-    ///     },
-    ///     index: None,
-    /// };
+    /// let tool_call = ToolCall::new("call_123", "get_weather", r#"{"location":"Paris"}"#);
     ///
     /// let params: WeatherParams = tool_call.parse_params()?;
     /// # Ok::<(), openrouter_rs::error::OpenRouterError>(())
@@ -168,7 +227,7 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
-    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
+    /// # use openrouter_rs::types::ToolCall;
     /// # use openrouter_rs::types::typed_tool::TypedTool;
     /// # use serde::{Deserialize, Serialize};
     /// # use schemars::JsonSchema;
@@ -178,15 +237,7 @@ impl ToolCall {
     /// #     fn name() -> &'static str { "get_weather" }
     /// #     fn description() -> &'static str { "Get weather" }
     /// # }
-    /// # let tool_call = ToolCall {
-    /// #     id: "call_123".to_string(),
-    /// #     type_: "function".to_string(),
-    /// #     function: FunctionCall {
-    /// #         name: "get_weather".to_string(),
-    /// #         arguments: r#"{"location":"Paris"}"#.to_string(),
-    /// #     },
-    /// #     index: None,
-    /// # };
+    /// # let tool_call = ToolCall::new("call_123", "get_weather", r#"{"location":"Paris"}"#);
     /// if tool_call.is_tool::<WeatherParams>() {
     ///     let params = tool_call.parse_params::<WeatherParams>()?;
     ///     // Handle weather tool
@@ -205,16 +256,8 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
-    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
-    /// # let tool_call = ToolCall {
-    /// #     id: "call_123".to_string(),
-    /// #     type_: "function".to_string(),
-    /// #     function: FunctionCall {
-    /// #         name: "get_weather".to_string(),
-    /// #         arguments: "{}".to_string(),
-    /// #     },
-    /// #     index: None,
-    /// # };
+    /// # use openrouter_rs::types::ToolCall;
+    /// # let tool_call = ToolCall::new("call_123", "get_weather", "{}");
     /// match tool_call.name() {
     ///     "get_weather" => { /* handle weather */ }
     ///     "calculator" => { /* handle calculator */ }
@@ -230,16 +273,8 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
-    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
-    /// # let tool_call = ToolCall {
-    /// #     id: "call_123".to_string(),
-    /// #     type_: "function".to_string(),
-    /// #     function: FunctionCall {
-    /// #         name: "get_weather".to_string(),
-    /// #         arguments: r#"{"location":"Paris"}"#.to_string(),
-    /// #     },
-    /// #     index: None,
-    /// # };
+    /// # use openrouter_rs::types::ToolCall;
+    /// # let tool_call = ToolCall::new("call_123", "get_weather", r#"{"location":"Paris"}"#);
     /// println!("Raw arguments: {}", tool_call.arguments_json());
     /// ```
     pub fn arguments_json(&self) -> &str {
@@ -251,16 +286,8 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
-    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
-    /// # let tool_call = ToolCall {
-    /// #     id: "call_123".to_string(),
-    /// #     type_: "function".to_string(),
-    /// #     function: FunctionCall {
-    /// #         name: "get_weather".to_string(),
-    /// #         arguments: "{}".to_string(),
-    /// #     },
-    /// #     index: None,
-    /// # };
+    /// # use openrouter_rs::types::ToolCall;
+    /// # let tool_call = ToolCall::new("call_123", "get_weather", "{}");
     /// println!("Tool call ID: {}", tool_call.id());
     /// ```
     pub fn id(&self) -> &str {
@@ -272,16 +299,8 @@ impl ToolCall {
     /// # Examples
     ///
     /// ```rust
-    /// # use openrouter_rs::types::{ToolCall, completion::FunctionCall};
-    /// # let tool_call = ToolCall {
-    /// #     id: "call_123".to_string(),
-    /// #     type_: "function".to_string(),
-    /// #     function: FunctionCall {
-    /// #         name: "get_weather".to_string(),
-    /// #         arguments: "{}".to_string(),
-    /// #     },
-    /// #     index: None,
-    /// # };
+    /// # use openrouter_rs::types::ToolCall;
+    /// # let tool_call = ToolCall::new("call_123", "get_weather", "{}");
     /// assert_eq!(tool_call.tool_type(), "function");
     /// ```
     pub fn tool_type(&self) -> &str {
@@ -290,6 +309,7 @@ impl ToolCall {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ErrorResponse {
     pub code: i32,
     pub message: String,
@@ -339,6 +359,7 @@ where
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum Choice {
     NonChat(NonChatChoice),
@@ -451,6 +472,7 @@ impl Choice {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum FinishReason {
     ToolCalls,
@@ -461,6 +483,7 @@ pub enum FinishReason {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct NonChatChoice {
     pub finish_reason: Option<FinishReason>,
     pub text: String,
@@ -470,6 +493,7 @@ pub struct NonChatChoice {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct NonStreamingChoice {
     pub finish_reason: Option<FinishReason>,
     pub native_finish_reason: Option<String>,
@@ -480,6 +504,7 @@ pub struct NonStreamingChoice {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct StreamingChoice {
     pub finish_reason: Option<FinishReason>,
     pub native_finish_reason: Option<String>,
@@ -490,6 +515,7 @@ pub struct StreamingChoice {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Message {
     #[serde(default, deserialize_with = "deserialize_optional_text_content")]
     pub content: Option<String>,
@@ -511,6 +537,7 @@ pub struct Message {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Delta {
     #[serde(default, deserialize_with = "deserialize_optional_text_content")]
     pub content: Option<String>,
@@ -531,6 +558,7 @@ pub struct Delta {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub enum ObjectType {
     #[serde(rename = "chat.completion")]
     ChatCompletion,
@@ -539,6 +567,7 @@ pub enum ObjectType {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct CompletionsResponse {
     pub id: String,
     pub choices: Vec<Choice>,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -81,12 +81,10 @@
 //! ```rust
 //! use openrouter_rs::types::{DataCollectionPolicy, ProviderPreferences};
 //!
-//! let prefs = ProviderPreferences {
-//!     allow_fallbacks: Some(true),
-//!     require_parameters: Some(true),
-//!     data_collection: Some(DataCollectionPolicy::Deny),
-//!     ..Default::default()
-//! };
+//! let mut prefs = ProviderPreferences::default();
+//! prefs.allow_fallbacks = Some(true);
+//! prefs.require_parameters = Some(true);
+//! prefs.data_collection = Some(DataCollectionPolicy::Deny);
 //! ```
 //!
 //! ## 📊 Model Categories
@@ -158,6 +156,7 @@ pub use {
 };
 
 #[derive(Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct ApiResponse<T> {
     pub data: T,
 }
@@ -178,6 +177,7 @@ pub struct ApiResponse<T> {
 /// let assistant_msg = Message::new(Role::Assistant, "Hello! How can I help?");
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     /// System instructions that guide the AI's behavior
@@ -225,6 +225,7 @@ impl Display for Role {
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum Effort {
     /// Extra high reasoning depth and thoroughness
@@ -255,6 +256,7 @@ impl Display for Effort {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ReasoningConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<Effort>,
@@ -327,6 +329,7 @@ impl ReasoningConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum ModelCategory {
     Roleplay,
@@ -383,6 +386,7 @@ impl ModelCategory {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum SupportedParameters {
     Tools,

--- a/src/types/pagination.rs
+++ b/src/types/pagination.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Common pagination input used by paginated OpenRouter endpoints.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct PaginationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u32>,

--- a/src/types/provider.rs
+++ b/src/types/provider.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Sorting strategy for provider selection when no order is specified
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum ProviderSortBy {
     /// Sort by price (cheapest first)
@@ -14,6 +15,7 @@ pub enum ProviderSortBy {
 
 /// Data collection policy preference
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum DataCollectionPolicy {
     /// Allow providers which may collect user data (default)
@@ -24,6 +26,7 @@ pub enum DataCollectionPolicy {
 
 /// Model quantization levels
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum Quantization {
     Int4,
@@ -39,6 +42,7 @@ pub enum Quantization {
 
 /// Numeric threshold value or percentile cutoffs.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum PerformancePreference {
     Value(f64),
@@ -47,6 +51,7 @@ pub enum PerformancePreference {
 
 /// Percentile-based throughput/latency cutoffs.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 #[serde(default, deny_unknown_fields)]
 pub struct PercentileCutoffs {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -61,6 +66,7 @@ pub struct PercentileCutoffs {
 
 /// Price limit represented as either number or string.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum PriceLimit {
     Number(f64),
@@ -87,6 +93,7 @@ impl From<&str> for PriceLimit {
 
 /// Maximum price constraints for provider routing.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 #[serde(default, deny_unknown_fields)]
 pub struct MaxPrice {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,6 +120,7 @@ pub struct MaxPrice {
 /// - Quantization preferences
 /// - Routing optimization strategies
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
 #[serde(default, deny_unknown_fields)]
 pub struct ProviderPreferences {
     /// Whether to allow backup providers to serve requests

--- a/src/types/response_format.rs
+++ b/src/types/response_format.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 
 /// Configuration for structured output responses
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum ResponseFormatType {
     /// Standard text response (default)
@@ -19,6 +20,7 @@ pub enum ResponseFormatType {
 
 /// JSON Schema configuration for structured outputs
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct JsonSchemaConfig {
     /// Name for the schema (used for reference)
     pub name: String,
@@ -29,8 +31,19 @@ pub struct JsonSchemaConfig {
     pub schema: Value,
 }
 
+impl JsonSchemaConfig {
+    pub fn new(name: impl Into<String>, strict: bool, schema: Value) -> Self {
+        Self {
+            name: name.into(),
+            strict,
+            schema,
+        }
+    }
+}
+
 /// Response format configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum ResponseFormat {
     /// Legacy shorthand format type specification (e.g. "text")
@@ -73,11 +86,7 @@ impl ResponseFormat {
     pub fn json_schema(name: impl Into<String>, strict: bool, schema: Value) -> Self {
         ResponseFormat::JsonSchema {
             type_: ResponseFormatType::JsonSchema,
-            json_schema: JsonSchemaConfig {
-                name: name.into(),
-                strict,
-                schema,
-            },
+            json_schema: JsonSchemaConfig::new(name, strict, schema),
         }
     }
 

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -74,6 +74,7 @@ use crate::{
 /// Tool calls are accumulated internally and emitted as complete objects
 /// only once in the final [`StreamEvent::Done`] event.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum StreamEvent {
     /// A fragment of text content from the assistant's response.
     ContentDelta(String),
@@ -337,6 +338,7 @@ impl Stream for ToolAwareStream {
 
 /// Source stream family for a [`UnifiedStreamEvent`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum UnifiedStreamSource {
     Chat,
     Responses,
@@ -345,6 +347,7 @@ pub enum UnifiedStreamSource {
 
 /// Unified stream event model across chat/responses/messages APIs.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UnifiedStreamEvent {
     /// Text content delta from the model.
     ContentDelta(String),

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -78,6 +78,7 @@ use crate::error::OpenRouterError;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct Tool {
     /// Type of tool (always "function" for now)
     #[serde(rename = "type")]
@@ -156,6 +157,7 @@ impl ToolBuilder {
 /// description, and parameter schema.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
 pub struct FunctionDefinition {
     /// Name of the function
     #[builder(setter(into))]
@@ -260,6 +262,7 @@ impl FunctionDefinitionBuilder {
 /// let specific = ToolChoice::force_tool("get_weather");
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum ToolChoice {
     /// Simple string choices: "none", "auto", "required"
@@ -297,6 +300,7 @@ impl ToolChoice {
 
 /// Specific tool choice for forcing a particular tool
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct SpecificToolChoice {
     #[serde(rename = "type")]
     pub tool_type: String,
@@ -305,6 +309,7 @@ pub struct SpecificToolChoice {
 
 /// Function specification for specific tool choice
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct SpecificToolFunction {
     pub name: String,
 }

--- a/tests/integration/chat.rs
+++ b/tests/integration/chat.rs
@@ -65,6 +65,7 @@ fn get_first_content(response: &CompletionsResponse) -> &str {
         Choice::NonStreaming(c) => c.message.content.as_deref().unwrap_or_default(),
         Choice::Streaming(c) => c.delta.content.as_deref().unwrap_or_default(),
         Choice::NonChat(c) => c.text.as_str(),
+        _ => "",
     }
 }
 

--- a/tests/integration/contract.rs
+++ b/tests/integration/contract.rs
@@ -95,6 +95,7 @@ async fn assert_stream_completes(
                 UnifiedStreamEvent::ToolDelta(_) | UnifiedStreamEvent::Raw { .. } => {
                     saw_payload = true;
                 }
+                _ => {}
             }
         }
 
@@ -380,6 +381,7 @@ async fn test_read_only_contract_embeddings_surface() -> Result<(), OpenRouterEr
                     response.data.iter().any(|item| match &item.embedding {
                         EmbeddingVector::Float(values) => !values.is_empty(),
                         EmbeddingVector::Base64(value) => !value.trim().is_empty(),
+                        _ => false,
                     }),
                     "embedding response should include at least one non-empty vector"
                 );

--- a/tests/integration/embeddings.rs
+++ b/tests/integration/embeddings.rs
@@ -104,6 +104,7 @@ async fn test_create_embedding_live() -> Result<(), OpenRouterError> {
                     response.data.iter().any(|item| match &item.embedding {
                         EmbeddingVector::Float(values) => !values.is_empty(),
                         EmbeddingVector::Base64(value) => !value.trim().is_empty(),
+                        _ => false,
                     }),
                     "at least one embedding item should contain non-empty vector payload"
                 );

--- a/tests/integration/messages.rs
+++ b/tests/integration/messages.rs
@@ -129,6 +129,7 @@ async fn test_stream_messages_unified_done_semantics() -> Result<(), OpenRouterE
                     );
                     saw_payload_event = true;
                 }
+                _ => {}
             }
         }
 

--- a/tests/integration/responses.rs
+++ b/tests/integration/responses.rs
@@ -266,6 +266,7 @@ async fn test_stream_response_unified_done_semantics() -> Result<(), OpenRouterE
                 UnifiedStreamEvent::Raw { .. } => {
                     saw_payload_event = true;
                 }
+                _ => {}
             }
         }
 

--- a/tests/integration/tools.rs
+++ b/tests/integration/tools.rs
@@ -1,8 +1,7 @@
 use openrouter_rs::{
     api::chat::{ChatCompletionRequest, Message},
     types::{
-        Role, Tool, ToolChoice,
-        completion::{FunctionCall, ToolCall},
+        Role, Tool, ToolCall, ToolChoice,
         typed_tool::{TypedTool, TypedToolParams},
     },
 };
@@ -120,17 +119,9 @@ async fn test_tool_message_creation() {
 #[tokio::test]
 async fn test_assistant_message_with_tool_calls() {
     use openrouter_rs::Content;
-    use openrouter_rs::types::{FunctionCall, ToolCall};
+    use openrouter_rs::types::ToolCall;
 
-    let tool_call = ToolCall {
-        id: "call_123".to_string(),
-        type_: "function".to_string(),
-        function: FunctionCall {
-            name: "test_function".to_string(),
-            arguments: r#"{"param": "value"}"#.to_string(),
-        },
-        index: None,
-    };
+    let tool_call = ToolCall::new("call_123", "test_function", r#"{"param": "value"}"#);
 
     let assistant_msg =
         Message::assistant_with_tool_calls("I'll help you with that", vec![tool_call]);
@@ -291,15 +282,7 @@ impl TypedTool for TestToolParams {
 
 /// Create a test ToolCall for testing
 fn create_test_tool_call(tool_name: &str, arguments: &str) -> ToolCall {
-    ToolCall {
-        id: format!("call_{}", tool_name),
-        type_: "function".to_string(),
-        function: FunctionCall {
-            name: tool_name.to_string(),
-            arguments: arguments.to_string(),
-        },
-        index: None,
-    }
+    ToolCall::new(format!("call_{tool_name}"), tool_name, arguments)
 }
 
 #[tokio::test]

--- a/tests/unit/audio.rs
+++ b/tests/unit/audio.rs
@@ -26,9 +26,7 @@ fn test_speech_request_serialization() {
         .voice("alloy")
         .response_format(SpeechResponseFormat::Mp3)
         .speed(1.1)
-        .provider(SpeechProviderOptions {
-            options: Some(provider_options),
-        })
+        .provider(SpeechProviderOptions::new(provider_options))
         .build()
         .expect("speech request should build");
 

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -162,16 +162,12 @@ fn test_multimodal_content_part_deserialization() {
 
 #[test]
 fn test_chat_request_extended_control_fields_serialize() {
-    let trace = TraceOptions {
-        trace_id: Some("trace-1".to_string()),
-        span_name: Some("sdk.chat".to_string()),
-        generation_name: None,
-        trace_name: None,
-        parent_span_id: None,
-        extra: [("team".to_string(), json!("rust-sdk"))]
-            .into_iter()
-            .collect(),
-    };
+    let mut trace = TraceOptions::default();
+    trace.trace_id = Some("trace-1".to_string());
+    trace.span_name = Some("sdk.chat".to_string());
+    trace.extra = [("team".to_string(), json!("rust-sdk"))]
+        .into_iter()
+        .collect();
 
     let request = ChatCompletionRequest::builder()
         .model("openai/gpt-5")
@@ -224,6 +220,11 @@ fn test_chat_request_extended_generation_fields_serialize() {
 
 #[test]
 fn test_chat_request_plugins_and_stream_options_serialize() {
+    let mut stream_options = StreamOptions::default();
+    stream_options.include_usage = Some(true);
+    let mut debug = DebugOptions::default();
+    debug.echo_upstream_body = Some(true);
+
     let request = ChatCompletionRequest::builder()
         .model("openai/gpt-5")
         .messages(vec![Message::new(Role::User, "search the web")])
@@ -232,12 +233,8 @@ fn test_chat_request_plugins_and_stream_options_serialize() {
                 .option("max_results", 3)
                 .option("search_prompt", "latest rust release"),
         ])
-        .stream_options(StreamOptions {
-            include_usage: Some(true),
-        })
-        .debug(DebugOptions {
-            echo_upstream_body: Some(true),
-        })
+        .stream_options(stream_options)
+        .debug(debug)
         .build()
         .expect("request should build");
 

--- a/tests/unit/embeddings.rs
+++ b/tests/unit/embeddings.rs
@@ -32,18 +32,10 @@ fn test_embedding_request_text_input_serialize() {
 
 #[test]
 fn test_embedding_request_multimodal_input_serialize() {
-    let input = EmbeddingInput::MultimodalArray(vec![EmbeddingMultimodalInput {
-        content: vec![
-            EmbeddingContentPart::Text {
-                text: "caption this".to_string(),
-            },
-            EmbeddingContentPart::ImageUrl {
-                image_url: openrouter_rs::api::embeddings::EmbeddingImageUrl {
-                    url: "https://example.com/image.jpg".to_string(),
-                },
-            },
-        ],
-    }]);
+    let input = EmbeddingInput::MultimodalArray(vec![EmbeddingMultimodalInput::new(vec![
+        EmbeddingContentPart::text("caption this"),
+        EmbeddingContentPart::image_url("https://example.com/image.jpg"),
+    ])]);
 
     let request = EmbeddingRequest::new("openai/text-embedding-3-large", input);
     let value = serde_json::to_value(&request).expect("embedding request should serialize");
@@ -77,6 +69,7 @@ fn test_embedding_response_float_deserialization() {
     match &response.data[0].embedding {
         EmbeddingVector::Float(values) => assert_eq!(values.len(), 3),
         EmbeddingVector::Base64(_) => panic!("expected float vector"),
+        _ => panic!("unexpected embedding vector variant"),
     }
 }
 
@@ -129,6 +122,7 @@ fn test_embedding_response_base64_deserialization() {
     match &response.data[0].embedding {
         EmbeddingVector::Base64(value) => assert_eq!(value, "AAAAAA=="),
         EmbeddingVector::Float(_) => panic!("expected base64 vector"),
+        _ => panic!("unexpected embedding vector variant"),
     }
 }
 

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -62,13 +62,11 @@ fn test_anthropic_messages_request_serialization() {
         .route("fallback")
         .user("user-123")
         .session_id("session-abc")
-        .trace(TraceOptions {
-            trace_id: Some("trace-1".to_string()),
-            trace_name: None,
-            span_name: Some("messages.unit".to_string()),
-            generation_name: None,
-            parent_span_id: None,
-            extra: Default::default(),
+        .trace({
+            let mut trace = TraceOptions::default();
+            trace.trace_id = Some("trace-1".to_string());
+            trace.span_name = Some("messages.unit".to_string());
+            trace
         })
         .models(vec!["anthropic/claude-sonnet-4".to_string()])
         .output_config(AnthropicOutputConfig::with_effort(

--- a/tests/unit/provider.rs
+++ b/tests/unit/provider.rs
@@ -5,27 +5,25 @@ use openrouter_rs::types::{
 
 #[test]
 fn test_provider_preferences_new_fields_scalar_serialize() {
-    let prefs = ProviderPreferences {
-        allow_fallbacks: Some(true),
-        require_parameters: Some(true),
-        data_collection: Some(DataCollectionPolicy::Deny),
-        zdr: Some(true),
-        enforce_distillable_text: Some(true),
-        order: Some(vec!["openai".to_string(), "anthropic".to_string()]),
-        only: Some(vec!["openai".to_string()]),
-        ignore: Some(vec!["some-provider".to_string()]),
-        quantizations: Some(vec![Quantization::Fp16]),
-        sort: Some(ProviderSortBy::Price),
-        max_price: Some(MaxPrice {
-            prompt: Some(PriceLimit::Number(1.25)),
-            completion: Some(PriceLimit::String("2.5".to_string())),
-            image: None,
-            audio: None,
-            request: Some(PriceLimit::Number(0.01)),
-        }),
-        preferred_min_throughput: Some(PerformancePreference::Value(120.0)),
-        preferred_max_latency: Some(PerformancePreference::Value(3.5)),
-    };
+    let mut max_price = MaxPrice::default();
+    max_price.prompt = Some(PriceLimit::Number(1.25));
+    max_price.completion = Some(PriceLimit::String("2.5".to_string()));
+    max_price.request = Some(PriceLimit::Number(0.01));
+
+    let mut prefs = ProviderPreferences::default();
+    prefs.allow_fallbacks = Some(true);
+    prefs.require_parameters = Some(true);
+    prefs.data_collection = Some(DataCollectionPolicy::Deny);
+    prefs.zdr = Some(true);
+    prefs.enforce_distillable_text = Some(true);
+    prefs.order = Some(vec!["openai".to_string(), "anthropic".to_string()]);
+    prefs.only = Some(vec!["openai".to_string()]);
+    prefs.ignore = Some(vec!["some-provider".to_string()]);
+    prefs.quantizations = Some(vec![Quantization::Fp16]);
+    prefs.sort = Some(ProviderSortBy::Price);
+    prefs.max_price = Some(max_price);
+    prefs.preferred_min_throughput = Some(PerformancePreference::Value(120.0));
+    prefs.preferred_max_latency = Some(PerformancePreference::Value(3.5));
 
     let json = serde_json::to_value(&prefs).expect("provider prefs should serialize");
 
@@ -44,21 +42,17 @@ fn test_provider_preferences_new_fields_scalar_serialize() {
 
 #[test]
 fn test_provider_preferences_percentile_preferences_serialize() {
-    let prefs = ProviderPreferences {
-        preferred_min_throughput: Some(PerformancePreference::Percentiles(PercentileCutoffs {
-            p50: Some(100.0),
-            p75: None,
-            p90: Some(50.0),
-            p99: None,
-        })),
-        preferred_max_latency: Some(PerformancePreference::Percentiles(PercentileCutoffs {
-            p50: Some(2.5),
-            p75: Some(3.0),
-            p90: None,
-            p99: None,
-        })),
-        ..Default::default()
-    };
+    let mut throughput = PercentileCutoffs::default();
+    throughput.p50 = Some(100.0);
+    throughput.p90 = Some(50.0);
+
+    let mut latency = PercentileCutoffs::default();
+    latency.p50 = Some(2.5);
+    latency.p75 = Some(3.0);
+
+    let mut prefs = ProviderPreferences::default();
+    prefs.preferred_min_throughput = Some(PerformancePreference::Percentiles(throughput));
+    prefs.preferred_max_latency = Some(PerformancePreference::Percentiles(latency));
 
     let json = serde_json::to_value(&prefs).expect("provider prefs should serialize");
 

--- a/tests/unit/rerank.rs
+++ b/tests/unit/rerank.rs
@@ -13,6 +13,9 @@ use openrouter_rs::{
 
 #[test]
 fn test_rerank_request_serialization() {
+    let mut provider = ProviderPreferences::default();
+    provider.allow_fallbacks = Some(true);
+
     let request = RerankRequest::builder()
         .model("cohere/rerank-v3.5")
         .query("What is the capital of France?")
@@ -21,10 +24,7 @@ fn test_rerank_request_serialization() {
             "Berlin is the capital of Germany.".to_string(),
         ])
         .top_n(1)
-        .provider(ProviderPreferences {
-            allow_fallbacks: Some(true),
-            ..ProviderPreferences::default()
-        })
+        .provider(provider)
         .build()
         .expect("rerank request should build");
 

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -145,13 +145,11 @@ fn test_responses_request_serialization() {
         .truncation("auto")
         .user("user-123")
         .session_id("session-abc")
-        .trace(TraceOptions {
-            trace_id: Some("trace-1".to_string()),
-            trace_name: None,
-            span_name: Some("responses.unit".to_string()),
-            generation_name: None,
-            parent_span_id: None,
-            extra: Default::default(),
+        .trace({
+            let mut trace = TraceOptions::default();
+            trace.trace_id = Some("trace-1".to_string());
+            trace.span_name = Some("responses.unit".to_string());
+            trace
         })
         .plugins(vec![Plugin::new("web").option("max_results", 3)])
         .build()

--- a/tests/unit/stream.rs
+++ b/tests/unit/stream.rs
@@ -1,10 +1,10 @@
 use futures_util::{StreamExt, stream};
 use openrouter_rs::error::OpenRouterError;
 use openrouter_rs::types::completion::{
-    Choice, CompletionsResponse, Delta, ObjectType, PartialFunctionCall, PartialToolCall,
-    ResponseUsage, StreamingChoice,
+    CompletionsResponse, PartialFunctionCall, PartialToolCall, ResponseUsage,
 };
 use openrouter_rs::types::stream::{StreamEvent, ToolAwareStream};
+use serde_json::json;
 
 // =============================================
 // PartialToolCall deserialization tests
@@ -163,31 +163,32 @@ fn test_streaming_chunk_arguments_fragment() {
 
 /// Helper: create a CompletionsResponse with a streaming content delta.
 fn content_chunk(id: &str, model: &str, content: &str) -> CompletionsResponse {
-    CompletionsResponse {
-        id: id.to_string(),
-        choices: vec![Choice::Streaming(StreamingChoice {
-            finish_reason: None,
-            native_finish_reason: None,
-            delta: Delta {
-                content: Some(content.to_string()),
-                role: None,
-                tool_calls: None,
-                reasoning: None,
-                reasoning_details: None,
-                audio: None,
-                refusal: None,
+    serde_json::from_value(json!({
+        "id": id,
+        "choices": [{
+            "finish_reason": null,
+            "native_finish_reason": null,
+            "delta": {
+                "content": content,
+                "role": null,
+                "tool_calls": null,
+                "reasoning": null,
+                "reasoning_details": null,
+                "audio": null,
+                "refusal": null
             },
-            error: None,
-            index: Some(0),
-            logprobs: None,
-        })],
-        created: 1700000000,
-        model: model.to_string(),
-        object_type: ObjectType::ChatCompletionChunk,
-        provider: None,
-        system_fingerprint: None,
-        usage: None,
-    }
+            "error": null,
+            "index": 0,
+            "logprobs": null
+        }],
+        "created": 1700000000_u64,
+        "model": model,
+        "object": "chat.completion.chunk",
+        "provider": null,
+        "system_fingerprint": null,
+        "usage": null
+    }))
+    .expect("content chunk should deserialize")
 }
 
 /// Helper: create a CompletionsResponse with a partial tool call delta.
@@ -201,44 +202,45 @@ fn tool_call_chunk(
     func_args: Option<&str>,
 ) -> CompletionsResponse {
     let function = if func_name.is_some() || func_args.is_some() {
-        Some(PartialFunctionCall {
-            name: func_name.map(|s| s.to_string()),
-            arguments: func_args.map(|s| s.to_string()),
+        json!({
+            "name": func_name,
+            "arguments": func_args
         })
     } else {
-        None
+        serde_json::Value::Null
     };
 
-    CompletionsResponse {
-        id: id.to_string(),
-        choices: vec![Choice::Streaming(StreamingChoice {
-            finish_reason: None,
-            native_finish_reason: None,
-            delta: Delta {
-                content: None,
-                role: None,
-                tool_calls: Some(vec![PartialToolCall {
-                    id: tool_id.map(|s| s.to_string()),
-                    type_: tool_type.map(|s| s.to_string()),
-                    function,
-                    index: Some(tool_call_index),
-                }]),
-                reasoning: None,
-                reasoning_details: None,
-                audio: None,
-                refusal: None,
+    serde_json::from_value(json!({
+        "id": id,
+        "choices": [{
+            "finish_reason": null,
+            "native_finish_reason": null,
+            "delta": {
+                "content": null,
+                "role": null,
+                "tool_calls": [{
+                    "id": tool_id,
+                    "type": tool_type,
+                    "function": function,
+                    "index": tool_call_index
+                }],
+                "reasoning": null,
+                "reasoning_details": null,
+                "audio": null,
+                "refusal": null
             },
-            error: None,
-            index: Some(0),
-            logprobs: None,
-        })],
-        created: 1700000000,
-        model: model.to_string(),
-        object_type: ObjectType::ChatCompletionChunk,
-        provider: None,
-        system_fingerprint: None,
-        usage: None,
-    }
+            "error": null,
+            "index": 0,
+            "logprobs": null
+        }],
+        "created": 1700000000_u64,
+        "model": model,
+        "object": "chat.completion.chunk",
+        "provider": null,
+        "system_fingerprint": null,
+        "usage": null
+    }))
+    .expect("tool call chunk should deserialize")
 }
 
 /// Helper: create a final chunk with finish_reason and usage.
@@ -256,31 +258,32 @@ fn done_chunk(
         _ => None,
     };
 
-    CompletionsResponse {
-        id: id.to_string(),
-        choices: vec![Choice::Streaming(StreamingChoice {
-            finish_reason: reason,
-            native_finish_reason: Some(finish_reason.to_string()),
-            delta: Delta {
-                content: None,
-                role: None,
-                tool_calls: None,
-                reasoning: None,
-                reasoning_details: None,
-                audio: None,
-                refusal: None,
+    serde_json::from_value(json!({
+        "id": id,
+        "choices": [{
+            "finish_reason": reason,
+            "native_finish_reason": finish_reason,
+            "delta": {
+                "content": null,
+                "role": null,
+                "tool_calls": null,
+                "reasoning": null,
+                "reasoning_details": null,
+                "audio": null,
+                "refusal": null
             },
-            error: None,
-            index: Some(0),
-            logprobs: None,
-        })],
-        created: 1700000000,
-        model: model.to_string(),
-        object_type: ObjectType::ChatCompletionChunk,
-        provider: None,
-        system_fingerprint: None,
-        usage,
-    }
+            "error": null,
+            "index": 0,
+            "logprobs": null
+        }],
+        "created": 1700000000_u64,
+        "model": model,
+        "object": "chat.completion.chunk",
+        "provider": null,
+        "system_fingerprint": null,
+        "usage": usage
+    }))
+    .expect("done chunk should deserialize")
 }
 
 #[tokio::test]
@@ -369,14 +372,7 @@ async fn test_tool_aware_stream_single_tool_call() {
             "gen-1",
             "gpt-4",
             "tool_calls",
-            Some(ResponseUsage {
-                prompt_tokens: 100,
-                completion_tokens: 20,
-                total_tokens: 120,
-                cost: None,
-                cost_details: None,
-                is_byok: None,
-            }),
+            Some(ResponseUsage::new(100, 20, 120)),
         )),
     ];
 
@@ -609,31 +605,32 @@ async fn test_tool_aware_stream_empty_stream() {
 
 #[tokio::test]
 async fn test_tool_aware_stream_reasoning_deltas() {
-    let reasoning_chunk = CompletionsResponse {
-        id: "gen-1".to_string(),
-        choices: vec![Choice::Streaming(StreamingChoice {
-            finish_reason: None,
-            native_finish_reason: None,
-            delta: Delta {
-                content: None,
-                role: None,
-                tool_calls: None,
-                reasoning: Some("Let me think...".to_string()),
-                reasoning_details: None,
-                audio: None,
-                refusal: None,
+    let reasoning_chunk: CompletionsResponse = serde_json::from_value(json!({
+        "id": "gen-1",
+        "choices": [{
+            "finish_reason": null,
+            "native_finish_reason": null,
+            "delta": {
+                "content": null,
+                "role": null,
+                "tool_calls": null,
+                "reasoning": "Let me think...",
+                "reasoning_details": null,
+                "audio": null,
+                "refusal": null
             },
-            error: None,
-            index: Some(0),
-            logprobs: None,
-        })],
-        created: 1700000000,
-        model: "test-model".to_string(),
-        object_type: ObjectType::ChatCompletionChunk,
-        provider: None,
-        system_fingerprint: None,
-        usage: None,
-    };
+            "error": null,
+            "index": 0,
+            "logprobs": null
+        }],
+        "created": 1700000000_u64,
+        "model": "test-model",
+        "object": "chat.completion.chunk",
+        "provider": null,
+        "system_fingerprint": null,
+        "usage": null
+    }))
+    .expect("reasoning chunk should deserialize");
 
     let chunks: Vec<Result<CompletionsResponse, OpenRouterError>> = vec![
         Ok(reasoning_chunk),

--- a/tests/unit/unified_stream.rs
+++ b/tests/unit/unified_stream.rs
@@ -1,20 +1,9 @@
-use std::collections::HashMap;
-
 use futures_util::{StreamExt, stream};
 use openrouter_rs::{
-    api::{
-        messages::{
-            AnthropicContentPart, AnthropicMessagesResponse, AnthropicMessagesSseEvent,
-            AnthropicMessagesStreamEvent, AnthropicMessagesUsage,
-        },
-        responses::ResponsesStreamEvent,
-    },
+    api::{messages::AnthropicMessagesSseEvent, responses::ResponsesStreamEvent},
     error::OpenRouterError,
     types::{
-        completion::{
-            Choice, CompletionsResponse, Delta, FinishReason, ObjectType, PartialFunctionCall,
-            PartialToolCall, ResponseUsage, StreamingChoice,
-        },
+        completion::{CompletionsResponse, FinishReason, PartialToolCall, ResponseUsage},
         stream::{
             UnifiedStreamEvent, UnifiedStreamSource, adapt_chat_stream, adapt_messages_stream,
             adapt_responses_stream,
@@ -32,45 +21,50 @@ fn chat_chunk(
     finish_reason: Option<FinishReason>,
     usage: Option<ResponseUsage>,
 ) -> CompletionsResponse {
-    CompletionsResponse {
-        id: id.to_string(),
-        choices: vec![Choice::Streaming(StreamingChoice {
-            finish_reason,
-            native_finish_reason: None,
-            delta: Delta {
-                content: content.map(ToOwned::to_owned),
-                role: None,
-                tool_calls: partial_tool.map(|p| vec![p]),
-                reasoning: reasoning.map(ToOwned::to_owned),
-                reasoning_details: None,
-                audio: None,
-                refusal: None,
+    serde_json::from_value(json!({
+        "id": id,
+        "choices": [{
+            "finish_reason": finish_reason,
+            "native_finish_reason": null,
+            "delta": {
+                "content": content,
+                "role": null,
+                "tool_calls": partial_tool.map(|p| vec![p]),
+                "reasoning": reasoning,
+                "reasoning_details": null,
+                "audio": null,
+                "refusal": null
             },
-            error: None,
-            index: Some(0),
-            logprobs: None,
-        })],
-        created: 1_700_000_000,
-        model: model.to_string(),
-        object_type: ObjectType::ChatCompletionChunk,
-        provider: None,
-        system_fingerprint: None,
-        usage,
-    }
+            "error": null,
+            "index": 0,
+            "logprobs": null
+        }],
+        "created": 1_700_000_000_u64,
+        "model": model,
+        "object": "chat.completion.chunk",
+        "provider": null,
+        "system_fingerprint": null,
+        "usage": usage
+    }))
+    .expect("chat chunk should deserialize")
 }
 
 fn responses_event(event_type: &str, data: serde_json::Value) -> ResponsesStreamEvent {
-    let mut map = HashMap::new();
+    let mut map = serde_json::Map::new();
+    map.insert("type".to_string(), json!(event_type));
+    map.insert("sequence_number".to_string(), serde_json::Value::Null);
     if let Some(obj) = data.as_object() {
         for (k, v) in obj {
             map.insert(k.clone(), v.clone());
         }
     }
-    ResponsesStreamEvent {
-        event_type: event_type.to_string(),
-        sequence_number: None,
-        data: map,
-    }
+    serde_json::from_value(serde_json::Value::Object(map))
+        .expect("responses event should deserialize")
+}
+
+fn messages_event(event: &str, data: serde_json::Value) -> AnthropicMessagesSseEvent {
+    serde_json::from_value(json!({ "event": event, "data": data }))
+        .expect("messages event should deserialize")
 }
 
 #[tokio::test]
@@ -81,15 +75,18 @@ async fn test_unified_chat_stream_mixed_sequence() {
             "test-model",
             Some("Hello "),
             Some("thinking"),
-            Some(PartialToolCall {
-                id: Some("call_1".to_string()),
-                type_: Some("function".to_string()),
-                function: Some(PartialFunctionCall {
-                    name: Some("get_weather".to_string()),
-                    arguments: Some("{\"location\":\"SF\"}".to_string()),
-                }),
-                index: Some(0),
-            }),
+            Some(
+                serde_json::from_value(json!({
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"location\":\"SF\"}"
+                    },
+                    "index": 0
+                }))
+                .expect("partial tool call should deserialize"),
+            ),
             None,
             None,
         )),
@@ -100,14 +97,7 @@ async fn test_unified_chat_stream_mixed_sequence() {
             None,
             None,
             Some(FinishReason::Stop),
-            Some(ResponseUsage {
-                prompt_tokens: 5,
-                completion_tokens: 7,
-                total_tokens: 12,
-                cost: None,
-                cost_details: None,
-                is_byok: None,
-            }),
+            Some(ResponseUsage::new(5, 7, 12)),
         )),
     ];
 
@@ -281,59 +271,58 @@ async fn test_unified_responses_stream_non_terminal_completed_suffix_stays_open(
 #[tokio::test]
 async fn test_unified_messages_stream_mixed_sequence() {
     let events = vec![
-        Ok(AnthropicMessagesSseEvent {
-            event: "message_start".to_string(),
-            data: AnthropicMessagesStreamEvent::MessageStart {
-                message: Box::new(AnthropicMessagesResponse {
-                    id: Some("msg_1".to_string()),
-                    object_type: Some("message".to_string()),
-                    role: Some("assistant".to_string()),
-                    content: Vec::new(),
-                    model: Some("anthropic/claude-sonnet-4".to_string()),
-                    stop_reason: None,
-                    stop_sequence: None,
-                    usage: Some(AnthropicMessagesUsage {
-                        input_tokens: Some(5),
-                        output_tokens: Some(0),
-                        cache_creation_input_tokens: None,
-                        cache_read_input_tokens: None,
-                        service_tier: None,
-                        extra: HashMap::new(),
-                    }),
-                    extra: HashMap::new(),
-                }),
-            },
-        }),
-        Ok(AnthropicMessagesSseEvent {
-            event: "content_block_delta".to_string(),
-            data: AnthropicMessagesStreamEvent::ContentBlockDelta {
-                index: 0,
-                delta: json!({ "type": "text_delta", "text": "Hello" }),
-            },
-        }),
-        Ok(AnthropicMessagesSseEvent {
-            event: "content_block_delta".to_string(),
-            data: AnthropicMessagesStreamEvent::ContentBlockDelta {
-                index: 0,
-                delta: json!({ "type": "thinking_delta", "thinking": "plan" }),
-            },
-        }),
-        Ok(AnthropicMessagesSseEvent {
-            event: "content_block_start".to_string(),
-            data: AnthropicMessagesStreamEvent::ContentBlockStart {
-                index: 1,
-                content_block: Box::new(AnthropicContentPart::ToolUse {
-                    id: "toolu_1".to_string(),
-                    name: "get_weather".to_string(),
-                    input: Some(json!({ "city": "SF" })),
-                    cache_control: None,
-                }),
-            },
-        }),
-        Ok(AnthropicMessagesSseEvent {
-            event: "message_stop".to_string(),
-            data: AnthropicMessagesStreamEvent::MessageStop,
-        }),
+        Ok(messages_event(
+            "message_start",
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "anthropic/claude-sonnet-4",
+                    "stop_reason": null,
+                    "stop_sequence": null,
+                    "usage": {
+                        "input_tokens": 5,
+                        "output_tokens": 0
+                    }
+                }
+            }),
+        )),
+        Ok(messages_event(
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "text_delta", "text": "Hello" }
+            }),
+        )),
+        Ok(messages_event(
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "thinking_delta", "thinking": "plan" }
+            }),
+        )),
+        Ok(messages_event(
+            "content_block_start",
+            json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": { "city": "SF" }
+                }
+            }),
+        )),
+        Ok(messages_event(
+            "message_stop",
+            json!({ "type": "message_stop" }),
+        )),
     ];
 
     let mut stream = adapt_messages_stream(stream::iter(events).boxed());
@@ -369,20 +358,21 @@ async fn test_unified_messages_stream_error_then_done() {
 #[tokio::test]
 async fn test_unified_messages_tool_delta_preserves_content_block_index() {
     let events = vec![
-        Ok(AnthropicMessagesSseEvent {
-            event: "content_block_delta".to_string(),
-            data: AnthropicMessagesStreamEvent::ContentBlockDelta {
-                index: 2,
-                delta: json!({
+        Ok(messages_event(
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta",
+                "index": 2,
+                "delta": {
                     "type": "input_json_delta",
                     "partial_json": "{\"city\":\"S"
-                }),
-            },
-        }),
-        Ok(AnthropicMessagesSseEvent {
-            event: "message_stop".to_string(),
-            data: AnthropicMessagesStreamEvent::MessageStop,
-        }),
+                }
+            }),
+        )),
+        Ok(messages_event(
+            "message_stop",
+            json!({ "type": "message_stop" }),
+        )),
     ];
 
     let mut stream = adapt_messages_stream(stream::iter(events).boxed());
@@ -424,22 +414,23 @@ async fn test_unified_messages_tool_delta_preserves_content_block_index() {
 #[tokio::test]
 async fn test_unified_messages_tool_start_preserves_content_block_index() {
     let events = vec![
-        Ok(AnthropicMessagesSseEvent {
-            event: "content_block_start".to_string(),
-            data: AnthropicMessagesStreamEvent::ContentBlockStart {
-                index: 3,
-                content_block: Box::new(AnthropicContentPart::ToolUse {
-                    id: "toolu_2".to_string(),
-                    name: "get_weather".to_string(),
-                    input: Some(json!({ "city": "SF" })),
-                    cache_control: None,
-                }),
-            },
-        }),
-        Ok(AnthropicMessagesSseEvent {
-            event: "message_stop".to_string(),
-            data: AnthropicMessagesStreamEvent::MessageStop,
-        }),
+        Ok(messages_event(
+            "content_block_start",
+            json!({
+                "type": "content_block_start",
+                "index": 3,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_2",
+                    "name": "get_weather",
+                    "input": { "city": "SF" }
+                }
+            }),
+        )),
+        Ok(messages_event(
+            "message_stop",
+            json!({ "type": "message_stop" }),
+        )),
     ];
 
     let mut stream = adapt_messages_stream(stream::iter(events).boxed());

--- a/tests/unit/videos.rs
+++ b/tests/unit/videos.rs
@@ -39,9 +39,7 @@ fn test_video_generation_request_serialization() {
         .input_references(vec![VideoInputReference::new(
             "https://example.com/reference.png",
         )])
-        .provider(VideoProviderOptions {
-            options: Some(provider_options),
-        })
+        .provider(VideoProviderOptions::new(provider_options))
         .build()
         .expect("video generation request should build");
 


### PR DESCRIPTION
## Summary
- Mark high-churn public SDK API model structs/enums as #[non_exhaustive] for the 0.10.0 release boundary.
- Add ergonomic constructors/helpers and update tests/examples away from direct response literals and exhaustive enum matches.
- Update OpenSpec inventory, migration docs, README, changelog, and migration-doc checks.

## Test Plan
- [x] openspec validate mark-public-response-types-non-exhaustive
- [x] just quality
- [x] just quality-ci

## Breaking Changes
- Source-level breaking: affected public structs can no longer be constructed with external struct literals, and affected public enums require wildcard match arms outside the crate.
- Intended for 0.10.0, not a 0.9.x patch.