### PR TITLE
feat: accept audio transcription OpenAPI drift

### DIFF
--- a/.github/ISSUE_TEMPLATE/upstream-compatibility-update.md
+++ b/.github/ISSUE_TEMPLATE/upstream-compatibility-update.md
@@ -11,7 +11,7 @@ Briefly describe the upstream change and why it matters for `openrouter-rs`.
 
 ## Trigger
 
-- [ ] Nightly OpenAPI drift report
+- [ ] Weekly OpenAPI drift report
 - [ ] Upstream docs or release note
 - [ ] Live contract or integration behavior difference
 - [ ] User report

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -2,7 +2,7 @@ name: OpenAPI Drift
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -76,7 +76,7 @@ jobs:
               'Detected actionable upstream OpenAPI drift against the tracked baseline.',
               '',
               '## Trigger',
-              '- Source: nightly OpenAPI drift workflow',
+              '- Source: weekly OpenAPI drift workflow',
               `- Workflow run: ${runUrl}`,
               '',
               '## Expected Repo Follow-Up',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added typed SDK support for `POST /audio/transcriptions`, including `api::audio::{TranscriptionRequest, TranscriptionInputAudio, TranscriptionResponse}` and the canonical `client.audio().transcriptions().create(...)` surface.
 - Added typed OpenRouter chat-completion usage cost fields via `ResponseUsage::cost`, `ResponseUsage::cost_details`, `ResponseUsage::is_byok`, and `ResponseCostDetails`.
 - Added ergonomic constructors for non-exhaustive helper types such as `ResponseUsage::new`, `ToolCall::new`, `FunctionCall::new`, `JsonSchemaConfig::new`, embedding multimodal parts, and provider-options wrappers.
 
 ### Changed
 - Breaking (0.10.0 target): Marked high-churn public SDK request, response, metadata, usage, pricing, discovery, streaming, and upstream taxonomy types as `#[non_exhaustive]`; construct affected request/configuration types through builders, constructors, or helpers, and include wildcard arms when matching affected public enums outside the crate.
 - Accepted the 2026-04-29 OpenAPI drift review, including `stt` generation origins and chat usage cost metadata, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
+- Accepted the 2026-05-03 OpenAPI drift review, including audio transcription support, and restored the repository snapshot to `52 / 52` official OpenAPI endpoint coverage.
+- Changed the scheduled OpenAPI drift workflow from daily to weekly while keeping manual `workflow_dispatch` runs available.
 
 ## [0.9.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 </div>
 
-`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `51 / 51` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `52 / 52` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
-- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
+- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
 - Typed request/response models with builder-style ergonomics
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
-- Discovery, rerank, audio speech, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Discovery, rerank, audio speech/transcription, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -103,6 +103,7 @@ The canonical public surface is domain-oriented:
 | `messages()` | `create`, `stream`, `stream_unified` | `/messages` | API key |
 | `rerank()` | `create` | `/rerank` | API key |
 | `audio().speech()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
+| `audio().transcriptions()` | `create` | `/audio/transcriptions` | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/endpoints/zdr`, `/embeddings*` | API key |
 | `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
@@ -122,7 +123,7 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 `openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:
 
 - chat completions, responses, and Anthropic-compatible messages
-- rerank, audio speech generation, and video generation polling/content retrieval
+- rerank, audio speech generation, audio transcription, and video generation polling/content retrieval
 - unified streaming across chat, responses, and messages
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
@@ -163,6 +164,7 @@ The repo includes runnable examples for the highest-value workflows:
 | [`examples/create_message.rs`](examples/create_message.rs) | `messages()` create |
 | [`examples/create_rerank.rs`](examples/create_rerank.rs) | `rerank().create(...)` |
 | [`examples/create_speech.rs`](examples/create_speech.rs) | `audio().speech().create(...)` |
+| [`examples/create_transcription.rs`](examples/create_transcription.rs) | `audio().transcriptions().create(...)` |
 | [`examples/create_video_generation.rs`](examples/create_video_generation.rs) | `videos().create(...)` |
 | [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
 | [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
@@ -185,6 +187,7 @@ cargo run --example create_response
 cargo run --example create_message
 cargo run --example create_rerank
 cargo run --example create_speech
+cargo run --example create_transcription
 cargo run --example create_embedding
 ```
 
