### PR TITLE
fix: satisfy new clippy collapsible match lint

### DIFF
--- a/tests/integration/contract.rs
+++ b/tests/integration/contract.rs
@@ -77,20 +77,14 @@ async fn assert_stream_completes(
                     saw_done = true;
                     break;
                 }
-                UnifiedStreamEvent::ContentDelta(delta) => {
-                    if !delta.trim().is_empty() {
-                        saw_payload = true;
-                    }
+                UnifiedStreamEvent::ContentDelta(delta)
+                | UnifiedStreamEvent::ReasoningDelta(delta)
+                    if !delta.trim().is_empty() =>
+                {
+                    saw_payload = true;
                 }
-                UnifiedStreamEvent::ReasoningDelta(delta) => {
-                    if !delta.trim().is_empty() {
-                        saw_payload = true;
-                    }
-                }
-                UnifiedStreamEvent::ReasoningDetailsDelta(details) => {
-                    if !details.is_empty() {
-                        saw_payload = true;
-                    }
+                UnifiedStreamEvent::ReasoningDetailsDelta(details) if !details.is_empty() => {
+                    saw_payload = true;
                 }
                 UnifiedStreamEvent::ToolDelta(_) | UnifiedStreamEvent::Raw { .. } => {
                     saw_payload = true;

--- a/tests/integration/messages.rs
+++ b/tests/integration/messages.rs
@@ -103,20 +103,14 @@ async fn test_stream_messages_unified_done_semantics() -> Result<(), OpenRouterE
                     saw_done = true;
                     break;
                 }
-                UnifiedStreamEvent::ContentDelta(delta) => {
-                    if !delta.trim().is_empty() {
-                        saw_payload_event = true;
-                    }
+                UnifiedStreamEvent::ContentDelta(delta)
+                | UnifiedStreamEvent::ReasoningDelta(delta)
+                    if !delta.trim().is_empty() =>
+                {
+                    saw_payload_event = true;
                 }
-                UnifiedStreamEvent::ReasoningDelta(delta) => {
-                    if !delta.trim().is_empty() {
-                        saw_payload_event = true;
-                    }
-                }
-                UnifiedStreamEvent::ReasoningDetailsDelta(details) => {
-                    if !details.is_empty() {
-                        saw_payload_event = true;
-                    }
+                UnifiedStreamEvent::ReasoningDetailsDelta(details) if !details.is_empty() => {
+                    saw_payload_event = true;
                 }
                 UnifiedStreamEvent::ToolDelta(_) => {
                     saw_payload_event = true;

--- a/tests/integration/responses.rs
+++ b/tests/integration/responses.rs
@@ -245,20 +245,14 @@ async fn test_stream_response_unified_done_semantics() -> Result<(), OpenRouterE
                     saw_done = true;
                     break;
                 }
-                UnifiedStreamEvent::ContentDelta(delta) => {
-                    if !delta.trim().is_empty() {
-                        saw_payload_event = true;
-                    }
+                UnifiedStreamEvent::ContentDelta(delta)
+                | UnifiedStreamEvent::ReasoningDelta(delta)
+                    if !delta.trim().is_empty() =>
+                {
+                    saw_payload_event = true;
                 }
-                UnifiedStreamEvent::ReasoningDelta(delta) => {
-                    if !delta.trim().is_empty() {
-                        saw_payload_event = true;
-                    }
-                }
-                UnifiedStreamEvent::ReasoningDetailsDelta(details) => {
-                    if !details.is_empty() {
-                        saw_payload_event = true;
-                    }
+                UnifiedStreamEvent::ReasoningDetailsDelta(details) if !details.is_empty() => {
+                    saw_payload_event = true;
                 }
                 UnifiedStreamEvent::ToolDelta(_) => {
                     saw_payload_event = true;


### PR DESCRIPTION
## Summary
- Collapse nested payload-empty checks into guarded match arms in unified stream integration tests.
- Fixes the CI stable clippy failure introduced after #206 was merged.

## Test Plan
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] just quality-ci