@@ -212,7 +215,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`51 / 51`)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`52 / 52`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the planned `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
@@ -306,7 +309,7 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 ### Operations, Validation, And Distribution
 
 - [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md) for endpoint-by-endpoint implementation and test status
-- [`docs/operations/openapi-drift-reporting.md`](docs/operations/openapi-drift-reporting.md) for nightly upstream-spec drift detection and baseline refresh workflow
+- [`docs/operations/openapi-drift-reporting.md`](docs/operations/openapi-drift-reporting.md) for weekly upstream-spec drift detection and baseline refresh workflow
 - [`docs/operations/cli-automation-workflows.md`](docs/operations/cli-automation-workflows.md) for JSON-first shell and CI recipes built around `openrouter-cli`
 - [`tests/integration/README.md`](tests/integration/README.md) for live test pools and env switches
 - [`docs/community/awesome-openrouter/README.md`](docs/community/awesome-openrouter/README.md) for the Awesome OpenRouter submission kit and directory-safe assets

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ If you are not sure where to start, use the groups below.
 ## Operations And Validation
 
 - [`operations/official-endpoint-test-matrix.md`](operations/official-endpoint-test-matrix.md) for accepted endpoint coverage and live-test status
-- [`operations/openapi-drift-reporting.md`](operations/openapi-drift-reporting.md) for the nightly upstream-spec drift workflow
+- [`operations/openapi-drift-reporting.md`](operations/openapi-drift-reporting.md) for the weekly upstream-spec drift workflow
 - [`specs/openrouter/README.md`](../specs/openrouter/README.md) for baseline, source snapshot, overlays, and generator config organization
 - [`tests/integration/README.md`](../tests/integration/README.md) for integration-test pools and environment switches
 - [`operations/cli-automation-workflows.md`](operations/cli-automation-workflows.md) for copy-paste CLI shell and CI recipes

--- a/docs/community/awesome-openrouter/README.md
+++ b/docs/community/awesome-openrouter/README.md
@@ -91,7 +91,7 @@ Use the following reviewer-facing signals in the Awesome OpenRouter PR body. Sna
 - `openrouter-cli` crate: published companion CLI with `59` downloads across its first three releases
 - Current stable SDK release is `0.8.0`, which ships on `reqwest + rustls` instead of the old `surf -> isahc -> curl` stack
 - Published API docs on docs.rs and runnable examples in-repo
-- Endpoint coverage, live test status, and nightly OpenAPI drift reporting are published in [`docs/operations/official-endpoint-test-matrix.md`](../../operations/official-endpoint-test-matrix.md) and [`docs/operations/openapi-drift-reporting.md`](../../operations/openapi-drift-reporting.md)
+- Endpoint coverage, live test status, and weekly OpenAPI drift reporting are published in [`docs/operations/official-endpoint-test-matrix.md`](../../operations/official-endpoint-test-matrix.md) and [`docs/operations/openapi-drift-reporting.md`](../../operations/openapi-drift-reporting.md)
 - Contributor, security, support, release, MSRV, and breaking-change policies are public in-repo
 
 Refresh the numbers above if submission happens materially later than this snapshot date.

--- a/docs/community/awesome-openrouter/pr-draft.md
+++ b/docs/community/awesome-openrouter/pr-draft.md
@@ -24,7 +24,7 @@ Snapshot date: `2026-04-20`
 - `openrouter-rs` on crates.io: `12,007` total downloads, `4,255` recent downloads
 - `openrouter-cli` on crates.io: published companion CLI with `59` downloads across its first three releases
 - docs.rs documentation is live and the repo includes runnable SDK and CLI examples
-- The repository publishes an endpoint matrix for accepted OpenAPI coverage and live-test status, plus nightly in-repo OpenAPI drift reporting
+- The repository publishes an endpoint matrix for accepted OpenAPI coverage and live-test status, plus weekly in-repo OpenAPI drift reporting
 
 ## Submission Links
 

--- a/docs/design/generated-core-architecture.md
+++ b/docs/design/generated-core-architecture.md
@@ -10,7 +10,7 @@ The repository already has a useful OpenAPI drift loop:
 
 - tracked baseline snapshots under `specs/openrouter/`
 - endpoint coverage review via `docs/operations/official-endpoint-test-matrix.md`
-- nightly drift reporting in `docs/operations/openapi-drift-reporting.md`
+- weekly drift reporting in `docs/operations/openapi-drift-reporting.md`
 
 That is enough to detect upstream change, but not enough to define how spec data should eventually drive implementation.
 
@@ -21,7 +21,7 @@ If the project wants to stay aligned with a spec-driven SDK direction, it needs 
 
 ## Goals
 
-- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`, and `legacy()`
+- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`, and `legacy()`
 - Introduce a generated low-level layer that can follow the upstream OpenAPI more mechanically
 - Separate drift detection inputs from generation inputs so review workflows stay useful
 - Preserve streaming, typed tools, builder ergonomics, and unified abstractions as handwritten Rust-first surfaces
@@ -48,7 +48,7 @@ Today the repository has three important realities:
 2. The tracked OpenAPI baseline is review-oriented, not generation-oriented.
 
    - `specs/openrouter/openapi-baseline.json` is intentionally seeded from the currently accepted endpoint matrix
-   - that baseline is useful for nightly drift and coverage review
+   - that baseline is useful for weekly drift and coverage review
    - it is not a good long-term source of truth for generation because it can intentionally lag full upstream coverage
 
 3. The hardest SDK behavior is not plain request serialization.
@@ -93,7 +93,7 @@ specs/openrouter/
 
 Meaning:
 
-- `openapi-baseline.json` and `openapi-baseline.operations.json` stay drift-focused and continue to back nightly detection
+- `openapi-baseline.json` and `openapi-baseline.operations.json` stay drift-focused and continue to back weekly detection
 - `source/openapi.json` becomes the accepted full upstream snapshot used for generation work
 - `overlays/*.yaml` carries repo-reviewed adjustments needed for generation, naming, or schema quirks
 - `generator/config.yaml` describes generator inputs, output paths, and reproducibility settings

--- a/docs/design/http-transport-migration.md
+++ b/docs/design/http-transport-migration.md
@@ -30,7 +30,7 @@ The key issue is not that every layer is dead. The issue is that the public SDK 
 
 - Remove the default dependency chain on runtime `libcurl` / `curl`
 - Move the SDK onto a Tokio-native and actively maintained client stack
-- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`, and `legacy()`
+- Keep the canonical public API domain-oriented: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`, and `legacy()`
 - Preserve current behavior for JSON requests, auth headers, query encoding, and SSE streaming
 - Reduce coupling between public error types and a specific HTTP client implementation
 - Make the migration reviewable in a small number of focused PRs instead of one rewrite

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,15 +1,15 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-04-29
+Snapshot date: 2026-05-03
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
-Nightly drift workflow: `.github/workflows/openapi-drift.yml`
+Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `51` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `51 / 51` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 51` endpoints currently exercised.
+- Official OpenAPI endpoints: `52` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `52 / 52` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 52` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
@@ -23,11 +23,12 @@ Drift review note:
 - Upstream added `response_cache_source_id` to generation metadata, workspace I/O logging key filters and sampling rate fields, and `callback_url` for video generation requests. The SDK now exposes those typed fields, and the 2026-04-28 baseline refresh keeps the accepted endpoint snapshot at `51 / 51`.
 - Upstream refreshed web-search, provider, and Responses output schemas. Existing OpenRouter plugin passthrough, Anthropic hosted-tool extras, provider option maps, and Responses `Value` payloads carry those schema details without a public API migration.
 - Upstream added `stt` as a generation origin and chat-completion usage cost metadata. `GenerationData::origin` remains a flexible `String`, and `ResponseUsage` now exposes typed `cost`, `cost_details`, and `is_byok` fields. The 2026-04-29 baseline refresh keeps the accepted endpoint snapshot at `51 / 51`.
+- Upstream added `POST /audio/transcriptions`. The SDK now exposes a typed transcription surface, and the 2026-05-03 baseline refresh keeps the accepted endpoint snapshot at `52 / 52`.
 
 Legend:
 
 - `SDK`: endpoint implemented in `openrouter-rs`.
-- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
+- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
 - `Unit`: unit coverage depth.
   - `Path` = test asserts HTTP method/path (often with header/body checks).
   - `Contract` = serde/request-shape/parser coverage only.
@@ -81,6 +82,7 @@ Legend:
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
 | `POST /audio/speech` | `client.audio().speech().create(...)` | Yes | Path | No | P1 |
+| `POST /audio/transcriptions` | `client.audio().transcriptions().create(...)` | Yes | Path | No | P1 |
 | `POST /videos` | `client.videos().create(...)` | Yes | Path | No | P2 |
 | `POST /workspaces` | `client.management().create_workspace(...)` | Yes | Path | No | P1 |
 | `POST /workspaces/{id}/members/add` | `client.management().add_workspace_members(...)` | Yes | Path | No | P1 |
@@ -105,7 +107,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity`.
 3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
-4. P1/P2: add low-cost live or smoke coverage for `/audio/speech` and `/videos*` once stable fixtures and cost controls are defined.
+4. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, and `/videos*` once stable fixtures and cost controls are defined.
 5. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
 
 ## Reproduce Snapshot

--- a/docs/operations/openapi-drift-reporting.md
+++ b/docs/operations/openapi-drift-reporting.md
@@ -1,6 +1,6 @@
 # OpenAPI Drift Reporting
 
-`openrouter-rs` tracks a checked-in OpenRouter OpenAPI baseline and compares it against the latest upstream spec on a nightly schedule.
+`openrouter-rs` tracks a checked-in OpenRouter OpenAPI baseline and compares it against the latest upstream spec on a weekly schedule.
 
 ## Why This Exists
 
@@ -17,7 +17,7 @@ This keeps `openrouter-rs` aligned with upstream changes without blocking releas
 
 - Tracked baseline snapshot: `specs/openrouter/openapi-baseline.json`
 - Normalized operation snapshot: `specs/openrouter/openapi-baseline.operations.json`
-- Nightly workflow: `.github/workflows/openapi-drift.yml`
+- Weekly workflow: `.github/workflows/openapi-drift.yml`
 
 The comparison is operation-level (`METHOD /path`). It first resolves local `#/components/...`
 references, including referenced Path Item objects, then folds in effective defaults before hashing:
@@ -57,7 +57,7 @@ This lets the report separate:
 - changed operations that are already covered by the repo's existing handling
 - changed operations that still need SDK/docs/test follow-up
 
-This keeps the nightly issue useful when upstream bulk-edits supported metadata or dynamic taxonomy
+This keeps the weekly issue useful when upstream bulk-edits supported metadata or dynamic taxonomy
 schemas across many operations without hiding the underlying OpenAPI drift artifacts.
 
 The initial tracked baseline is intentionally seeded from the accepted endpoint matrix rather
@@ -79,7 +79,7 @@ This writes a report to:
 - `/tmp/openrouter-openapi-latest.operations.json`
 
 The compare command also emits both `has_drift` and `has_actionable_drift` when GitHub Actions
-passes a `GITHUB_OUTPUT` file. The nightly workflow keeps uploading the full raw drift artifacts,
+passes a `GITHUB_OUTPUT` file. The weekly workflow keeps uploading the full raw drift artifacts,
 but it only opens or refreshes the follow-up issue when `has_actionable_drift=true`.
 
 Refresh the tracked baseline after reviewing and accepting upstream changes:
@@ -95,7 +95,7 @@ That updates:
 
 ## Follow-Up Flow
 
-When the nightly workflow reports actionable drift:
+When the weekly workflow reports actionable drift:
 
 1. Keep the generated issue open as the active compatibility-update record.
 2. Review the generated report and candidate operations snapshot artifact.

--- a/docs/policies/compatibility-update-policy.md
+++ b/docs/policies/compatibility-update-policy.md
@@ -5,7 +5,7 @@ This document defines how `openrouter-rs` records upstream OpenRouter compatibil
 It complements:
 
 - [`docs/policies/maintenance-policy.md`](maintenance-policy.md) for release, MSRV, and breaking-change rules
-- [`docs/operations/openapi-drift-reporting.md`](../operations/openapi-drift-reporting.md) for nightly spec-drift detection
+- [`docs/operations/openapi-drift-reporting.md`](../operations/openapi-drift-reporting.md) for weekly spec-drift detection
 - [`CHANGELOG.md`](../../CHANGELOG.md) and [`MIGRATION.md`](../../MIGRATION.md) for durable user-facing notes
 
 The goal is to keep upstream-alignment reporting predictable without creating a heavy editorial workflow.
@@ -41,7 +41,7 @@ Compatibility updates use different surfaces for different jobs:
 | [`CHANGELOG.md`](../../CHANGELOG.md) | Durable user-facing summary of accepted compatibility-affecting repo changes | In the same PR that lands a user-visible SDK/docs/test/support change |
 | [`MIGRATION.md`](../../MIGRATION.md) | Durable upgrade guidance | When canonical usage, public API names, compatibility bridges, required config, or migration steps changed |
 | [`docs/operations/official-endpoint-test-matrix.md`](../operations/official-endpoint-test-matrix.md) | Current implementation and live-test status by operation | When the accepted upstream operation surface changed or support status changed |
-| [`docs/operations/openapi-drift-reporting.md`](../operations/openapi-drift-reporting.md) | Detection workflow and baseline refresh rules | When the nightly detection/reporting mechanics change |
+| [`docs/operations/openapi-drift-reporting.md`](../operations/openapi-drift-reporting.md) | Detection workflow and baseline refresh rules | When the weekly detection/reporting mechanics change |
 
 This repository does not maintain a separate compatibility newsletter or a second standalone changelog.
 
@@ -53,7 +53,7 @@ The cadence is intentionally small and event-driven:
 
 | Cadence | Trigger | Expected output |
 | --- | --- | --- |
-| Nightly | Upstream OpenAPI drift check | Report artifact every run; auto-opened or refreshed issue only when repo-aware classification marks the drift as actionable |
+| Weekly | Upstream OpenAPI drift check | Report artifact every run; auto-opened or refreshed issue only when repo-aware classification marks the drift as actionable |
 | As needed | Non-spec upstream change noticed by maintainers, tests, or users | Manual compatibility update issue using the reusable template |
 | Same PR as acceptance | Repo accepts the change and updates code/docs/tests/baseline | `CHANGELOG.md`, `MIGRATION.md`, endpoint matrix, or baseline refresh updated in the same PR as needed |
 | Next release cut | A version is published | Release notes summarize already-landed compatibility updates; release notes do not replace the earlier docs updates |
@@ -79,7 +79,7 @@ When no migration path is required, do not force `MIGRATION.md` churn. The thres
 
 ## Reusable Template
 
-Use [`.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`](../../.github/ISSUE_TEMPLATE/upstream-compatibility-update.md) for manual reports and for follow-up issues derived from the nightly drift workflow.
+Use [`.github/ISSUE_TEMPLATE/upstream-compatibility-update.md`](../../.github/ISSUE_TEMPLATE/upstream-compatibility-update.md) for manual reports and for follow-up issues derived from the weekly drift workflow.
 
 The template deliberately asks for:
 
@@ -89,4 +89,4 @@ The template deliberately asks for:
 - the user impact
 - linked implementation work
 
-That keeps compatibility updates consistent whether they originate from the nightly drift bot, a live contract failure, or a maintainer noticing an upstream change in docs/releases.
+That keeps compatibility updates consistent whether they originate from the weekly drift bot, a live contract failure, or a maintainer noticing an upstream change in docs/releases.

--- a/examples/create_transcription.rs
+++ b/examples/create_transcription.rs
@@ -1,0 +1,39 @@
+use openrouter_rs::{
+    OpenRouterClient,
+    api::audio::{TranscriptionInputAudio, TranscriptionRequest},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = OpenRouterClient::builder()
+        .api_key(std::env::var("OPENROUTER_API_KEY")?)
+        .build()?;
+
+    let audio_data = std::env::var("OPENROUTER_TRANSCRIPTION_AUDIO_BASE64")
+        .expect("set OPENROUTER_TRANSCRIPTION_AUDIO_BASE64 to raw base64 audio bytes");
+    let audio_format =
+        std::env::var("OPENROUTER_TRANSCRIPTION_AUDIO_FORMAT").unwrap_or_else(|_| "wav".into());
+    let model = std::env::var("OPENROUTER_TRANSCRIPTION_MODEL")
+        .unwrap_or_else(|_| "openai/whisper-large-v3".into());
+
+    let mut request = TranscriptionRequest::builder();
+    request
+        .model(model)
+        .input_audio(TranscriptionInputAudio::new(audio_data, audio_format));
+    if let Ok(language) = std::env::var("OPENROUTER_TRANSCRIPTION_LANGUAGE") {
+        request.language(language);
+    }
+
+    let response = client
+        .audio()
+        .transcriptions()
+        .create(&request.build()?)
+        .await?;
+
+    println!("{}", response.text);
+    if let Some(usage) = response.usage {
+        println!("usage: {:?}", usage);
+    }
+
+    Ok(())
+}

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -15382,6 +15382,7 @@
       "OutputWebFetchServerToolItem": {
         "description": "An openrouter:web_fetch server tool output item",
         "example": {
+          "httpStatus": 200,
           "id": "wf_tmp_abc123",
           "status": "completed",
           "title": "Example Domain",
@@ -15391,6 +15392,14 @@
         "properties": {
           "content": {
             "type": "string"
+          },
+          "error": {
+            "description": "The error message if the fetch failed.",
+            "type": "string"
+          },
+          "httpStatus": {
+            "description": "The HTTP status code returned by the upstream URL fetch.",
+            "type": "integer"
           },
           "id": {
             "type": "string"
@@ -15436,11 +15445,55 @@
       "OutputWebSearchServerToolItem": {
         "description": "An openrouter:web_search server tool output item",
         "example": {
+          "action": {
+            "query": "latest AI news",
+            "type": "search"
+          },
           "id": "ws_tmp_abc123",
           "status": "completed",
           "type": "openrouter:web_search"
         },
         "properties": {
+          "action": {
+            "description": "The search action performed, matching OpenAI web_search_call.action shape. Includes the query the model issued and optional source URLs returned by the search provider.",
+            "properties": {
+              "query": {
+                "type": "string"
+              },
+              "sources": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "url"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "url"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "type": {
+                "enum": [
+                  "search"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "query"
+            ],
+            "type": "object"
+          },
           "id": {
             "type": "string"
           },
@@ -16017,6 +16070,671 @@
         "example": "OpenAI",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "ProviderOptions": {
+        "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
+        "example": {
+          "openai": {
+            "max_tokens": 1000
+          }
+        },
+        "properties": {
+          "01ai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "ai21": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "aion-labs": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "akashml": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "alibaba": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "amazon-bedrock": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "amazon-nova": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "ambient": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "anthropic": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "anyscale": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "arcee-ai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "atlas-cloud": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "atoma": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "avian": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "azure": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "baidu": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "baseten": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "black-forest-labs": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "byteplus": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "centml": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "cerebras": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "chutes": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "cirrascale": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "clarifai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "cloudflare": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "cohere": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "crofai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "crusoe": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "deepinfra": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "deepseek": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "dekallm": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "enfer": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "fake-provider": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "featherless": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "fireworks": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "friendli": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "gmicloud": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "google-ai-studio": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "google-vertex": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "gopomelo": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "groq": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "huggingface": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "hyperbolic": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "hyperbolic-quantized": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "inception": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "inceptron": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "inference-net": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "infermatic": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "inflection": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "inocloud": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "io-net": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "ionstream": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "klusterai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "lambda": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "lepton": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "liquid": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "lynn": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "lynn-private": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "mancer": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "mancer-old": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "mara": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "meta": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "minimax": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "mistral": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "modal": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "modelrun": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "modular": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "moonshotai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "morph": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "ncompass": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "nebius": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "nex-agi": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "nextbit": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "nineteen": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "novita": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "nvidia": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "octoai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "open-inference": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "openai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "parasail": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "perplexity": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "phala": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "poolside": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "recraft": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "recursal": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "reflection": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "reka": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "relace": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "replicate": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "sambanova": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "sambanova-cloaked": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "seed": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "sf-compute": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "siliconflow": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "sourceful": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "stealth": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "stepfun": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "streamlake": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "switchpoint": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "targon": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "together": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "together-lite": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "ubicloud": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "upstage": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "venice": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "wandb": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "xai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "xiaomi": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "z-ai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
       },
       "ProviderOverloadedResponse": {
         "description": "Provider Overloaded - Provider is temporarily overloaded",
@@ -17909,6 +18627,141 @@
         },
         "type": "object"
       },
+      "STTInputAudio": {
+        "description": "Base64-encoded audio to transcribe",
+        "example": {
+          "data": "UklGRiQA...",
+          "format": "wav"
+        },
+        "properties": {
+          "data": {
+            "description": "Base64-encoded audio data (raw bytes, not a data URI)",
+            "type": "string"
+          },
+          "format": {
+            "description": "Audio format (e.g., wav, mp3, flac, m4a, ogg, webm, aac). Supported formats vary by provider.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "format"
+        ],
+        "type": "object"
+      },
+      "STTRequest": {
+        "description": "Speech-to-text request input. Accepts a JSON body with input_audio containing base64-encoded audio.",
+        "example": {
+          "input_audio": {
+            "data": "UklGRiQA...",
+            "format": "wav"
+          },
+          "language": "en",
+          "model": "openai/whisper-large-v3"
+        },
+        "properties": {
+          "input_audio": {
+            "$ref": "#/components/schemas/STTInputAudio"
+          },
+          "language": {
+            "description": "ISO-639-1 language code (e.g., \"en\", \"ja\"). Auto-detected if omitted.",
+            "example": "en",
+            "type": "string"
+          },
+          "model": {
+            "description": "STT model identifier",
+            "example": "openai/whisper-large-v3",
+            "type": "string"
+          },
+          "provider": {
+            "description": "Provider-specific passthrough configuration",
+            "properties": {
+              "options": {
+                "$ref": "#/components/schemas/ProviderOptions"
+              }
+            },
+            "type": "object"
+          },
+          "temperature": {
+            "description": "Sampling temperature for transcription",
+            "example": 0,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "model",
+          "input_audio"
+        ],
+        "type": "object"
+      },
+      "STTResponse": {
+        "description": "STT response containing transcribed text and optional usage statistics",
+        "example": {
+          "text": "Hello, this is a test of OpenAI speech-to-text transcription.",
+          "usage": {
+            "cost": 0.000508,
+            "input_tokens": 83,
+            "output_tokens": 30,
+            "seconds": 9.2,
+            "total_tokens": 113
+          }
+        },
+        "properties": {
+          "text": {
+            "description": "The transcribed text",
+            "example": "Hello, this is a test of OpenAI speech-to-text transcription. The weather is sunny today and the temperature is around 72 degrees.",
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/STTUsage"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "STTUsage": {
+        "description": "Aggregated usage statistics for the request",
+        "example": {
+          "cost": 0.000508,
+          "input_tokens": 83,
+          "output_tokens": 30,
+          "seconds": 9.2,
+          "total_tokens": 113
+        },
+        "properties": {
+          "cost": {
+            "description": "Total cost of the request in USD",
+            "example": 0.000508,
+            "format": "double",
+            "type": "number"
+          },
+          "input_tokens": {
+            "description": "Number of input tokens billed for this request",
+            "example": 83,
+            "type": "integer"
+          },
+          "output_tokens": {
+            "description": "Number of output tokens generated",
+            "example": 30,
+            "type": "integer"
+          },
+          "seconds": {
+            "description": "Duration of the input audio in seconds",
+            "example": 9.2,
+            "format": "double",
+            "type": "number"
+          },
+          "total_tokens": {
+            "description": "Total number of tokens used (input + output)",
+            "example": 113,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "SearchContextSizeEnum": {
         "description": "Size of the search context for web search tools",
         "enum": [
@@ -18050,664 +18903,7 @@
             "description": "Provider-specific passthrough configuration",
             "properties": {
               "options": {
-                "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
-                "properties": {
-                  "01ai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ai21": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "aion-labs": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "akashml": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "alibaba": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "amazon-bedrock": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "amazon-nova": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ambient": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "anthropic": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "anyscale": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "arcee-ai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "atlas-cloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "atoma": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "avian": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "azure": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "baidu": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "baseten": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "black-forest-labs": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "byteplus": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "centml": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cerebras": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "chutes": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cirrascale": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "clarifai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cloudflare": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cohere": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "crofai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "crusoe": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "deepinfra": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "deepseek": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "dekallm": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "enfer": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "fake-provider": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "featherless": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "fireworks": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "friendli": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "gmicloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "google-ai-studio": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "google-vertex": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "gopomelo": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "groq": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "huggingface": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "hyperbolic": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "hyperbolic-quantized": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inception": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inceptron": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inference-net": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "infermatic": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inflection": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inocloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "io-net": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ionstream": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "klusterai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lambda": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lepton": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "liquid": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lynn": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lynn-private": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mancer": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mancer-old": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mara": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "meta": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "minimax": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mistral": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "modal": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "modelrun": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "modular": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "moonshotai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "morph": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ncompass": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nebius": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nex-agi": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nextbit": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nineteen": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "novita": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nvidia": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "octoai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "open-inference": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "openai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "parasail": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "perplexity": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "phala": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "poolside": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "recraft": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "recursal": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "reflection": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "reka": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "relace": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "replicate": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sambanova": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sambanova-cloaked": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "seed": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sf-compute": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "siliconflow": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sourceful": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "stealth": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "stepfun": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "streamlake": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "switchpoint": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "targon": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "together": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "together-lite": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ubicloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "upstage": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "venice": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "wandb": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "xai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "xiaomi": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "z-ai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  }
-                },
-                "type": "object"
+                "$ref": "#/components/schemas/ProviderOptions"
               }
             },
             "type": "object"
@@ -19963,671 +20159,20 @@
             "description": "Provider-specific passthrough configuration",
             "properties": {
               "options": {
-                "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
-                "example": {
-                  "google-vertex": {
-                    "output_config": {
-                      "effort": "low"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProviderOptions"
+                  },
+                  {
+                    "example": {
+                      "google-vertex": {
+                        "output_config": {
+                          "effort": "low"
+                        }
+                      }
                     }
                   }
-                },
-                "properties": {
-                  "01ai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ai21": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "aion-labs": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "akashml": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "alibaba": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "amazon-bedrock": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "amazon-nova": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ambient": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "anthropic": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "anyscale": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "arcee-ai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "atlas-cloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "atoma": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "avian": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "azure": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "baidu": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "baseten": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "black-forest-labs": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "byteplus": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "centml": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cerebras": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "chutes": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cirrascale": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "clarifai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cloudflare": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "cohere": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "crofai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "crusoe": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "deepinfra": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "deepseek": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "dekallm": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "enfer": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "fake-provider": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "featherless": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "fireworks": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "friendli": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "gmicloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "google-ai-studio": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "google-vertex": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "gopomelo": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "groq": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "huggingface": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "hyperbolic": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "hyperbolic-quantized": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inception": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inceptron": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inference-net": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "infermatic": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inflection": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "inocloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "io-net": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ionstream": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "klusterai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lambda": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lepton": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "liquid": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lynn": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "lynn-private": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mancer": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mancer-old": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mara": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "meta": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "minimax": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "mistral": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "modal": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "modelrun": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "modular": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "moonshotai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "morph": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ncompass": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nebius": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nex-agi": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nextbit": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nineteen": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "novita": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "nvidia": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "octoai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "open-inference": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "openai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "parasail": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "perplexity": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "phala": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "poolside": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "recraft": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "recursal": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "reflection": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "reka": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "relace": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "replicate": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sambanova": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sambanova-cloaked": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "seed": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sf-compute": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "siliconflow": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "sourceful": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "stealth": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "stepfun": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "streamlake": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "switchpoint": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "targon": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "together": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "together-lite": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "ubicloud": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "upstage": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "venice": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "wandb": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "xai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "xiaomi": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  },
-                  "z-ai": {
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "type": "object"
-                  }
-                },
-                "type": "object"
+                ]
               }
             },
             "type": "object"
@@ -22022,6 +21567,217 @@
           "TTS"
         ],
         "x-speakeasy-name-override": "createSpeech"
+      }
+    },
+    "/audio/transcriptions": {
+      "post": {
+        "description": "Transcribes audio into text",
+        "operationId": "createAudioTranscriptions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "input_audio": {
+                  "data": "UklGRiQA...",
+                  "format": "wav"
+                },
+                "language": "en",
+                "model": "openai/whisper-large-v3"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/STTRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "text": "Hello, this is a test of OpenAI speech-to-text transcription.",
+                  "usage": {
+                    "cost": 0.000508,
+                    "input_tokens": 83,
+                    "output_tokens": 30,
+                    "seconds": 9.2,
+                    "total_tokens": 113
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/STTResponse"
+                }
+              }
+            },
+            "description": "Transcription result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Create transcription",
+        "tags": [
+          "STT"
+        ],
+        "x-speakeasy-name-override": "createTranscription"
       }
     },
     "/auth/keys": {
@@ -31132,6 +30888,10 @@
     {
       "description": "Rerank endpoints",
       "name": "Rerank"
+    },
+    {
+      "description": "Speech-to-text endpoints",
+      "name": "STT"
     },
     {
       "description": "Text-to-speech endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-04-29T07:05:54+00:00",
+  "captured_at": "2026-05-03T15:20:20+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,7 +14,7 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 51,
+  "operation_count": 52,
   "operations": [
     {
       "deprecated": false,
@@ -381,6 +381,17 @@
     },
     {
       "deprecated": false,
+      "fingerprint": "3e769b982b15ba24",
+      "id": "POST /audio/transcriptions",
+      "method": "POST",
+      "operation_id": "createAudioTranscriptions",
+      "path": "/audio/transcriptions",
+      "tags": [
+        "STT"
+      ]
+    },
+    {
+      "deprecated": false,
       "fingerprint": "350024ac1009cddb",
       "id": "POST /auth/keys",
       "method": "POST",
@@ -524,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4c2837ade6b8b03b",
+      "fingerprint": "e380a2d857603c15",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -535,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3002492824810c79",
+      "fingerprint": "f40410acf2aa121e",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",

--- a/src/api/audio.rs
+++ b/src/api/audio.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 const OFFICIAL_SPEECH_PATH: &str = "/audio/speech";
+const TRANSCRIPTIONS_PATH: &str = "/audio/transcriptions";
 const LEGACY_TTS_PATH: &str = "/tts";
 
 /// Supported audio output formats for `POST /audio/speech`.
@@ -63,6 +64,96 @@ impl SpeechRequest {
     pub fn builder() -> SpeechRequestBuilder {
         SpeechRequestBuilder::default()
     }
+}
+
+/// Base64-encoded audio input for `POST /audio/transcriptions`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct TranscriptionInputAudio {
+    #[builder(setter(into))]
+    pub data: String,
+    #[builder(setter(into))]
+    pub format: String,
+}
+
+impl TranscriptionInputAudio {
+    pub fn builder() -> TranscriptionInputAudioBuilder {
+        TranscriptionInputAudioBuilder::default()
+    }
+
+    pub fn new(data: impl Into<String>, format: impl Into<String>) -> Self {
+        Self {
+            data: data.into(),
+            format: format.into(),
+        }
+    }
+}
+
+/// Provider-specific passthrough options for transcription requests.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct TranscriptionProviderOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl TranscriptionProviderOptions {
+    pub fn new(options: HashMap<String, serde_json::Value>) -> Self {
+        Self {
+            options: Some(options),
+        }
+    }
+}
+
+/// Request payload for `POST /audio/transcriptions`.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+pub struct TranscriptionRequest {
+    #[builder(setter(into))]
+    pub model: String,
+    pub input_audio: TranscriptionInputAudio,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<TranscriptionProviderOptions>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+}
+
+impl TranscriptionRequest {
+    pub fn builder() -> TranscriptionRequestBuilder {
+        TranscriptionRequestBuilder::default()
+    }
+}
+
+/// Response payload from `POST /audio/transcriptions`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct TranscriptionResponse {
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TranscriptionUsage>,
+}
+
+/// Usage metadata for audio transcription requests.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct TranscriptionUsage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seconds: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_tokens: Option<u64>,
 }
 
 /// Submit a speech request and return raw audio bytes.
@@ -134,6 +225,57 @@ pub(crate) async fn create_speech_with_client(
     }
 
     Err(official_error)
+}
+
+/// Submit an audio transcription request.
+pub async fn create_transcription(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &TranscriptionRequest,
+) -> Result<TranscriptionResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_transcription_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_transcription_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &TranscriptionRequest,
+) -> Result<TranscriptionResponse, OpenRouterError> {
+    let url = format!("{base_url}{TRANSCRIPTIONS_PATH}");
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+    )?
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "audio transcription").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
 }
 
 async fn send_speech_request(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,7 +9,7 @@
 //! - `client.responses()` -> [`responses`]
 //! - `client.messages()` -> [`messages`]
 //! - `client.rerank()` -> [`rerank`]
-//! - `client.audio().speech()` -> [`audio`]
+//! - `client.audio().speech()` / `client.audio().transcriptions()` -> [`audio`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
 //! - `client.management()` -> [`api_keys`], [`auth`], [`credits`], [`generation`], [`guardrails`], [`organization`], [`workspaces`]
@@ -21,7 +21,7 @@
 //! - Responses API
 //! - Anthropic-compatible Messages API
 //! - rerank
-//! - audio speech generation
+//! - audio speech generation and transcription
 //! - video generation and polling
 //! - model discovery, providers, user model filters, model counts, and ZDR endpoints
 //! - embeddings

--- a/src/client.rs
+++ b/src/client.rs
@@ -1134,6 +1134,27 @@ impl OpenRouterClient {
         }
     }
 
+    /// Submit an audio transcription request.
+    pub async fn create_transcription(
+        &self,
+        request: &audio::TranscriptionRequest,
+    ) -> Result<audio::TranscriptionResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            audio::create_transcription_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                &self.x_title,
+                &self.http_referer,
+                &self.app_categories,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Submit a text-to-speech request and return raw audio bytes.
     #[deprecated(note = "use create_speech")]
     pub async fn create_tts(
@@ -1884,6 +1905,13 @@ impl<'a> AudioClient<'a> {
             client: self.client,
         }
     }
+
+    /// Domain client for audio transcription operations.
+    pub fn transcriptions(&self) -> TranscriptionsClient<'a> {
+        TranscriptionsClient {
+            client: self.client,
+        }
+    }
 }
 
 /// Domain client for audio speech endpoints.
@@ -1901,6 +1929,22 @@ impl<'a> SpeechClient<'a> {
 
 #[deprecated(note = "use SpeechClient")]
 pub type TtsClient<'a> = SpeechClient<'a>;
+
+/// Domain client for audio transcription endpoints.
+#[derive(Debug, Clone, Copy)]
+pub struct TranscriptionsClient<'a> {
+    client: &'a OpenRouterClient,
+}
+
+impl<'a> TranscriptionsClient<'a> {
+    /// Create an audio transcription (`POST /audio/transcriptions`).
+    pub async fn create(
+        &self,
+        request: &audio::TranscriptionRequest,
+    ) -> Result<audio::TranscriptionResponse, OpenRouterError> {
+        self.client.create_transcription(request).await
+    }
+}
 
 /// Domain client for video generation endpoints.
 #[derive(Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # OpenRouter Rust SDK
 //!
 //! `openrouter-rs` is a type-safe, async Rust SDK for the [OpenRouter API](https://openrouter.ai/),
-//! providing typed access to chat, responses, messages, rerank, audio speech, video generation,
+//! providing typed access to chat, responses, messages, rerank, audio speech/transcription, video generation,
 //! discovery, embeddings, and management endpoints.
 //!
 //! ## ✨ Key Features
@@ -9,7 +9,7 @@
 //! - **🔒 Type Safety**: Leverages Rust's type system for compile-time error prevention
 //! - **⚡ Async/Await**: Built on `tokio` for high-performance async operations  
 //! - **🏗️ Builder Pattern**: Ergonomic client and request construction
-//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `videos()`, `models()`, `management()`
+//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`
 //! - **📡 Streaming Support**: Real-time response streaming with `futures`
 //! - **🧩 Unified Streaming Events**: Shared stream event model across chat/responses/messages
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
@@ -146,6 +146,7 @@
 //! | Chat Completions | ✅ | [`api::chat`] |
 //! | Rerank | ✅ | [`api::rerank`] |
 //! | Audio Speech | ✅ | [`api::audio`] |
+//! | Audio Transcription | ✅ | [`api::audio`] |
 //! | Video Generation | ✅ | [`api::videos`] |
 //! | Legacy Text Completions (`legacy-completions`) | ✅ | `api::legacy::completion` |
 //! | Model Information | ✅ | [`api::models`] |

--- a/tests/unit/audio.rs
+++ b/tests/unit/audio.rs
@@ -8,7 +8,10 @@ use std::{
 };
 
 use http::StatusCode;
-use openrouter_rs::api::audio::{self, SpeechProviderOptions, SpeechRequest, SpeechResponseFormat};
+use openrouter_rs::api::audio::{
+    self, SpeechProviderOptions, SpeechRequest, SpeechResponseFormat, TranscriptionInputAudio,
+    TranscriptionProviderOptions, TranscriptionRequest,
+};
 
 #[test]
 fn test_speech_request_serialization() {
@@ -40,6 +43,181 @@ fn test_speech_request_serialization() {
         value["provider"]["options"]["openai"]["instructions"],
         "Speak clearly"
     );
+}
+
+#[test]
+fn test_transcription_request_serialization() {
+    let mut provider_options = HashMap::new();
+    provider_options.insert(
+        "openai".to_string(),
+        serde_json::json!({
+            "prompt": "Use product names verbatim"
+        }),
+    );
+
+    let request = TranscriptionRequest::builder()
+        .model("openai/whisper-large-v3")
+        .input_audio(TranscriptionInputAudio::new("UklGRiQA...", "wav"))
+        .language("en")
+        .temperature(0.0)
+        .provider(TranscriptionProviderOptions::new(provider_options))
+        .build()
+        .expect("transcription request should build");
+
+    let value = serde_json::to_value(&request).expect("transcription request should serialize");
+    assert_eq!(value["model"], "openai/whisper-large-v3");
+    assert_eq!(value["input_audio"]["data"], "UklGRiQA...");
+    assert_eq!(value["input_audio"]["format"], "wav");
+    assert_eq!(value["language"], "en");
+    assert_eq!(value["temperature"], 0.0);
+    assert_eq!(
+        value["provider"]["options"]["openai"]["prompt"],
+        "Use product names verbatim"
+    );
+}
+
+#[tokio::test]
+async fn test_create_transcription_path_body_headers_and_response() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let (tx, rx) = mpsc::channel::<(String, String, String)>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send((request_line, request_text, body_text))
+            .expect("server should send captured request");
+
+        let response = r#"{
+            "text": "Hello from audio",
+            "usage": {
+                "cost": 0.000508,
+                "input_tokens": 83,
+                "output_tokens": 30,
+                "seconds": 9.2,
+                "total_tokens": 113
+            }
+        }"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response.len(),
+            response
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    let base_url = format!("http://{addr}/api/v1");
+    let request = TranscriptionRequest::builder()
+        .model("openai/whisper-large-v3")
+        .input_audio(TranscriptionInputAudio::new("UklGRiQA...", "wav"))
+        .language("en")
+        .build()
+        .expect("transcription request should build");
+
+    let response = audio::create_transcription(
+        &base_url,
+        "api-key",
+        &Some("openrouter-rs".to_string()),
+        &Some("https://example.com".to_string()),
+        &Some(vec!["cli-agent".to_string()]),
+        &request,
+    )
+    .await
+    .expect("transcription request should succeed");
+    assert_eq!(response.text, "Hello from audio");
+    assert_eq!(
+        response.usage.as_ref().and_then(|usage| usage.total_tokens),
+        Some(113)
+    );
+
+    let (request_line, request_text, body_text) = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(request_line, "POST /api/v1/audio/transcriptions HTTP/1.1");
+
+    let body_json: serde_json::Value =
+        serde_json::from_str(&body_text).expect("body should be valid json");
+    assert_eq!(body_json["model"], "openai/whisper-large-v3");
+    assert_eq!(body_json["input_audio"]["data"], "UklGRiQA...");
+    assert_eq!(body_json["input_audio"]["format"], "wav");
+    assert_eq!(body_json["language"], "en");
+
+    let request_lower = request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include api key, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("x-title: openrouter-rs")
+            || request_lower.contains("x-title:openrouter-rs"),
+        "x-title header should be present, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("http-referer: https://example.com")
+            || request_lower.contains("http-referer:https://example.com"),
+        "http-referer header should be present, request:\n{}",
+        request_text
+    );
+    assert!(
+        request_lower.contains("x-openrouter-categories: cli-agent")
+            || request_lower.contains("x-openrouter-categories:cli-agent"),
+        "x-openrouter-categories header should be present, request:\n{}",
+        request_text
+    );
+
+    server.join().expect("server thread should finish");
 }
 
 #[tokio::test]

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -389,6 +389,21 @@ async fn test_audio_speech_domain_requires_api_key() {
 }
 
 #[tokio::test]
+async fn test_audio_transcriptions_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let request = audio::TranscriptionRequest::builder()
+        .model("openai/whisper-large-v3")
+        .input_audio(audio::TranscriptionInputAudio::new("UklGRiQA...", "wav"))
+        .build()
+        .expect("transcription request should build");
+
+    let result = client.audio().transcriptions().create(&request).await;
+    assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
 async fn test_videos_domain_requires_api_key() {
     let client = OpenRouterClient::builder()
         .build()
@@ -838,6 +853,45 @@ async fn test_audio_speech_domain_create_delegates_to_api_module() {
     assert_eq!(body_json["input"], "Hello world");
     assert_eq!(body_json["voice"], "alloy");
     assert_eq!(body_json["response_format"], "mp3");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_audio_transcriptions_domain_create_delegates_to_api_module() {
+    let response_body = r#"{"text":"hello world","usage":{"seconds":1.5}}"#;
+    let (base_url, rx, server) = spawn_json_server(response_body);
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .build()
+        .expect("client should build");
+    let request = audio::TranscriptionRequest::builder()
+        .model("openai/whisper-large-v3")
+        .input_audio(audio::TranscriptionInputAudio::new("UklGRiQA...", "wav"))
+        .build()
+        .expect("transcription request should build");
+
+    let response = client
+        .audio()
+        .transcriptions()
+        .create(&request)
+        .await
+        .expect("transcription should succeed");
+    assert_eq!(response.text, "hello world");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/audio/transcriptions HTTP/1.1"
+    );
+
+    let body_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body_json["model"], "openai/whisper-large-v3");
+    assert_eq!(body_json["input_audio"]["format"], "wav");
 
     server.join().expect("server thread should finish");
 }


### PR DESCRIPTION
## Summary
- Add typed SDK support for POST /audio/transcriptions via api::audio transcription request/response types and client.audio().transcriptions().create(...)
- Refresh the tracked OpenAPI baseline and endpoint matrix to the current 52 / 52 upstream snapshot
- Reduce scheduled OpenAPI drift checks from daily to weekly while keeping manual workflow_dispatch runs

## Why So Many Files Changed
- The large JSON diff is the checked-in OpenAPI baseline refresh, not hand-written SDK churn
- The docs changes keep README, endpoint matrix, compatibility policy, and drift-reporting guidance aligned with the new baseline and weekly cadence
- The code/test changes are the actual public SDK surface for the new transcription endpoint

## Test Plan
- just quality
- just openapi-drift-check
- cargo check --examples
- just check-migration-docs
- cargo test --test migration_smoke --all-features

Closes #208