### PR TITLE
feat: accept latest OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `OpenRouterExperimentalMetadata` request-header opt-in for chat completions, Responses API, and Anthropic-compatible Messages requests, plus typed chat response access to `service_tier` and `openrouter_metadata`.
+- Added typed guardrail content-filter support, including built-in filter entries, custom regex filters, and provider-specific ZDR flags on guardrail create/update requests and guardrail responses.
+- Added typed `supported_voices` model discovery fields and `GenerationData::service_tier` for generation metadata responses.
 - Added typed SDK support for `POST /audio/transcriptions`, including `api::audio::{TranscriptionRequest, TranscriptionInputAudio, TranscriptionResponse}` and the canonical `client.audio().transcriptions().create(...)` surface.
 - Added typed OpenRouter chat-completion usage cost fields via `ResponseUsage::cost`, `ResponseUsage::cost_details`, `ResponseUsage::is_byok`, and `ResponseCostDetails`.
 - Added ergonomic constructors for non-exhaustive helper types such as `ResponseUsage::new`, `ToolCall::new`, `FunctionCall::new`, `JsonSchemaConfig::new`, embedding multimodal parts, and provider-options wrappers.
@@ -16,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking (0.10.0 target): Marked high-churn public SDK request, response, metadata, usage, pricing, discovery, streaming, and upstream taxonomy types as `#[non_exhaustive]`; construct affected request/configuration types through builders, constructors, or helpers, and include wildcard arms when matching affected public enums outside the crate.
 - Accepted the 2026-04-29 OpenAPI drift review, including `stt` generation origins and chat usage cost metadata, and kept the repository snapshot at `51 / 51` official OpenAPI endpoint coverage.
 - Accepted the 2026-05-03 OpenAPI drift review, including audio transcription support, and restored the repository snapshot to `52 / 52` official OpenAPI endpoint coverage.
+- Accepted the 2026-05-15 OpenAPI drift review, including experimental response metadata, guardrail content filters, model supported voices, and generation service tiers, while keeping the repository snapshot at `52 / 52` official OpenAPI endpoint coverage.
 - Changed the scheduled OpenAPI drift workflow from daily to weekly while keeping manual `workflow_dispatch` runs available.
 
 ## [0.9.0] - 2026-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accepted the 2026-05-15 OpenAPI drift review, including experimental response metadata, guardrail content filters, model supported voices, and generation service tiers, while keeping the repository snapshot at `52 / 52` official OpenAPI endpoint coverage.
 - Changed the scheduled OpenAPI drift workflow from daily to weekly while keeping manual `workflow_dispatch` runs available.
 
+### Fixed
+- Preserved top-level `openrouter_metadata` and `user_id` fields on normalized API errors so guardrail-blocked responses keep their diagnostic metadata.
+
 ## [0.9.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Preserved top-level `openrouter_metadata` and `user_id` fields on normalized API errors so guardrail-blocked responses keep their diagnostic metadata.
+- Preserved `openrouter_metadata` and future top-level extras on Anthropic Messages `message_stop` stream events.
 
 ## [0.9.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The current repo snapshot implements `52 / 52` official OpenAPI method/path entr
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
+- Opt-in experimental response metadata for chat, Responses API, and Anthropic-compatible Messages requests
 - Discovery, rerank, audio speech/transcription, video generation, embeddings, API-key management, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
@@ -118,6 +119,8 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - `x_title`
 - `app_categories`
 
+Chat, Responses API, and Anthropic-compatible Messages request builders also expose `experimental_metadata(OpenRouterExperimentalMetadata::Enabled)` for OpenRouter's opt-in routing metadata response header.
+
 ## Common Workflows
 
 `openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:
@@ -128,8 +131,8 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, embeddings, and ZDR endpoints
-- typed generation metadata, workspace I/O logging controls, and video callback URL support
-- management-key workflows for keys, workspace-scoped keys, auth codes, organization members, workspaces, workspace membership, guardrails, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
+- typed generation metadata, model voice metadata, workspace I/O logging controls, and video callback URL support
+- management-key workflows for keys, workspace-scoped keys, auth codes, organization members, workspaces, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-05-03
+Snapshot date: 2026-05-15
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -24,6 +24,9 @@ Drift review note:
 - Upstream refreshed web-search, provider, and Responses output schemas. Existing OpenRouter plugin passthrough, Anthropic hosted-tool extras, provider option maps, and Responses `Value` payloads carry those schema details without a public API migration.
 - Upstream added `stt` as a generation origin and chat-completion usage cost metadata. `GenerationData::origin` remains a flexible `String`, and `ResponseUsage` now exposes typed `cost`, `cost_details`, and `is_byok` fields. The 2026-04-29 baseline refresh keeps the accepted endpoint snapshot at `51 / 51`.
 - Upstream added `POST /audio/transcriptions`. The SDK now exposes a typed transcription surface, and the 2026-05-03 baseline refresh keeps the accepted endpoint snapshot at `52 / 52`.
+- Upstream added experimental response metadata headers for chat completions, Responses API, and Anthropic-compatible Messages. The SDK exposes this through `OpenRouterExperimentalMetadata` on the request builders and parses chat `openrouter_metadata` / `service_tier` response fields.
+- Upstream expanded guardrails with built-in content filters, custom regex filters, and provider-specific ZDR flags. The SDK now exposes those typed fields on guardrail create/update requests and guardrail responses.
+- Upstream added model `supported_voices` and generation `service_tier` metadata. The SDK now exposes those typed fields, and the 2026-05-15 baseline refresh keeps the accepted endpoint snapshot at `52 / 52`.
 
 Legend:
 

--- a/examples/domain_chat_completion.rs
+++ b/examples/domain_chat_completion.rs
@@ -1,4 +1,8 @@
-use openrouter_rs::{OpenRouterClient, api::chat::*, types::Role};
+use openrouter_rs::{
+    OpenRouterClient,
+    api::chat::*,
+    types::{OpenRouterExperimentalMetadata, Role},
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,6 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )])
         .max_tokens(64)
         .temperature(0.2)
+        .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()?;
 
     let response = client.chat().create(&request).await?;

--- a/examples/stream_messages.rs
+++ b/examples/stream_messages.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     print!("{text}");
                 }
             }
-            AnthropicMessagesStreamEvent::MessageStop => {
+            AnthropicMessagesStreamEvent::MessageStop { .. } => {
                 println!();
                 println!("done");
             }

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -166,6 +166,88 @@
           "type": "response.output_text.annotation.added"
         }
       },
+      "AnthropicAdvisorMessageUsageIteration": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicBaseUsageIteration"
+          },
+          {
+            "properties": {
+              "model": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "advisor_message"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "model"
+            ],
+            "type": "object"
+          }
+        ],
+        "example": {
+          "cache_creation": null,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 823,
+          "model": "claude-opus-4-6",
+          "output_tokens": 1612,
+          "type": "advisor_message"
+        }
+      },
+      "AnthropicAdvisorToolResult": {
+        "example": {
+          "content": {
+            "text": "Advisor response text",
+            "type": "advisor_result"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "advisor_tool_result"
+        },
+        "properties": {
+          "content": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "advisor_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_use_id",
+          "content"
+        ],
+        "type": "object"
+      },
+      "AnthropicAllowedCallers": {
+        "example": [
+          "direct"
+        ],
+        "items": {
+          "enum": [
+            "direct",
+            "code_execution_20250825",
+            "code_execution_20260120"
+          ],
+          "type": "string",
+          "x-speakeasy-unknown-values": "allow"
+        },
+        "type": "array"
+      },
       "AnthropicBase64ImageSource": {
         "example": {
           "data": "/9j/4AAQ...",
@@ -400,6 +482,7 @@
         "type": "object"
       },
       "AnthropicCacheControlDirective": {
+        "description": "Enable automatic prompt caching. When set at the top level, the system automatically applies cache breakpoints to the last cacheable block in the request. Currently supported for Anthropic Claude models.",
         "example": {
           "type": "ephemeral"
         },
@@ -1627,20 +1710,6 @@
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
       },
-      "AnthropicServerToolName": {
-        "enum": [
-          "web_search",
-          "web_fetch",
-          "code_execution",
-          "bash_code_execution",
-          "text_editor_code_execution",
-          "tool_search_tool_regex",
-          "tool_search_tool_bm25"
-        ],
-        "example": "web_search",
-        "type": "string",
-        "x-speakeasy-unknown-values": "allow"
-      },
       "AnthropicServerToolUsage": {
         "example": {
           "web_fetch_requests": 0,
@@ -1658,46 +1727,6 @@
         "required": [
           "web_search_requests",
           "web_fetch_requests"
-        ],
-        "type": "object"
-      },
-      "AnthropicServerToolUseBlock": {
-        "example": {
-          "caller": {
-            "type": "direct"
-          },
-          "id": "srvtoolu_01abc",
-          "input": {
-            "query": "latest news"
-          },
-          "name": "web_search",
-          "type": "server_tool_use"
-        },
-        "properties": {
-          "caller": {
-            "$ref": "#/components/schemas/AnthropicCaller"
-          },
-          "id": {
-            "type": "string"
-          },
-          "input": {
-            "nullable": true
-          },
-          "name": {
-            "$ref": "#/components/schemas/AnthropicServerToolName"
-          },
-          "type": {
-            "enum": [
-              "server_tool_use"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "id",
-          "caller",
-          "name"
         ],
         "type": "object"
       },
@@ -2493,6 +2522,9 @@
             "$ref": "#/components/schemas/AnthropicMessageUsageIteration"
           },
           {
+            "$ref": "#/components/schemas/AnthropicAdvisorMessageUsageIteration"
+          },
+          {
             "$ref": "#/components/schemas/AnthropicUnknownUsageIteration"
           }
         ],
@@ -2847,6 +2879,172 @@
         ],
         "type": "object"
       },
+      "ApplyPatchCallItem": {
+        "description": "A file create/update/delete via diff patch",
+        "example": {
+          "call_id": "call-abc123",
+          "operation": {
+            "diff": "--- a\n+++ b\n",
+            "path": "src/main.ts",
+            "type": "update_file"
+          },
+          "status": "completed",
+          "type": "apply_patch_call"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "operation": {
+            "oneOf": [
+              {
+                "properties": {
+                  "diff": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "create_file"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "path",
+                  "diff"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "delete_file"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "path"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "diff": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "update_file"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "path",
+                  "diff"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "in_progress"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "completed"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "apply_patch_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "operation",
+          "status"
+        ],
+        "type": "object"
+      },
+      "ApplyPatchCallOutputItem": {
+        "description": "Output from an apply patch operation",
+        "example": {
+          "call_id": "call-abc123",
+          "status": "completed",
+          "type": "apply_patch_call_output"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "output": {
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "completed"
+                ],
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "failed"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "apply_patch_call_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "status"
+        ],
+        "type": "object"
+      },
       "ApplyPatchServerTool": {
         "description": "Apply patch tool configuration",
         "example": {
@@ -2915,6 +3113,13 @@
           "error": {
             "$ref": "#/components/schemas/BadGatewayResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -2963,6 +3168,13 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/BadRequestResponseErrorData"
+          },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
           },
           "user_id": {
             "nullable": true,
@@ -3159,6 +3371,82 @@
           "item_id",
           "content_index",
           "part",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseCustomToolCallInputDeltaEvent": {
+        "description": "Event emitted when a custom tool call's freeform input is being streamed. Mirrors `response.function_call_arguments.delta` but for `custom` tools whose input is opaque text rather than JSON arguments.",
+        "example": {
+          "delta": "*** Begin Patch",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.custom_tool_call_input.delta"
+        },
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.custom_tool_call_input.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "delta",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "BaseCustomToolCallInputDoneEvent": {
+        "description": "Event emitted when a custom tool call's freeform input streaming is complete. Mirrors `response.function_call_arguments.done` but for `custom` tools.",
+        "example": {
+          "input": "*** Begin Patch\n*** End Patch",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 6,
+          "type": "response.custom_tool_call_input.done"
+        },
+        "properties": {
+          "input": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.custom_tool_call_input.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "item_id",
+          "output_index",
+          "input",
           "sequence_number"
         ],
         "type": "object"
@@ -3403,6 +3691,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/OutputMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAIResponseCustomToolCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAIResponseCustomToolCallOutput"
                 }
               ]
             },
@@ -3425,7 +3719,7 @@
           "container": null,
           "content": [
             {
-              "citations": null,
+              "citations": [],
               "text": "Hello!",
               "type": "text"
             }
@@ -3967,6 +4261,7 @@
             "items": {
               "discriminator": {
                 "mapping": {
+                  "custom_tool_call": "#/components/schemas/OutputItemCustomToolCall",
                   "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
                   "function_call": "#/components/schemas/OutputItemFunctionCall",
                   "image_generation_call": "#/components/schemas/OutputItemImageGenerationCall",
@@ -3985,6 +4280,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/OutputItemFunctionCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemCustomToolCall"
                 },
                 {
                   "$ref": "#/components/schemas/OutputItemWebSearchCall"
@@ -5440,14 +5738,7 @@
         },
         "properties": {
           "cache_control": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AnthropicCacheControlDirective"
-              },
-              {
-                "description": "Enable automatic prompt caching. When set, the system automatically applies cache breakpoints to the last cacheable block in the request. Currently supported for Anthropic Claude models."
-              }
-            ]
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
           },
           "debug": {
             "$ref": "#/components/schemas/ChatDebugOptions"
@@ -5554,6 +5845,7 @@
                   "auto-router": "#/components/schemas/AutoRouterPlugin",
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
+                  "fusion": "#/components/schemas/FusionPlugin",
                   "moderation": "#/components/schemas/ModerationPlugin",
                   "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
@@ -5582,6 +5874,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ParetoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/FusionPlugin"
                 }
               ]
             },
@@ -5823,6 +6118,9 @@
             ],
             "type": "string"
           },
+          "openrouter_metadata": {
+            "$ref": "#/components/schemas/OpenRouterMetadata"
+          },
           "service_tier": {
             "description": "The service tier used by the upstream provider for this request",
             "example": "default",
@@ -5977,6 +6275,9 @@
               "chat.completion.chunk"
             ],
             "type": "string"
+          },
+          "openrouter_metadata": {
+            "$ref": "#/components/schemas/OpenRouterMetadata"
           },
           "service_tier": {
             "description": "The service tier used by the upstream provider for this request",
@@ -6137,6 +6438,35 @@
         },
         "required": [
           "index"
+        ],
+        "type": "object"
+      },
+      "ChatStreamingResponse": {
+        "example": {
+          "data": {
+            "choices": [
+              {
+                "delta": {
+                  "content": "Hello",
+                  "role": "assistant"
+                },
+                "finish_reason": null,
+                "index": 0
+              }
+            ],
+            "created": 1677652288,
+            "id": "chatcmpl-123",
+            "model": "openai/gpt-4",
+            "object": "chat.completion.chunk"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChatStreamChunk"
+          }
+        },
+        "required": [
+          "data"
         ],
         "type": "object"
       },
@@ -6553,7 +6883,7 @@
         },
         "properties": {
           "allowed_domains": {
-            "description": "Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Firecrawl or Perplexity.",
+            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Perplexity. Cannot be used with excluded_domains.",
             "items": {
               "type": "string"
             },
@@ -6563,7 +6893,7 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported with Firecrawl, OpenAI (silently ignored), or Perplexity.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Anthropic, and xAI. Not supported with OpenAI (silently ignored) or Perplexity. Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
@@ -6771,6 +7101,33 @@
         ],
         "type": "object"
       },
+      "CompactionItem": {
+        "description": "A context compaction marker with encrypted summary",
+        "example": {
+          "encrypted_content": "enc_abc123...",
+          "type": "compaction"
+        },
+        "properties": {
+          "encrypted_content": {
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "compaction"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "encrypted_content"
+        ],
+        "type": "object"
+      },
       "CompletedEvent": {
         "description": "Event emitted when a response has completed successfully",
         "example": {
@@ -6920,6 +7277,13 @@
           "error": {
             "$ref": "#/components/schemas/ConflictResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -6954,6 +7318,101 @@
         "required": [
           "code",
           "message"
+        ],
+        "type": "object"
+      },
+      "ContentFilterAction": {
+        "description": "Action taken when the pattern matches",
+        "enum": [
+          "redact",
+          "block"
+        ],
+        "example": "block",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ContentFilterBuiltinAction": {
+        "description": "Action taken when the builtin filter triggers",
+        "enum": [
+          "redact",
+          "block",
+          "flag"
+        ],
+        "example": "block",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ContentFilterBuiltinEntry": {
+        "description": "A builtin content filter entry. Builtin filters include PII detectors and the regex-based prompt injection detector.",
+        "example": {
+          "action": "block",
+          "label": "[PROMPT_INJECTION]",
+          "slug": "regex-prompt-injection"
+        },
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/ContentFilterBuiltinAction"
+          },
+          "label": {
+            "description": "Optional label used in redaction placeholders (e.g. \"[PROMPT_INJECTION]\")",
+            "example": "[PROMPT_INJECTION]",
+            "maxLength": 100,
+            "type": "string"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/ContentFilterBuiltinSlug"
+          }
+        },
+        "required": [
+          "slug",
+          "action"
+        ],
+        "type": "object"
+      },
+      "ContentFilterBuiltinSlug": {
+        "description": "The builtin filter identifier",
+        "enum": [
+          "email",
+          "phone",
+          "ssn",
+          "credit-card",
+          "ip-address",
+          "person-name",
+          "address",
+          "regex-prompt-injection"
+        ],
+        "example": "regex-prompt-injection",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ContentFilterEntry": {
+        "description": "A custom regex content filter that scans request messages for matching patterns.",
+        "example": {
+          "action": "redact",
+          "label": "[API_KEY]",
+          "pattern": "\\b(sk-[a-zA-Z0-9]{48})\\b"
+        },
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/ContentFilterAction"
+          },
+          "label": {
+            "description": "Optional label used in redaction placeholders or error messages",
+            "example": "[API_KEY]",
+            "maxLength": 100,
+            "nullable": true,
+            "type": "string"
+          },
+          "pattern": {
+            "description": "A regex pattern to match against request content",
+            "example": "\\b(sk-[a-zA-Z0-9]{48})\\b",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "pattern",
+          "action"
         ],
         "type": "object"
       },
@@ -7136,8 +7595,18 @@
             "anthropic",
             "deepseek"
           ],
+          "content_filter_builtins": [
+            {
+              "action": "block",
+              "slug": "regex-prompt-injection"
+            }
+          ],
+          "content_filters": null,
           "description": "A guardrail for limiting API usage",
-          "enforce_zdr": false,
+          "enforce_zdr_anthropic": true,
+          "enforce_zdr_google": false,
+          "enforce_zdr_openai": true,
+          "enforce_zdr_other": false,
           "ignored_models": null,
           "ignored_providers": null,
           "limit_usd": 50,
@@ -7173,6 +7642,35 @@
             "nullable": true,
             "type": "array"
           },
+          "content_filter_builtins": {
+            "description": "Builtin content filters to apply. The \"flag\" action is only supported for \"regex-prompt-injection\"; PII slugs (email, phone, ssn, credit-card, ip-address, person-name, address) accept \"block\" or \"redact\" only.",
+            "example": [
+              {
+                "action": "block",
+                "slug": "regex-prompt-injection"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterBuiltinEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "content_filters": {
+            "description": "Custom regex content filters to apply to request messages",
+            "example": [
+              {
+                "action": "redact",
+                "label": "[API_KEY]",
+                "pattern": "\\b(sk-[a-zA-Z0-9]{48})\\b"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "description": {
             "description": "Description of the guardrail",
             "example": "A guardrail for limiting API usage",
@@ -7181,7 +7679,32 @@
             "type": "string"
           },
           "enforce_zdr": {
-            "description": "Whether to enforce zero data retention",
+            "deprecated": true,
+            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_anthropic": {
+            "description": "Whether to enforce zero data retention for Anthropic models. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_google": {
+            "description": "Whether to enforce zero data retention for Google models. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_openai": {
+            "description": "Whether to enforce zero data retention for OpenAI models. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_other": {
+            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, or Google. Falls back to enforce_zdr when not provided.",
             "example": false,
             "nullable": true,
             "type": "boolean"
@@ -7248,9 +7771,21 @@
               "anthropic",
               "google"
             ],
+            "content_filter_builtins": [
+              {
+                "action": "block",
+                "label": "[PROMPT_INJECTION]",
+                "slug": "regex-prompt-injection"
+              }
+            ],
+            "content_filters": null,
             "created_at": "2025-08-24T10:30:00Z",
             "description": "A guardrail for limiting API usage",
-            "enforce_zdr": false,
+            "enforce_zdr": null,
+            "enforce_zdr_anthropic": true,
+            "enforce_zdr_google": false,
+            "enforce_zdr_openai": true,
+            "enforce_zdr_other": false,
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
@@ -7351,11 +7886,11 @@
             "type": "string"
           },
           "slug": {
-            "description": "URL-friendly slug (lowercase alphanumeric and hyphens only)",
+            "description": "URL-friendly slug (lowercase alphanumeric segments separated by single hyphens, no leading/trailing hyphens)",
             "example": "production",
             "maxLength": 50,
             "minLength": 1,
-            "pattern": "^[a-z0-9-]+$",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
             "type": "string"
           }
         },
@@ -7517,6 +8052,141 @@
           "name"
         ],
         "type": "object"
+      },
+      "CustomToolCallInputDeltaEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseCustomToolCallInputDeltaEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a custom tool call's freeform input is being streamed. Mirrors `response.function_call_arguments.delta` but for `custom` tools whose input is opaque text rather than JSON arguments.",
+        "example": {
+          "delta": "*** Begin Patch",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.custom_tool_call_input.delta"
+        }
+      },
+      "CustomToolCallInputDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseCustomToolCallInputDoneEvent"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ],
+        "description": "Event emitted when a custom tool call's freeform input streaming is complete. Mirrors `response.function_call_arguments.done` but for `custom` tools.",
+        "example": {
+          "input": "*** Begin Patch\n*** End Patch",
+          "item_id": "item-1",
+          "output_index": 0,
+          "sequence_number": 6,
+          "type": "response.custom_tool_call_input.done"
+        }
+      },
+      "CustomToolCallItem": {
+        "description": "A call to a custom (freeform-grammar) tool created by the model \u2014 distinct from `function_call`. Used for tools like Codex CLI's `apply_patch` whose payload is opaque text rather than JSON arguments.",
+        "example": {
+          "call_id": "call-abc123",
+          "id": "ctc-abc123",
+          "input": "*** Begin Patch\n*** End Patch",
+          "name": "apply_patch",
+          "type": "custom_tool_call"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace qualifier for tools registered as part of a namespace tool group (e.g. an MCP server)",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "custom_tool_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "input"
+        ],
+        "type": "object"
+      },
+      "CustomToolCallOutputItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIResponseCustomToolCallOutput"
+          },
+          {
+            "properties": {
+              "output": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/InputText"
+                        },
+                        {
+                          "allOf": [
+                            {
+                              "$ref": "#/components/schemas/InputImage"
+                            },
+                            {
+                              "properties": {},
+                              "type": "object"
+                            }
+                          ],
+                          "description": "Image input content item",
+                          "example": {
+                            "detail": "auto",
+                            "image_url": "https://example.com/image.jpg",
+                            "type": "input_image"
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/InputFile"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "The output from a custom (freeform-grammar) tool call execution. Mirrors `function_call_output` but is matched to a `custom_tool_call` rather than a `function_call`.",
+        "example": {
+          "call_id": "call-abc123",
+          "id": "ctco-abc123",
+          "output": "patch applied successfully",
+          "type": "custom_tool_call_output"
+        }
       },
       "DatetimeServerTool": {
         "description": "OpenRouter built-in server tool: returns the current date and time",
@@ -7776,6 +8446,13 @@
           "error": {
             "$ref": "#/components/schemas/EdgeNetworkTimeoutResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -7813,6 +8490,30 @@
         ],
         "type": "object"
       },
+      "EndpointInfo": {
+        "example": {
+          "model": "openai/gpt-4o",
+          "provider": "OpenAI",
+          "selected": true
+        },
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "selected": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "provider",
+          "model",
+          "selected"
+        ],
+        "type": "object"
+      },
       "EndpointStatus": {
         "enum": [
           0,
@@ -7825,6 +8526,34 @@
         "example": 0,
         "type": "integer",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "EndpointsMetadata": {
+        "example": {
+          "available": [
+            {
+              "model": "openai/gpt-4o",
+              "provider": "OpenAI",
+              "selected": true
+            }
+          ],
+          "total": 3
+        },
+        "properties": {
+          "available": {
+            "items": {
+              "$ref": "#/components/schemas/EndpointInfo"
+            },
+            "type": "array"
+          },
+          "total": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "available"
+        ],
+        "type": "object"
       },
       "ErrorEvent": {
         "allOf": [
@@ -8099,6 +8828,13 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/ForbiddenResponseErrorData"
+          },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
           },
           "user_id": {
             "nullable": true,
@@ -8452,6 +9188,112 @@
         ],
         "type": "object"
       },
+      "FusionPlugin": {
+        "example": {
+          "analysis_models": [
+            "~anthropic/claude-opus-latest",
+            "~openai/gpt-latest",
+            "~google/gemini-pro-latest"
+          ],
+          "enabled": true,
+          "id": "fusion",
+          "model": "~anthropic/claude-opus-latest"
+        },
+        "properties": {
+          "analysis_models": {
+            "description": "Slugs of models to run in parallel as the \"expert panel\" the judge analyzes. Each model receives the same user prompt with web_search + web_fetch enabled. Capped at 8 models to bound cost amplification. When omitted, defaults to the Quality preset from the /labs/fusion UI (~anthropic/claude-opus-latest, ~openai/gpt-latest, ~google/gemini-pro-latest).",
+            "example": [
+              "~anthropic/claude-opus-latest",
+              "~openai/gpt-latest",
+              "~google/gemini-pro-latest"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 8,
+            "minItems": 1,
+            "type": "array"
+          },
+          "enabled": {
+            "description": "Set to false to disable the fusion plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "id": {
+            "enum": [
+              "fusion"
+            ],
+            "type": "string"
+          },
+          "model": {
+            "description": "Slug of the model that performs both the judge step (with web_search + web_fetch) and the final synthesis. When omitted, defaults to the first model in the Quality preset.",
+            "example": "~anthropic/claude-opus-latest",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "FusionServerToolConfig": {
+        "description": "Configuration for the openrouter:fusion server tool.",
+        "example": {
+          "analysis_models": [
+            "~anthropic/claude-opus-latest",
+            "~openai/gpt-latest",
+            "~google/gemini-pro-latest"
+          ]
+        },
+        "properties": {
+          "analysis_models": {
+            "description": "Slugs of models to run in parallel as the analysis panel. Each model receives the user prompt with openrouter:web_search and openrouter:web_fetch enabled, then a judge model summarizes the collective output into structured analysis JSON. Capped at 8 models to bound cost amplification. Defaults to the Quality preset from /labs/fusion.",
+            "example": [
+              "~anthropic/claude-opus-latest",
+              "~openai/gpt-latest",
+              "~google/gemini-pro-latest"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 8,
+            "minItems": 1,
+            "type": "array"
+          },
+          "model": {
+            "description": "Slug of the judge model that produces the structured analysis JSON. Defaults to the model used in the outer API request.",
+            "example": "~anthropic/claude-opus-latest",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "FusionServerTool_OpenRouter": {
+        "description": "OpenRouter built-in server tool: fans out the user prompt to a panel of analysis models, then asks a judge model to summarize their collective output as structured JSON the outer model can synthesize from.",
+        "example": {
+          "parameters": {
+            "analysis_models": [
+              "~anthropic/claude-opus-latest",
+              "~openai/gpt-latest"
+            ]
+          },
+          "type": "openrouter:fusion"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/FusionServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:fusion"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
       "GenerationContentData": {
         "description": "Stored prompt and completion content",
         "example": {
@@ -8596,6 +9438,7 @@
             "provider_responses": null,
             "request_id": "req-1727282430-aBcDeFgHiJkLmNoPqRsT",
             "router": "openrouter/auto",
+            "service_tier": "priority",
             "session_id": null,
             "streamed": true,
             "tokens_completion": 25,
@@ -8805,6 +9648,12 @@
                 "nullable": true,
                 "type": "string"
               },
+              "service_tier": {
+                "description": "Service tier the upstream provider reported running this request on, or null if it did not report one.",
+                "example": "priority",
+                "nullable": true,
+                "type": "string"
+              },
               "session_id": {
                 "description": "Session identifier grouping multiple generations in the same session",
                 "nullable": true,
@@ -8881,6 +9730,7 @@
               "moderation_latency",
               "generation_time",
               "finish_reason",
+              "service_tier",
               "tokens_prompt",
               "tokens_completion",
               "native_tokens_prompt",
@@ -8922,9 +9772,21 @@
               "anthropic",
               "google"
             ],
+            "content_filter_builtins": [
+              {
+                "action": "block",
+                "label": "[PROMPT_INJECTION]",
+                "slug": "regex-prompt-injection"
+              }
+            ],
+            "content_filters": null,
             "created_at": "2025-08-24T10:30:00Z",
             "description": "Guardrail for production environment",
-            "enforce_zdr": false,
+            "enforce_zdr": null,
+            "enforce_zdr_anthropic": true,
+            "enforce_zdr_google": false,
+            "enforce_zdr_openai": true,
+            "enforce_zdr_other": false,
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
@@ -9001,6 +9863,13 @@
           "error": {
             "$ref": "#/components/schemas/GoneResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -9046,9 +9915,21 @@
             "anthropic",
             "google"
           ],
+          "content_filter_builtins": [
+            {
+              "action": "block",
+              "label": "[PROMPT_INJECTION]",
+              "slug": "regex-prompt-injection"
+            }
+          ],
+          "content_filters": null,
           "created_at": "2025-08-24T10:30:00Z",
           "description": "Guardrail for production environment",
-          "enforce_zdr": false,
+          "enforce_zdr": null,
+          "enforce_zdr_anthropic": true,
+          "enforce_zdr_google": false,
+          "enforce_zdr_openai": true,
+          "enforce_zdr_other": false,
           "id": "550e8400-e29b-41d4-a716-446655440000",
           "ignored_models": null,
           "ignored_providers": null,
@@ -9085,6 +9966,36 @@
             "nullable": true,
             "type": "array"
           },
+          "content_filter_builtins": {
+            "description": "Builtin content filters applied to requests. Includes PII detectors and the regex-based prompt injection detector.",
+            "example": [
+              {
+                "action": "block",
+                "label": "[PROMPT_INJECTION]",
+                "slug": "regex-prompt-injection"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterBuiltinEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "content_filters": {
+            "description": "Custom regex content filters applied to request messages",
+            "example": [
+              {
+                "action": "redact",
+                "label": "[API_KEY]",
+                "pattern": "\\b(sk-[a-zA-Z0-9]{48})\\b"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "created_at": {
             "description": "ISO 8601 timestamp of when the guardrail was created",
             "example": "2025-08-24T10:30:00Z",
@@ -9097,7 +10008,32 @@
             "type": "string"
           },
           "enforce_zdr": {
-            "description": "Whether to enforce zero data retention",
+            "deprecated": true,
+            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_anthropic": {
+            "description": "Whether to enforce zero data retention for Anthropic models. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_google": {
+            "description": "Whether to enforce zero data retention for Google models. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_openai": {
+            "description": "Whether to enforce zero data retention for OpenAI models. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_other": {
+            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, or Google. Falls back to enforce_zdr when not provided.",
             "example": false,
             "nullable": true,
             "type": "boolean"
@@ -9925,6 +10861,9 @@
                   "$ref": "#/components/schemas/OutputFunctionCallItem"
                 },
                 {
+                  "$ref": "#/components/schemas/OutputCustomToolCallItem"
+                },
+                {
                   "$ref": "#/components/schemas/OutputWebSearchCallItem"
                 },
                 {
@@ -9980,6 +10919,48 @@
                 },
                 {
                   "$ref": "#/components/schemas/OutputSearchModelsServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/LocalShellCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/LocalShellCallOutputItem"
+                },
+                {
+                  "$ref": "#/components/schemas/ShellCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/ShellCallOutputItem"
+                },
+                {
+                  "$ref": "#/components/schemas/ApplyPatchCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/ApplyPatchCallOutputItem"
+                },
+                {
+                  "$ref": "#/components/schemas/McpListToolsItem"
+                },
+                {
+                  "$ref": "#/components/schemas/McpApprovalRequestItem"
+                },
+                {
+                  "$ref": "#/components/schemas/McpApprovalResponseItem"
+                },
+                {
+                  "$ref": "#/components/schemas/McpCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/CustomToolCallItem"
+                },
+                {
+                  "$ref": "#/components/schemas/CustomToolCallOutputItem"
+                },
+                {
+                  "$ref": "#/components/schemas/CompactionItem"
+                },
+                {
+                  "$ref": "#/components/schemas/ItemReferenceItem"
                 }
               ]
             },
@@ -10038,6 +11019,13 @@
           "error": {
             "$ref": "#/components/schemas/InternalServerResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -10072,6 +11060,29 @@
         "required": [
           "code",
           "message"
+        ],
+        "type": "object"
+      },
+      "ItemReferenceItem": {
+        "description": "A reference to a previous response item by ID",
+        "example": {
+          "id": "msg-abc123",
+          "type": "item_reference"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "item_reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id"
         ],
         "type": "object"
       },
@@ -10369,9 +11380,21 @@
                 "anthropic",
                 "google"
               ],
+              "content_filter_builtins": [
+                {
+                  "action": "block",
+                  "label": "[PROMPT_INJECTION]",
+                  "slug": "regex-prompt-injection"
+                }
+              ],
+              "content_filters": null,
               "created_at": "2025-08-24T10:30:00Z",
               "description": "Guardrail for production environment",
-              "enforce_zdr": false,
+              "enforce_zdr": null,
+              "enforce_zdr_anthropic": true,
+              "enforce_zdr_google": false,
+              "enforce_zdr_openai": true,
+              "enforce_zdr_other": false,
               "id": "550e8400-e29b-41d4-a716-446655440000",
               "ignored_models": null,
               "ignored_providers": null,
@@ -10513,6 +11536,327 @@
         "required": [
           "data",
           "total_count"
+        ],
+        "type": "object"
+      },
+      "LocalShellCallItem": {
+        "description": "A local shell command execution call",
+        "example": {
+          "action": {
+            "command": [
+              "ls",
+              "-la"
+            ],
+            "env": {
+              "PATH": "/usr/bin"
+            },
+            "timeout_ms": 5000,
+            "type": "exec"
+          },
+          "call_id": "call-abc123",
+          "id": "shell-abc123",
+          "status": "completed",
+          "type": "local_shell_call"
+        },
+        "properties": {
+          "action": {
+            "properties": {
+              "command": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "timeout_ms": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "type": {
+                "enum": [
+                  "exec"
+                ],
+                "type": "string"
+              },
+              "user": {
+                "nullable": true,
+                "type": "string"
+              },
+              "working_directory": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "command",
+              "env"
+            ],
+            "type": "object"
+          },
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "local_shell_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "action",
+          "status"
+        ],
+        "type": "object"
+      },
+      "LocalShellCallOutputItem": {
+        "description": "Output from a local shell command execution",
+        "example": {
+          "id": "output-abc123",
+          "output": "total 24\ndrwxr-xr-x  5 user  staff  160 Jan  1 12:00 .",
+          "status": "completed",
+          "type": "local_shell_call_output"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "output": {
+            "type": "string"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallStatus"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "local_shell_call_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "output"
+        ],
+        "type": "object"
+      },
+      "McpApprovalRequestItem": {
+        "description": "Request for approval to execute an MCP tool",
+        "example": {
+          "arguments": "{\"id\":\"123\"}",
+          "id": "approval-abc123",
+          "name": "delete_record",
+          "server_label": "database-server",
+          "type": "mcp_approval_request"
+        },
+        "properties": {
+          "arguments": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "server_label": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "mcp_approval_request"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "name",
+          "arguments",
+          "server_label"
+        ],
+        "type": "object"
+      },
+      "McpApprovalResponseItem": {
+        "description": "User response to an MCP tool approval request",
+        "example": {
+          "approval_request_id": "approval-abc123",
+          "approve": true,
+          "reason": "Approved for execution",
+          "type": "mcp_approval_response"
+        },
+        "properties": {
+          "approval_request_id": {
+            "type": "string"
+          },
+          "approve": {
+            "type": "boolean"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "reason": {
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "mcp_approval_response"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "approval_request_id",
+          "approve"
+        ],
+        "type": "object"
+      },
+      "McpCallItem": {
+        "description": "An MCP tool call with its output or error",
+        "example": {
+          "arguments": "{\"query\":\"SELECT * FROM users\"}",
+          "id": "mcp-call-abc123",
+          "name": "query_database",
+          "output": "[{\"id\":1,\"name\":\"Alice\"}]",
+          "server_label": "database-server",
+          "type": "mcp_call"
+        },
+        "properties": {
+          "arguments": {
+            "type": "string"
+          },
+          "error": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "output": {
+            "nullable": true,
+            "type": "string"
+          },
+          "server_label": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "mcp_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "name",
+          "arguments",
+          "server_label"
+        ],
+        "type": "object"
+      },
+      "McpListToolsItem": {
+        "description": "List of available MCP tools from a server",
+        "example": {
+          "id": "mcp-list-abc123",
+          "server_label": "database-server",
+          "tools": [
+            {
+              "description": "Execute a database query",
+              "input_schema": {
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": "query_database"
+            }
+          ],
+          "type": "mcp_list_tools"
+        },
+        "properties": {
+          "error": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "server_label": {
+            "type": "string"
+          },
+          "tools": {
+            "items": {
+              "properties": {
+                "annotations": {
+                  "nullable": true
+                },
+                "description": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "input_schema": {
+                  "additionalProperties": {
+                    "nullable": true
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "input_schema"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "mcp_list_tools"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "server_label",
+          "tools"
         ],
         "type": "object"
       },
@@ -10694,6 +12038,40 @@
           "guardrail_id",
           "assigned_by",
           "created_at"
+        ],
+        "type": "object"
+      },
+      "MessagesAdvisorToolResultBlock": {
+        "description": "Advisor tool result from a prior assistant turn, replayed back to the model on the next turn. Mirrors the block Anthropic returns in assistant content when the `advisor_20260301` tool runs.",
+        "example": {
+          "content": {
+            "text": "Advisor response text",
+            "type": "advisor_result"
+          },
+          "tool_use_id": "srvtoolu_01abc",
+          "type": "advisor_tool_result"
+        },
+        "properties": {
+          "content": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "advisor_tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_use_id",
+          "content"
         ],
         "type": "object"
       },
@@ -10890,7 +12268,7 @@
                 "$ref": "#/components/schemas/AnthropicRedactedThinkingBlock"
               },
               {
-                "$ref": "#/components/schemas/AnthropicServerToolUseBlock"
+                "$ref": "#/components/schemas/ORAnthropicServerToolUseBlock"
               },
               {
                 "$ref": "#/components/schemas/AnthropicWebSearchToolResult"
@@ -10915,6 +12293,9 @@
               },
               {
                 "$ref": "#/components/schemas/AnthropicCompactionBlock"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicAdvisorToolResult"
               },
               {
                 "properties": {
@@ -11332,7 +12713,7 @@
                           "nullable": true
                         },
                         "name": {
-                          "$ref": "#/components/schemas/AnthropicServerToolName"
+                          "type": "string"
                         },
                         "type": {
                           "enum": [
@@ -11430,6 +12811,9 @@
                         "content"
                       ],
                       "type": "object"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessagesAdvisorToolResultBlock"
                     }
                   ]
                 },
@@ -11754,6 +13138,7 @@
                   "auto-router": "#/components/schemas/AutoRouterPlugin",
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
+                  "fusion": "#/components/schemas/FusionPlugin",
                   "moderation": "#/components/schemas/ModerationPlugin",
                   "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
@@ -11782,6 +13167,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ParetoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/FusionPlugin"
                 }
               ]
             },
@@ -11794,12 +13182,7 @@
             "$ref": "#/components/schemas/DeprecatedRoute"
           },
           "service_tier": {
-            "enum": [
-              "auto",
-              "standard_only"
-            ],
-            "type": "string",
-            "x-speakeasy-unknown-values": "allow"
+            "type": "string"
           },
           "session_id": {
             "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
@@ -12117,16 +13500,7 @@
                 {
                   "properties": {
                     "allowed_callers": {
-                      "items": {
-                        "enum": [
-                          "direct",
-                          "code_execution_20250825",
-                          "code_execution_20260120"
-                        ],
-                        "type": "string",
-                        "x-speakeasy-unknown-values": "allow"
-                      },
-                      "type": "array"
+                      "$ref": "#/components/schemas/AnthropicAllowedCallers"
                     },
                     "allowed_domains": {
                       "items": {
@@ -12172,6 +13546,53 @@
                   "type": "object"
                 },
                 {
+                  "properties": {
+                    "allowed_callers": {
+                      "$ref": "#/components/schemas/AnthropicAllowedCallers"
+                    },
+                    "cache_control": {
+                      "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                    },
+                    "caching": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    },
+                    "defer_loading": {
+                      "type": "boolean"
+                    },
+                    "max_uses": {
+                      "type": "integer"
+                    },
+                    "model": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "enum": [
+                        "advisor"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "advisor_20260301"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "model"
+                  ],
+                  "type": "object"
+                },
+                {
                   "$ref": "#/components/schemas/DatetimeServerTool"
                 },
                 {
@@ -12185,6 +13606,20 @@
                 },
                 {
                   "$ref": "#/components/schemas/OpenRouterWebSearchServerTool"
+                },
+                {
+                  "additionalProperties": {
+                    "nullable": true
+                  },
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object"
                 }
               ]
             },
@@ -12245,6 +13680,9 @@
                 ],
                 "type": "object"
               },
+              "openrouter_metadata": {
+                "$ref": "#/components/schemas/OpenRouterMetadata"
+              },
               "provider": {
                 "$ref": "#/components/schemas/ProviderName"
               },
@@ -12303,7 +13741,7 @@
           "container": null,
           "content": [
             {
-              "citations": null,
+              "citations": [],
               "text": "Hello! I'm doing well, thank you for asking.",
               "type": "text"
             }
@@ -12416,6 +13854,7 @@
                   "Clarifai",
                   "Cloudflare",
                   "Cohere",
+                  "Crucible",
                   "Crusoe",
                   "DeepInfra",
                   "DeepSeek",
@@ -12454,6 +13893,7 @@
                   "OpenInference",
                   "Parasail",
                   "Poolside",
+                  "Perceptron",
                   "Perplexity",
                   "Phala",
                   "Recraft",
@@ -12565,6 +14005,9 @@
           "type": "message_stop"
         },
         "properties": {
+          "openrouter_metadata": {
+            "$ref": "#/components/schemas/OpenRouterMetadata"
+          },
           "type": {
             "enum": [
               "message_stop"
@@ -12627,6 +14070,42 @@
           }
         ]
       },
+      "MessagesStreamingResponse": {
+        "example": {
+          "data": {
+            "delta": {
+              "text": "Hello",
+              "type": "text_delta"
+            },
+            "index": 0,
+            "type": "content_block_delta"
+          },
+          "event": "content_block_delta"
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/MessagesStreamEvents"
+          },
+          "event": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "event",
+          "data"
+        ],
+        "type": "object"
+      },
+      "MetadataLevel": {
+        "description": "Opt-in level for surfacing routing metadata on the response under `openrouter_metadata`.",
+        "enum": [
+          "disabled",
+          "enabled"
+        ],
+        "example": "enabled",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "Model": {
         "description": "Information about an AI model available on OpenRouter",
         "example": {
@@ -12665,6 +14144,7 @@
             "top_p",
             "max_tokens"
           ],
+          "supported_voices": null,
           "top_provider": {
             "context_length": 8192,
             "is_moderated": true,
@@ -12743,6 +14223,15 @@
             },
             "type": "array"
           },
+          "supported_voices": {
+            "description": "List of supported voice identifiers for TTS models. Null for non-TTS models.",
+            "example": null,
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "top_provider": {
             "$ref": "#/components/schemas/TopProviderInfo"
           }
@@ -12759,6 +14248,7 @@
           "per_request_limits",
           "supported_parameters",
           "default_parameters",
+          "supported_voices",
           "links"
         ],
         "type": "object"
@@ -12963,6 +14453,7 @@
                 "frequency_penalty",
                 "presence_penalty"
               ],
+              "supported_voices": null,
               "top_provider": {
                 "context_length": 8192,
                 "is_moderated": true,
@@ -13020,6 +14511,7 @@
               "top_p",
               "max_tokens"
             ],
+            "supported_voices": null,
             "top_provider": {
               "context_length": 8192,
               "is_moderated": true,
@@ -13061,6 +14553,13 @@
           "error": {
             "$ref": "#/components/schemas/NotFoundResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -13101,12 +14600,13 @@
       "ORAnthropicContentBlock": {
         "discriminator": {
           "mapping": {
+            "advisor_tool_result": "#/components/schemas/AnthropicAdvisorToolResult",
             "bash_code_execution_tool_result": "#/components/schemas/AnthropicBashCodeExecutionToolResult",
             "code_execution_tool_result": "#/components/schemas/AnthropicCodeExecutionToolResult",
             "compaction": "#/components/schemas/AnthropicCompactionBlock",
             "container_upload": "#/components/schemas/AnthropicContainerUpload",
             "redacted_thinking": "#/components/schemas/AnthropicRedactedThinkingBlock",
-            "server_tool_use": "#/components/schemas/AnthropicServerToolUseBlock",
+            "server_tool_use": "#/components/schemas/ORAnthropicServerToolUseBlock",
             "text": "#/components/schemas/AnthropicTextBlock",
             "text_editor_code_execution_tool_result": "#/components/schemas/AnthropicTextEditorCodeExecutionToolResult",
             "thinking": "#/components/schemas/AnthropicThinkingBlock",
@@ -13136,7 +14636,7 @@
             "$ref": "#/components/schemas/AnthropicRedactedThinkingBlock"
           },
           {
-            "$ref": "#/components/schemas/AnthropicServerToolUseBlock"
+            "$ref": "#/components/schemas/ORAnthropicServerToolUseBlock"
           },
           {
             "$ref": "#/components/schemas/AnthropicWebSearchToolResult"
@@ -13161,8 +14661,71 @@
           },
           {
             "$ref": "#/components/schemas/AnthropicCompactionBlock"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicAdvisorToolResult"
           }
         ]
+      },
+      "ORAnthropicNullableCaller": {
+        "discriminator": {
+          "mapping": {
+            "code_execution_20250825": "#/components/schemas/AnthropicCodeExecution20250825Caller",
+            "code_execution_20260120": "#/components/schemas/AnthropicCodeExecution20260120Caller",
+            "direct": "#/components/schemas/AnthropicDirectCaller"
+          },
+          "propertyName": "type"
+        },
+        "example": null,
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnthropicDirectCaller"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecution20250825Caller"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicCodeExecution20260120Caller"
+          },
+          {
+            "nullable": true
+          }
+        ]
+      },
+      "ORAnthropicServerToolUseBlock": {
+        "example": {
+          "caller": null,
+          "id": "srvtoolu_01abc",
+          "input": {},
+          "name": "advisor",
+          "type": "server_tool_use"
+        },
+        "properties": {
+          "caller": {
+            "$ref": "#/components/schemas/ORAnthropicNullableCaller"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "server_tool_use"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "name"
+        ],
+        "type": "object"
       },
       "ORAnthropicStopReason": {
         "enum": [
@@ -13179,6 +14742,104 @@
         "nullable": true,
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "OpenAIResponseCustomToolCall": {
+        "example": {
+          "call_id": "call-abc123",
+          "id": "ctc-abc123",
+          "input": "*** Begin Patch\n*** End Patch",
+          "name": "apply_patch",
+          "type": "custom_tool_call"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace qualifier for tools registered as part of a namespace tool group (e.g. an MCP server)",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "custom_tool_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "input"
+        ],
+        "type": "object"
+      },
+      "OpenAIResponseCustomToolCallOutput": {
+        "example": {
+          "call_id": "call-abc123",
+          "output": "patch applied successfully",
+          "type": "custom_tool_call_output"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "input_file": "#/components/schemas/InputFile",
+                      "input_image": "#/components/schemas/InputImage",
+                      "input_text": "#/components/schemas/InputText"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InputText"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputImage"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InputFile"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "custom_tool_call_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "output"
+        ],
+        "type": "object"
       },
       "OpenAIResponseFunctionToolCall": {
         "example": {
@@ -13200,6 +14861,10 @@
             "type": "string"
           },
           "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace qualifier for tools registered as part of a namespace tool group (e.g. an MCP server)",
             "type": "string"
           },
           "status": {
@@ -13912,6 +15577,9 @@
           },
           {
             "properties": {
+              "openrouter_metadata": {
+                "$ref": "#/components/schemas/OpenRouterMetadata"
+              },
               "output": {
                 "items": {
                   "$ref": "#/components/schemas/OutputItems"
@@ -13998,6 +15666,75 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "OpenRouterMetadata": {
+        "example": {
+          "attempt": 1,
+          "endpoints": {
+            "available": [
+              {
+                "model": "openai/gpt-4o",
+                "provider": "OpenAI",
+                "selected": true
+              }
+            ],
+            "total": 1
+          },
+          "is_byok": false,
+          "region": "iad",
+          "requested": "openai/gpt-4o",
+          "strategy": "direct",
+          "summary": "available=1, selected=OpenAI"
+        },
+        "properties": {
+          "attempt": {
+            "type": "integer"
+          },
+          "attempts": {
+            "items": {
+              "$ref": "#/components/schemas/RouterAttempt"
+            },
+            "type": "array"
+          },
+          "endpoints": {
+            "$ref": "#/components/schemas/EndpointsMetadata"
+          },
+          "is_byok": {
+            "type": "boolean"
+          },
+          "params": {
+            "$ref": "#/components/schemas/RouterParams"
+          },
+          "pipeline": {
+            "items": {
+              "$ref": "#/components/schemas/PipelineStage"
+            },
+            "type": "array"
+          },
+          "region": {
+            "nullable": true,
+            "type": "string"
+          },
+          "requested": {
+            "type": "string"
+          },
+          "strategy": {
+            "$ref": "#/components/schemas/RoutingStrategy"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "requested",
+          "strategy",
+          "region",
+          "summary",
+          "attempt",
+          "is_byok",
+          "endpoints"
+        ],
         "type": "object"
       },
       "OpenRouterWebSearchServerTool": {
@@ -14271,6 +16008,47 @@
         ],
         "type": "object"
       },
+      "OutputCustomToolCallItem": {
+        "description": "A call to a custom (freeform-grammar) tool created by the model \u2014 distinct from `function_call`. Used for tools like Codex CLI's `apply_patch` whose payload is opaque text rather than JSON arguments.",
+        "example": {
+          "call_id": "call-abc123",
+          "id": "ctc-abc123",
+          "input": "*** Begin Patch\n*** End Patch",
+          "name": "apply_patch",
+          "type": "custom_tool_call"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace qualifier for tools registered as part of a namespace tool group (e.g. an MCP server)",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "custom_tool_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "input",
+          "call_id"
+        ],
+        "type": "object"
+      },
       "OutputDatetimeItem": {
         "description": "An openrouter:datetime server tool output item",
         "example": {
@@ -14385,6 +16163,149 @@
           "type": "function_call"
         }
       },
+      "OutputFusionServerToolItem": {
+        "description": "An openrouter:fusion server tool output item",
+        "example": {
+          "id": "st_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:fusion"
+        },
+        "properties": {
+          "analysis": {
+            "description": "Structured analysis produced by the fusion judge model.",
+            "properties": {
+              "blind_spots": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "consensus": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "contradictions": {
+                "items": {
+                  "properties": {
+                    "stances": {
+                      "items": {
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "stance": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "model",
+                          "stance"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "topic": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "topic",
+                    "stances"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "partial_coverage": {
+                "items": {
+                  "properties": {
+                    "models": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "point": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "models",
+                    "point"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "unique_insights": {
+                "items": {
+                  "properties": {
+                    "insight": {
+                      "type": "string"
+                    },
+                    "model": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "model",
+                    "insight"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "consensus",
+              "contradictions",
+              "partial_coverage",
+              "unique_insights",
+              "blind_spots"
+            ],
+            "type": "object"
+          },
+          "error": {
+            "description": "Error message when the fusion run did not produce an analysis result.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "responses": {
+            "description": "Slugs of the analysis models that produced a response in this fusion run.",
+            "items": {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:fusion"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
       "OutputImageGenerationCallItem": {
         "allOf": [
           {
@@ -14463,6 +16384,7 @@
           "item": {
             "discriminator": {
               "mapping": {
+                "custom_tool_call": "#/components/schemas/OutputItemCustomToolCall",
                 "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
                 "function_call": "#/components/schemas/OutputItemFunctionCall",
                 "image_generation_call": "#/components/schemas/OutputItemImageGenerationCall",
@@ -14481,6 +16403,9 @@
               },
               {
                 "$ref": "#/components/schemas/OutputItemFunctionCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemCustomToolCall"
               },
               {
                 "$ref": "#/components/schemas/OutputItemWebSearchCall"
@@ -14514,6 +16439,46 @@
         ],
         "type": "object"
       },
+      "OutputItemCustomToolCall": {
+        "example": {
+          "call_id": "call-abc123",
+          "id": "ctc-abc123",
+          "input": "*** Begin Patch\n*** End Patch",
+          "name": "apply_patch",
+          "type": "custom_tool_call"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace qualifier for tools registered as part of a namespace tool group (e.g. an MCP server)",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "custom_tool_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "input",
+          "call_id"
+        ],
+        "type": "object"
+      },
       "OutputItemDoneEvent": {
         "description": "Event emitted when an output item is complete",
         "example": {
@@ -14538,6 +16503,7 @@
           "item": {
             "discriminator": {
               "mapping": {
+                "custom_tool_call": "#/components/schemas/OutputItemCustomToolCall",
                 "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
                 "function_call": "#/components/schemas/OutputItemFunctionCall",
                 "image_generation_call": "#/components/schemas/OutputItemImageGenerationCall",
@@ -14556,6 +16522,9 @@
               },
               {
                 "$ref": "#/components/schemas/OutputItemFunctionCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemCustomToolCall"
               },
               {
                 "$ref": "#/components/schemas/OutputItemWebSearchCall"
@@ -14646,6 +16615,10 @@
             "type": "string"
           },
           "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace qualifier for tools registered as part of a namespace tool group (e.g. an MCP server)",
             "type": "string"
           },
           "status": {
@@ -14897,6 +16870,7 @@
           "mapping": {
             "code_interpreter_call": "#/components/schemas/OutputCodeInterpreterCallItem",
             "computer_call": "#/components/schemas/OutputComputerCallItem",
+            "custom_tool_call": "#/components/schemas/OutputCustomToolCallItem",
             "file_search_call": "#/components/schemas/OutputFileSearchCallItem",
             "function_call": "#/components/schemas/OutputFunctionCallItem",
             "image_generation_call": "#/components/schemas/OutputImageGenerationCallItem",
@@ -14908,6 +16882,7 @@
             "openrouter:datetime": "#/components/schemas/OutputDatetimeItem",
             "openrouter:experimental__search_models": "#/components/schemas/OutputSearchModelsServerToolItem",
             "openrouter:file_search": "#/components/schemas/OutputFileSearchServerToolItem",
+            "openrouter:fusion": "#/components/schemas/OutputFusionServerToolItem",
             "openrouter:image_generation": "#/components/schemas/OutputImageGenerationServerToolItem",
             "openrouter:mcp": "#/components/schemas/OutputMcpServerToolItem",
             "openrouter:memory": "#/components/schemas/OutputMemoryServerToolItem",
@@ -14998,6 +16973,12 @@
           },
           {
             "$ref": "#/components/schemas/OutputSearchModelsServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputFusionServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputCustomToolCallItem"
           }
         ]
       },
@@ -15621,6 +17602,13 @@
           "error": {
             "$ref": "#/components/schemas/PayloadTooLargeResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -15669,6 +17657,13 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/PaymentRequiredResponseErrorData"
+          },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
           },
           "user_id": {
             "nullable": true,
@@ -15843,6 +17838,70 @@
         },
         "type": "object"
       },
+      "PipelineStage": {
+        "example": {
+          "data": {
+            "action": "redacted",
+            "engines": [
+              "presidio"
+            ],
+            "flagged": true,
+            "matched_entity_types": [
+              "EMAIL",
+              "PHONE"
+            ]
+          },
+          "name": "content-filter",
+          "summary": "PII redacted via Presidio (EMAIL, PHONE)",
+          "type": "guardrail"
+        },
+        "properties": {
+          "cost_usd": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "data": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "guardrail_id": {
+            "type": "string"
+          },
+          "guardrail_scope": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/PipelineStageType"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
+      "PipelineStageType": {
+        "description": "Categorical kind of a pipeline stage. Multiple plugins can share a type (e.g. all guardrail-level plugins emit `guardrail`); the `name` field disambiguates which plugin emitted it.",
+        "enum": [
+          "guardrail",
+          "plugin",
+          "server_tools",
+          "response_healing",
+          "context_compression"
+        ],
+        "example": "guardrail",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "PreferredMaxLatency": {
         "anyOf": [
           {
@@ -16007,6 +18066,7 @@
           "Clarifai",
           "Cloudflare",
           "Cohere",
+          "Crucible",
           "Crusoe",
           "DeepInfra",
           "DeepSeek",
@@ -16045,6 +18105,7 @@
           "OpenInference",
           "Parasail",
           "Poolside",
+          "Perceptron",
           "Perplexity",
           "Phala",
           "Recraft",
@@ -16236,6 +18297,12 @@
             "type": "object"
           },
           "crofai": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "crucible": {
             "additionalProperties": {
               "nullable": true
             },
@@ -16559,6 +18626,12 @@
             },
             "type": "object"
           },
+          "perceptron": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
           "perplexity": {
             "additionalProperties": {
               "nullable": true
@@ -16747,6 +18820,13 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/ProviderOverloadedResponseErrorData"
+          },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
           },
           "user_id": {
             "nullable": true,
@@ -17055,6 +19135,7 @@
               "Clarifai",
               "Cloudflare",
               "Cohere",
+              "Crucible",
               "Crusoe",
               "DeepInfra",
               "DeepSeek",
@@ -17093,6 +19174,7 @@
               "OpenInference",
               "Parasail",
               "Poolside",
+              "Perceptron",
               "Perplexity",
               "Phala",
               "Recraft",
@@ -18100,6 +20182,13 @@
           "error": {
             "$ref": "#/components/schemas/RequestTimeoutResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -18337,6 +20426,9 @@
             "nullable": true,
             "type": "boolean"
           },
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
           "frequency_penalty": {
             "format": "double",
             "nullable": true,
@@ -18402,6 +20494,7 @@
                   "auto-router": "#/components/schemas/AutoRouterPlugin",
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
+                  "fusion": "#/components/schemas/FusionPlugin",
                   "moderation": "#/components/schemas/ModerationPlugin",
                   "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
@@ -18430,6 +20523,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ParetoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/FusionPlugin"
                 }
               ]
             },
@@ -18586,6 +20682,9 @@
                   "$ref": "#/components/schemas/DatetimeServerTool"
                 },
                 {
+                  "$ref": "#/components/schemas/FusionServerTool_OpenRouter"
+                },
+                {
                   "$ref": "#/components/schemas/ImageGenerationServerTool_OpenRouter"
                 },
                 {
@@ -18626,6 +20725,85 @@
           }
         },
         "type": "object"
+      },
+      "ResponsesStreamingResponse": {
+        "example": {
+          "data": {
+            "delta": "Hello",
+            "type": "response.output_text.delta"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/StreamEvents"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "RouterAttempt": {
+        "example": {
+          "model": "openai/gpt-4o",
+          "provider": "OpenAI",
+          "status": 200
+        },
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "provider",
+          "model",
+          "status"
+        ],
+        "type": "object"
+      },
+      "RouterParams": {
+        "additionalProperties": {
+          "nullable": true
+        },
+        "example": {
+          "version_group": "anthropic/claude-sonnet-4"
+        },
+        "properties": {
+          "quality_floor": {
+            "format": "double",
+            "type": "number"
+          },
+          "throughput_floor": {
+            "format": "double",
+            "type": "number"
+          },
+          "version_group": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RoutingStrategy": {
+        "enum": [
+          "direct",
+          "auto",
+          "free",
+          "latest",
+          "alias",
+          "fallback",
+          "pareto",
+          "bodybuilder",
+          "fusion"
+        ],
+        "example": "direct",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
       },
       "STTInputAudio": {
         "description": "Base64-encoded audio to transcribe",
@@ -18788,7 +20966,7 @@
         "type": "object"
       },
       "SearchQualityLevel": {
-        "description": "How much context to retrieve per result. Defaults to medium (15000 chars). Applies to Exa and Parallel engines; ignored with native provider search and Firecrawl.",
+        "description": "How much context to retrieve per result. Applies to Exa and Parallel engines; ignored with native provider search and Firecrawl. For Exa, pins a fixed per-result character cap (low=5,000, medium=15,000, high=30,000); when omitted, Exa picks an adaptive size per query and document (typically ~2,000\u20134,000 characters per result). For Parallel, controls the total characters across all results; when omitted, Parallel uses its own default size.",
         "enum": [
           "low",
           "medium",
@@ -18824,6 +21002,13 @@
           "error": {
             "$ref": "#/components/schemas/ServiceUnavailableResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -18858,6 +21043,151 @@
         "required": [
           "code",
           "message"
+        ],
+        "type": "object"
+      },
+      "ShellCallItem": {
+        "description": "A shell command execution call (newer variant)",
+        "example": {
+          "action": {
+            "commands": [
+              "ls",
+              "-la"
+            ],
+            "max_output_length": 10000
+          },
+          "call_id": "call-abc123",
+          "status": "completed",
+          "type": "shell_call"
+        },
+        "properties": {
+          "action": {
+            "properties": {
+              "commands": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "max_output_length": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "timeout_ms": {
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "commands"
+            ],
+            "type": "object"
+          },
+          "call_id": {
+            "type": "string"
+          },
+          "environment": {
+            "nullable": true
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallStatus"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "shell_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "action"
+        ],
+        "type": "object"
+      },
+      "ShellCallOutputItem": {
+        "description": "Output from a shell command execution (newer variant)",
+        "example": {
+          "call_id": "call-abc123",
+          "output": [
+            {
+              "content": "total 0\n",
+              "type": "stdout"
+            }
+          ],
+          "status": "completed",
+          "type": "shell_call_output"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "max_output_length": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "output": {
+            "items": {
+              "additionalProperties": {
+                "nullable": true
+              },
+              "properties": {
+                "content": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "exit_code": {
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallStatus"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "shell_call_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "type": "object"
       },
@@ -18985,6 +21315,8 @@
             "response.content_part.added": "#/components/schemas/ContentPartAddedEvent",
             "response.content_part.done": "#/components/schemas/ContentPartDoneEvent",
             "response.created": "#/components/schemas/OpenResponsesCreatedEvent",
+            "response.custom_tool_call_input.delta": "#/components/schemas/CustomToolCallInputDeltaEvent",
+            "response.custom_tool_call_input.done": "#/components/schemas/CustomToolCallInputDoneEvent",
             "response.failed": "#/components/schemas/StreamEventsResponseFailed",
             "response.function_call_arguments.delta": "#/components/schemas/FunctionCallArgsDeltaEvent",
             "response.function_call_arguments.done": "#/components/schemas/FunctionCallArgsDoneEvent",
@@ -19125,6 +21457,12 @@
           },
           {
             "$ref": "#/components/schemas/WebSearchCallCompletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/CustomToolCallInputDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/CustomToolCallInputDoneEvent"
           }
         ]
       },
@@ -19483,6 +21821,13 @@
           "error": {
             "$ref": "#/components/schemas/TooManyRequestsResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -19701,6 +22046,13 @@
           "error": {
             "$ref": "#/components/schemas/UnauthorizedResponseErrorData"
           },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
+          },
           "user_id": {
             "nullable": true,
             "type": "string"
@@ -19749,6 +22101,13 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/UnprocessableEntityResponseErrorData"
+          },
+          "openrouter_metadata": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true,
+            "type": "object"
           },
           "user_id": {
             "nullable": true,
@@ -19821,6 +22180,29 @@
             "nullable": true,
             "type": "array"
           },
+          "content_filter_builtins": {
+            "description": "Builtin content filters to apply. Set to null to remove. The \"flag\" action is only supported for \"regex-prompt-injection\"; PII slugs (email, phone, ssn, credit-card, ip-address, person-name, address) accept \"block\" or \"redact\" only.",
+            "example": [
+              {
+                "action": "block",
+                "slug": "regex-prompt-injection"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterBuiltinEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "content_filters": {
+            "description": "Custom regex content filters to apply. Set to null to remove.",
+            "example": null,
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "description": {
             "description": "New description for the guardrail",
             "example": "Updated description",
@@ -19829,7 +22211,32 @@
             "type": "string"
           },
           "enforce_zdr": {
-            "description": "Whether to enforce zero data retention",
+            "deprecated": true,
+            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_anthropic": {
+            "description": "Whether to enforce zero data retention for Anthropic models. Falls back to enforce_zdr when not provided.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_google": {
+            "description": "Whether to enforce zero data retention for Google models. Falls back to enforce_zdr when not provided.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_openai": {
+            "description": "Whether to enforce zero data retention for OpenAI models. Falls back to enforce_zdr when not provided.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "enforce_zdr_other": {
+            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, or Google. Falls back to enforce_zdr when not provided.",
             "example": true,
             "nullable": true,
             "type": "boolean"
@@ -19885,9 +22292,21 @@
             "allowed_providers": [
               "openai"
             ],
+            "content_filter_builtins": [
+              {
+                "action": "block",
+                "label": "[PROMPT_INJECTION]",
+                "slug": "regex-prompt-injection"
+              }
+            ],
+            "content_filters": null,
             "created_at": "2025-08-24T10:30:00Z",
             "description": "Updated description",
-            "enforce_zdr": true,
+            "enforce_zdr": null,
+            "enforce_zdr_anthropic": true,
+            "enforce_zdr_google": true,
+            "enforce_zdr_openai": true,
+            "enforce_zdr_other": true,
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
@@ -19984,11 +22403,11 @@
             "type": "string"
           },
           "slug": {
-            "description": "New URL-friendly slug",
+            "description": "New URL-friendly slug (lowercase alphanumeric segments separated by single hyphens, no leading/trailing hyphens)",
             "example": "updated-workspace",
             "maxLength": 50,
             "minLength": 1,
-            "pattern": "^[a-z0-9-]+$",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
             "type": "string"
           }
         },
@@ -20111,6 +22530,8 @@
               "1:1",
               "4:3",
               "3:4",
+              "3:2",
+              "2:3",
               "21:9",
               "9:21"
             ],
@@ -20372,6 +22793,8 @@
                 "1:1",
                 "4:3",
                 "3:4",
+                "3:2",
+                "2:3",
                 "21:9",
                 "9:21"
               ],
@@ -20425,30 +22848,38 @@
               "enum": [
                 "480x480",
                 "480x640",
+                "480x720",
                 "480x854",
                 "480x1120",
                 "640x480",
+                "720x480",
                 "720x720",
                 "720x960",
+                "720x1080",
                 "720x1280",
                 "720x1680",
                 "854x480",
                 "960x720",
+                "1080x720",
                 "1080x1080",
                 "1080x1440",
+                "1080x1620",
                 "1080x1920",
                 "1080x2520",
                 "1120x480",
                 "1280x720",
                 "1440x1080",
+                "1620x1080",
                 "1680x720",
                 "1920x1080",
                 "2160x2160",
                 "2160x2880",
+                "2160x3240",
                 "2160x3840",
                 "2160x5040",
                 "2520x1080",
                 "2880x2160",
+                "3240x2160",
                 "3840x2160",
                 "5040x2160"
               ],
@@ -20522,7 +22953,7 @@
         "type": "object"
       },
       "WebFetchEngineEnum": {
-        "description": "Which fetch engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in fetch. \"exa\" uses Exa Contents API (supports BYOK). \"openrouter\" uses direct HTTP fetch. \"firecrawl\" uses Firecrawl scrape (requires BYOK).",
+        "description": "Which fetch engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in fetch. \"exa\" uses Exa Contents API. \"openrouter\" uses direct HTTP fetch. \"firecrawl\" uses Firecrawl scrape (requires BYOK).",
         "enum": [
           "auto",
           "native",
@@ -20656,7 +23087,7 @@
         },
         "properties": {
           "allowed_domains": {
-            "description": "Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Firecrawl or Perplexity.",
+            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Perplexity. Cannot be used with excluded_domains.",
             "items": {
               "type": "string"
             },
@@ -20666,7 +23097,7 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported with Firecrawl, OpenAI (silently ignored), or Perplexity.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Anthropic, and xAI. Not supported with OpenAI (silently ignored) or Perplexity. Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
@@ -20865,6 +23296,49 @@
         ],
         "type": "object"
       },
+      "WebSearchServerToolConfig": {
+        "description": "Configuration for the openrouter:web_search server tool",
+        "example": {
+          "max_results": 5,
+          "search_context_size": "medium"
+        },
+        "properties": {
+          "allowed_domains": {
+            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Perplexity. Cannot be used with excluded_domains.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "engine": {
+            "$ref": "#/components/schemas/WebSearchEngineEnum"
+          },
+          "excluded_domains": {
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Anthropic, and xAI. Not supported with OpenAI (silently ignored) or Perplexity. Cannot be used with allowed_domains.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "max_results": {
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "example": 5,
+            "type": "integer"
+          },
+          "max_total_results": {
+            "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results. Useful for controlling cost and context size in agentic loops.",
+            "example": 20,
+            "type": "integer"
+          },
+          "search_context_size": {
+            "$ref": "#/components/schemas/SearchQualityLevel"
+          },
+          "user_location": {
+            "$ref": "#/components/schemas/WebSearchUserLocationServerTool"
+          }
+        },
+        "type": "object"
+      },
       "WebSearchServerTool_OpenRouter": {
         "description": "OpenRouter built-in server tool: searches the web for current information",
         "example": {
@@ -20875,19 +23349,7 @@
         },
         "properties": {
           "parameters": {
-            "properties": {
-              "max_results": {
-                "description": "Maximum number of search results to return per search call. Defaults to 5.",
-                "example": 5,
-                "type": "integer"
-              },
-              "max_total_results": {
-                "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results.",
-                "example": 20,
-                "type": "integer"
-              }
-            },
-            "type": "object"
+            "$ref": "#/components/schemas/WebSearchServerToolConfig"
           },
           "type": {
             "enum": [
@@ -21368,7 +23830,7 @@
     },
     "/audio/speech": {
       "post": {
-        "description": "Synthesizes audio from the input text",
+        "description": "Synthesizes audio from the input text. Returns a raw audio bytestream in the requested format (e.g. mp3, pcm, wav).",
         "operationId": "createAudioSpeech",
         "requestBody": {
           "content": {
@@ -21566,12 +24028,13 @@
         "tags": [
           "TTS"
         ],
+        "x-speakeasy-max-method-params": 1,
         "x-speakeasy-name-override": "createSpeech"
       }
     },
     "/audio/transcriptions": {
       "post": {
-        "description": "Transcribes audio into text",
+        "description": "Transcribes audio into text. Accepts base64-encoded audio input and returns the transcribed text.",
         "operationId": "createAudioTranscriptions",
         "requestBody": {
           "content": {
@@ -21777,6 +24240,7 @@
         "tags": [
           "STT"
         ],
+        "x-speakeasy-max-method-params": 1,
         "x-speakeasy-name-override": "createTranscription"
       }
     },
@@ -22155,6 +24619,18 @@
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
+        "parameters": [
+          {
+            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`.",
+            "example": "enabled",
+            "in": "header",
+            "name": "X-OpenRouter-Experimental-Metadata",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MetadataLevel"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -22229,15 +24705,7 @@
                   }
                 },
                 "schema": {
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/ChatStreamChunk"
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/ChatStreamingResponse"
                 },
                 "x-speakeasy-sse-sentinel": "[DONE]"
               }
@@ -22291,6 +24759,78 @@
               }
             },
             "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "guardrail-blocked": {
+                    "summary": "Guardrail blocked the request",
+                    "value": {
+                      "error": {
+                        "code": 403,
+                        "message": "Request blocked: prompt injection patterns detected",
+                        "metadata": {
+                          "patterns": [
+                            "ignore all previous instructions"
+                          ]
+                        }
+                      },
+                      "openrouter_metadata": {
+                        "attempt": 1,
+                        "endpoints": {
+                          "available": [
+                            {
+                              "model": "openai/gpt-4o",
+                              "provider": "OpenAI",
+                              "selected": false
+                            }
+                          ],
+                          "total": 1
+                        },
+                        "is_byok": false,
+                        "pipeline": [
+                          {
+                            "data": {
+                              "action": "blocked",
+                              "detected": true,
+                              "engines": [
+                                "regex"
+                              ],
+                              "patterns": [
+                                "ignore all previous instructions"
+                              ]
+                            },
+                            "guardrail_id": "grd_abc123",
+                            "guardrail_scope": "api-key",
+                            "name": "regex_pi_detection",
+                            "summary": "Blocked: prompt injection detected (1 pattern matched)",
+                            "type": "guardrail"
+                          }
+                        ],
+                        "region": "iad",
+                        "requested": "openai/gpt-4o",
+                        "strategy": "direct",
+                        "summary": "available=1"
+                      }
+                    }
+                  },
+                  "insufficient-permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": {
+                        "code": 403,
+                        "message": "Only management keys can perform this operation"
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Experimental-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
           },
           "404": {
             "content": {
@@ -23161,6 +25701,7 @@
                         "request": "0"
                       },
                       "supported_parameters": [],
+                      "supported_voices": null,
                       "top_provider": {
                         "context_length": 8192,
                         "is_moderated": false,
@@ -23885,7 +26426,10 @@
                   "deepseek"
                 ],
                 "description": "A guardrail for limiting API usage",
-                "enforce_zdr": false,
+                "enforce_zdr_anthropic": true,
+                "enforce_zdr_google": false,
+                "enforce_zdr_openai": true,
+                "enforce_zdr_other": false,
                 "ignored_models": null,
                 "ignored_providers": null,
                 "limit_usd": 50,
@@ -23913,7 +26457,11 @@
                     ],
                     "created_at": "2025-08-24T10:30:00Z",
                     "description": "A guardrail for limiting API usage",
-                    "enforce_zdr": false,
+                    "enforce_zdr": null,
+                    "enforce_zdr_anthropic": true,
+                    "enforce_zdr_google": false,
+                    "enforce_zdr_openai": true,
+                    "enforce_zdr_other": false,
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
@@ -24468,7 +27016,11 @@
                     ],
                     "created_at": "2025-08-24T10:30:00Z",
                     "description": "Updated description",
-                    "enforce_zdr": true,
+                    "enforce_zdr": null,
+                    "enforce_zdr_anthropic": true,
+                    "enforce_zdr_google": true,
+                    "enforce_zdr_openai": true,
+                    "enforce_zdr_other": true,
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
@@ -27233,6 +29785,18 @@
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
+        "parameters": [
+          {
+            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`.",
+            "example": "enabled",
+            "in": "header",
+            "name": "X-OpenRouter-Experimental-Metadata",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MetadataLevel"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -27291,19 +29855,7 @@
                   "event": "content_block_delta"
                 },
                 "schema": {
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/MessagesStreamEvents"
-                    },
-                    "event": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "event",
-                    "data"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/MessagesStreamingResponse"
                 },
                 "x-speakeasy-sse-sentinel": "[DONE]"
               }
@@ -27347,19 +29899,74 @@
           "403": {
             "content": {
               "application/json": {
-                "example": {
-                  "error": {
-                    "message": "Permission denied",
-                    "type": "permission_error"
+                "examples": {
+                  "guardrail-blocked": {
+                    "summary": "Guardrail blocked the request",
+                    "value": {
+                      "error": {
+                        "code": 403,
+                        "message": "Request blocked: prompt injection patterns detected",
+                        "metadata": {
+                          "patterns": [
+                            "ignore all previous instructions"
+                          ]
+                        }
+                      },
+                      "openrouter_metadata": {
+                        "attempt": 1,
+                        "endpoints": {
+                          "available": [
+                            {
+                              "model": "openai/gpt-4o",
+                              "provider": "OpenAI",
+                              "selected": false
+                            }
+                          ],
+                          "total": 1
+                        },
+                        "is_byok": false,
+                        "pipeline": [
+                          {
+                            "data": {
+                              "action": "blocked",
+                              "detected": true,
+                              "engines": [
+                                "regex"
+                              ],
+                              "patterns": [
+                                "ignore all previous instructions"
+                              ]
+                            },
+                            "guardrail_id": "grd_abc123",
+                            "guardrail_scope": "api-key",
+                            "name": "regex_pi_detection",
+                            "summary": "Blocked: prompt injection detected (1 pattern matched)",
+                            "type": "guardrail"
+                          }
+                        ],
+                        "region": "iad",
+                        "requested": "openai/gpt-4o",
+                        "strategy": "direct",
+                        "summary": "available=1"
+                      }
+                    }
                   },
-                  "type": "error"
+                  "insufficient-permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": {
+                        "code": 403,
+                        "message": "Only management keys can perform this operation"
+                      }
+                    }
+                  }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/MessagesErrorResponse"
+                  "$ref": "#/components/schemas/ForbiddenResponse"
                 }
               }
             },
-            "description": "Permission denied error"
+            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Experimental-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
           },
           "404": {
             "content": {
@@ -27551,6 +30158,7 @@
                         "top_p",
                         "max_tokens"
                       ],
+                      "supported_voices": null,
                       "top_provider": {
                         "context_length": 8192,
                         "is_moderated": true,
@@ -27724,6 +30332,7 @@
                         "top_p",
                         "max_tokens"
                       ],
+                      "supported_voices": null,
                       "top_provider": {
                         "context_length": 8192,
                         "is_moderated": true,
@@ -29185,6 +31794,18 @@
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
+        "parameters": [
+          {
+            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`.",
+            "example": "enabled",
+            "in": "header",
+            "name": "X-OpenRouter-Experimental-Metadata",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MetadataLevel"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -29239,15 +31860,7 @@
                   }
                 },
                 "schema": {
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/StreamEvents"
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/ResponsesStreamingResponse"
                 },
                 "x-speakeasy-sse-sentinel": "[DONE]"
               }
@@ -29301,6 +31914,78 @@
               }
             },
             "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "guardrail-blocked": {
+                    "summary": "Guardrail blocked the request",
+                    "value": {
+                      "error": {
+                        "code": 403,
+                        "message": "Request blocked: prompt injection patterns detected",
+                        "metadata": {
+                          "patterns": [
+                            "ignore all previous instructions"
+                          ]
+                        }
+                      },
+                      "openrouter_metadata": {
+                        "attempt": 1,
+                        "endpoints": {
+                          "available": [
+                            {
+                              "model": "openai/gpt-4o",
+                              "provider": "OpenAI",
+                              "selected": false
+                            }
+                          ],
+                          "total": 1
+                        },
+                        "is_byok": false,
+                        "pipeline": [
+                          {
+                            "data": {
+                              "action": "blocked",
+                              "detected": true,
+                              "engines": [
+                                "regex"
+                              ],
+                              "patterns": [
+                                "ignore all previous instructions"
+                              ]
+                            },
+                            "guardrail_id": "grd_abc123",
+                            "guardrail_scope": "api-key",
+                            "name": "regex_pi_detection",
+                            "summary": "Blocked: prompt injection detected (1 pattern matched)",
+                            "type": "guardrail"
+                          }
+                        ],
+                        "region": "iad",
+                        "requested": "openai/gpt-4o",
+                        "strategy": "direct",
+                        "summary": "available=1"
+                      }
+                    }
+                  },
+                  "insufficient-permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": {
+                        "code": 403,
+                        "message": "Only management keys can perform this operation"
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Experimental-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
           },
           "404": {
             "content": {
@@ -29723,7 +32408,7 @@
                   "generation_id": "gen-xyz789",
                   "id": "job-abc123",
                   "polling_url": "/api/v1/videos/job-abc123",
-                  "status": "complete",
+                  "status": "completed",
                   "unsigned_urls": [
                     "https://storage.example.com/video.mp4"
                   ],
@@ -30891,11 +33576,13 @@
     },
     {
       "description": "Speech-to-text endpoints",
-      "name": "STT"
+      "name": "STT",
+      "x-displayName": "Transcriptions"
     },
     {
       "description": "Text-to-speech endpoints",
-      "name": "TTS"
+      "name": "TTS",
+      "x-displayName": "Speech"
     },
     {
       "description": "Video Generation endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-05-03T15:20:20+00:00",
+  "captured_at": "2026-05-15T07:34:15+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -18,7 +18,7 @@
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "62d6681f3fc2fe20",
+      "fingerprint": "2fb8480286edd199",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2a479c2a2828c351",
+      "fingerprint": "1745c85b0992ea6e",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "01579a8548d64ab2",
+      "fingerprint": "4cc4b797882b36d3",
       "id": "DELETE /workspaces/{id}",
       "method": "DELETE",
       "operation_id": "deleteWorkspace",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a8e8f18928c3c86a",
+      "fingerprint": "d9c39756fe253cfc",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "05cecac9b09a5e7c",
+      "fingerprint": "3c98257b3b15ba09",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dd243a0e87c9d573",
+      "fingerprint": "c83853c4260db3c5",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9c99e9bec1b7a449",
+      "fingerprint": "b2e4d7f17e7ec2b1",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d6afb8ddc3f2def3",
+      "fingerprint": "1fb2cd7855c02223",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9fbe3d8789b59348",
+      "fingerprint": "1deaadf338b00e36",
       "id": "GET /generation/content",
       "method": "GET",
       "operation_id": "listGenerationContent",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb76f9599911ccb5",
+      "fingerprint": "264aa20a1d9cbc98",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "50df372af92b0439",
+      "fingerprint": "35e6f73bb468cb70",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "48ed8bcc9c811a11",
+      "fingerprint": "03bb4f3b9c8e6c2e",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -150,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "aa3c9f9c9d5fe9ae",
+      "fingerprint": "b9eb37561bc9cf3e",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -161,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bdcc5f13eb39b87d",
+      "fingerprint": "a9e5751ca222eb49",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -172,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "622584d38112ff60",
+      "fingerprint": "bdcbd251388c2a9f",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c73983473e1c0e0e",
+      "fingerprint": "98111f144a36687a",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bd94c1cb6e19cdd2",
+      "fingerprint": "de272d5aefee14f8",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7d938af215f4d03a",
+      "fingerprint": "4c7015c8e6d592b1",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "05c136e1dd21a680",
+      "fingerprint": "c6a3e2527d06fa7e",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "360a71c424058693",
+      "fingerprint": "da4869e1fabb1f97",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0fe1c297d2f1f250",
+      "fingerprint": "424f3a218e16b0c8",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6545cb7dfeff2040",
+      "fingerprint": "a33d2e3dc88d6365",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "afba5151a3299caf",
+      "fingerprint": "9312fc5514215fa6",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6d3ec9bee71dc2ce",
+      "fingerprint": "0190e638a75a742c",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "14596fe6b03e4428",
+      "fingerprint": "b0430f4a6ffa4c65",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0c91e369c0a0d9e1",
+      "fingerprint": "fb1755e343f1ad00",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f762b88d789b2723",
+      "fingerprint": "800226a4045deb52",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b0afcba279847c18",
+      "fingerprint": "f620e15efc87f708",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "44a48065dd2d673d",
+      "fingerprint": "5e91b64f55580e2e",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -337,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "17f6c0ff95ea6247",
+      "fingerprint": "e927a97f82d97c98",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -348,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e96abe881cfbc08b",
+      "fingerprint": "ebfe6f0d6437a64d",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "65f48e9d0833fc3a",
+      "fingerprint": "649393331ddf22fa",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ba5f39f18353bf5f",
+      "fingerprint": "e9f162d1133bac67",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3e769b982b15ba24",
+      "fingerprint": "7b7b1e3ef6e95379",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "350024ac1009cddb",
+      "fingerprint": "c424a5da1b3397d0",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ce53dfc76885c522",
+      "fingerprint": "61976fd06ab1a0db",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -414,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4aae24f2458bd5da",
+      "fingerprint": "7fb9b0f9d6910b9f",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "3aae29d559805e6d",
+      "fingerprint": "460f78d19065c975",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3abf52828889b69d",
+      "fingerprint": "f006042818f6b442",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -447,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f1bba43860a3f2fe",
+      "fingerprint": "ad2b9ec1db9c46f1",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -458,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cac6ec19bd951299",
+      "fingerprint": "1e173c303b2ff6ba",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -469,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fc5f8809122a9fec",
+      "fingerprint": "7b9cda7b1e3ce55f",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -480,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a60d54c8a1dd80c0",
+      "fingerprint": "64055d638a961139",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -491,7 +491,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "95cd05e9fbc9490b",
+      "fingerprint": "642759fa50e0f210",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -502,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "42c34e6c3b001698",
+      "fingerprint": "dc02bce8d250dcc5",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -513,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1faacb2f462abb75",
+      "fingerprint": "272fc47d729c98ad",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -524,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dbf5cfac17d684c4",
+      "fingerprint": "62c81bdf62f2b7b7",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -535,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e380a2d857603c15",
+      "fingerprint": "997bbd2c929d64db",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -546,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f40410acf2aa121e",
+      "fingerprint": "c9db226fcb6c90df",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -557,7 +557,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5862d59faefd93a2",
+      "fingerprint": "397a8a2e22c940f0",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -568,7 +568,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e870d118f618fb87",
+      "fingerprint": "bcd57c55024b39f7",
       "id": "POST /workspaces/{id}/members/add",
       "method": "POST",
       "operation_id": "bulkAddWorkspaceMembers",
@@ -579,7 +579,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7ddc552ce8a708a0",
+      "fingerprint": "d3a2a804cb7e2d88",
       "id": "POST /workspaces/{id}/members/remove",
       "method": "POST",
       "operation_id": "bulkRemoveWorkspaceMembers",

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -13,7 +13,8 @@ use crate::{
         request as transport_request, response as transport_response, sse::response_lines,
     },
     types::{
-        ProviderPreferences, ReasoningConfig, ResponseFormat, Role, completion::CompletionsResponse,
+        OpenRouterExperimentalMetadata, ProviderPreferences, ReasoningConfig, ResponseFormat, Role,
+        completion::CompletionsResponse,
     },
     utils::parse_sse_frames,
 };
@@ -483,6 +484,10 @@ pub struct ChatCompletionRequest {
     stream: Option<bool>,
 
     #[builder(setter(strip_option), default)]
+    #[serde(skip)]
+    experimental_metadata: Option<OpenRouterExperimentalMetadata>,
+
+    #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
 
@@ -844,6 +849,10 @@ impl ChatCompletionRequest {
         req.stream = Some(stream);
         req
     }
+
+    pub fn experimental_metadata(&self) -> Option<OpenRouterExperimentalMetadata> {
+        self.experimental_metadata
+    }
 }
 
 /// Send a chat completion request to a selected model.
@@ -894,13 +903,16 @@ pub(crate) async fn send_chat_completion_with_client(
     // Ensure that the request is not streaming to get a single response
     let request = request.stream(false);
 
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
+    let response = transport_request::with_experimental_metadata_header(
+        transport_request::with_client_request_headers(
+            transport_request::post(http_client, &url),
+            api_key,
+            x_title,
+            http_referer,
+            app_categories,
+        )?,
+        &request.experimental_metadata,
+    )
     .json(&request)
     .send()
     .await?;
@@ -959,13 +971,16 @@ pub(crate) async fn stream_chat_completion_with_client(
     // Ensure that the request is streaming to get a continuous response
     let request = request.stream(true);
 
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
+    let response = transport_request::with_experimental_metadata_header(
+        transport_request::with_client_request_headers(
+            transport_request::post(http_client, &url),
+            api_key,
+            x_title,
+            http_referer,
+            app_categories,
+        )?,
+        &request.experimental_metadata,
+    )
     .json(&request)
     .send()
     .await?;

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -123,6 +123,8 @@ pub struct UserModel {
     #[serde(default)]
     pub supported_parameters: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_voices: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_parameters: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration_date: Option<String>,

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -1,12 +1,14 @@
 use http::StatusCode;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::error::{ApiErrorContext, ApiErrorKind, OpenRouterError};
 
 #[derive(Deserialize, Debug)]
 struct ApiErrorResponse {
     error: ApiError,
+    openrouter_metadata: Option<Value>,
+    user_id: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -53,8 +55,13 @@ fn normalize_error_status(status: StatusCode, api_code: Option<i64>) -> StatusCo
 fn build_api_error(
     status: StatusCode,
     request_id: Option<String>,
-    api_error: ApiError,
+    payload: ApiErrorResponse,
 ) -> OpenRouterError {
+    let ApiErrorResponse {
+        error: api_error,
+        openrouter_metadata,
+        user_id,
+    } = payload;
     let ApiError {
         code,
         message,
@@ -87,6 +94,8 @@ fn build_api_error(
         Some(ApiErrorMetadata::Raw(raw)) => (ApiErrorKind::Generic, Some(raw)),
         None => (ApiErrorKind::Generic, None),
     };
+    let normalized_metadata =
+        merge_top_level_metadata(normalized_metadata, openrouter_metadata, user_id);
 
     OpenRouterError::Api(Box::new(ApiErrorContext {
         status,
@@ -98,13 +107,42 @@ fn build_api_error(
     }))
 }
 
+fn merge_top_level_metadata(
+    metadata: Option<Value>,
+    openrouter_metadata: Option<Value>,
+    user_id: Option<String>,
+) -> Option<Value> {
+    if openrouter_metadata.is_none() && user_id.is_none() {
+        return metadata;
+    }
+
+    let mut merged = match metadata {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("error_metadata".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+
+    if let Some(openrouter_metadata) = openrouter_metadata {
+        merged.insert("openrouter_metadata".to_string(), openrouter_metadata);
+    }
+    if let Some(user_id) = user_id {
+        merged.insert("user_id".to_string(), Value::String(user_id));
+    }
+
+    Some(Value::Object(merged))
+}
+
 pub fn parse_api_error(
     status: StatusCode,
     request_id: Option<String>,
     text: &str,
 ) -> OpenRouterError {
     match serde_json::from_str::<ApiErrorResponse>(text) {
-        Ok(payload) => build_api_error(status, request_id, payload.error),
+        Ok(payload) => build_api_error(status, request_id, payload),
         Err(_) => OpenRouterError::Api(Box::new(ApiErrorContext {
             status,
             api_code: Some(i64::from(u16::from(status))),

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -41,6 +41,7 @@ pub struct GenerationData {
     pub num_media_completion: Option<u32>,
     pub num_search_results: Option<u32>,
     pub response_cache_source_id: Option<String>,
+    pub service_tier: Option<String>,
 }
 
 /// Stored prompt/input and completion/output content returned by `GET /generation/content`.

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -10,6 +10,90 @@ use crate::{
     types::{ApiResponse, PaginationOptions},
 };
 
+/// Action for a custom regex content filter.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum ContentFilterAction {
+    Redact,
+    Block,
+}
+
+/// Action for a built-in content filter.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum ContentFilterBuiltinAction {
+    Redact,
+    Block,
+    Flag,
+}
+
+/// Built-in content filter identifier.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub enum ContentFilterBuiltinSlug {
+    Email,
+    Phone,
+    Ssn,
+    CreditCard,
+    IpAddress,
+    PersonName,
+    Address,
+    RegexPromptInjection,
+}
+
+/// Built-in content filter entry used by guardrail create/update requests and responses.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ContentFilterBuiltinEntry {
+    pub slug: ContentFilterBuiltinSlug,
+    pub action: ContentFilterBuiltinAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl ContentFilterBuiltinEntry {
+    pub fn new(slug: ContentFilterBuiltinSlug, action: ContentFilterBuiltinAction) -> Self {
+        Self {
+            slug,
+            action,
+            label: None,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}
+
+/// Custom regex content filter entry used by guardrail create/update requests and responses.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ContentFilterEntry {
+    pub pattern: String,
+    pub action: ContentFilterAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl ContentFilterEntry {
+    pub fn new(pattern: impl Into<String>, action: ContentFilterAction) -> Self {
+        Self {
+            pattern: pattern.into(),
+            action,
+            label: None,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}
+
 /// Guardrail model.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
@@ -27,7 +111,19 @@ pub struct Guardrail {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_models: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_filter_builtins: Option<Vec<ContentFilterBuiltinEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_filters: Option<Vec<ContentFilterEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enforce_zdr: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforce_zdr_anthropic: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforce_zdr_openai: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforce_zdr_google: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforce_zdr_other: Option<bool>,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
@@ -65,9 +161,27 @@ pub struct CreateGuardrailRequest {
     #[builder(setter(custom), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_models: Option<Vec<String>>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_filter_builtins: Option<Vec<ContentFilterBuiltinEntry>>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_filters: Option<Vec<ContentFilterEntry>>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     enforce_zdr: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_zdr_anthropic: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_zdr_openai: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_zdr_google: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_zdr_other: Option<bool>,
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     workspace_id: Option<String>,
@@ -76,6 +190,8 @@ pub struct CreateGuardrailRequest {
 impl CreateGuardrailRequestBuilder {
     strip_option_vec_setter!(allowed_providers, String);
     strip_option_vec_setter!(allowed_models, String);
+    strip_option_vec_setter!(content_filter_builtins, ContentFilterBuiltinEntry);
+    strip_option_vec_setter!(content_filters, ContentFilterEntry);
 }
 
 impl CreateGuardrailRequest {
@@ -107,8 +223,26 @@ pub struct UpdateGuardrailRequest {
     #[serde(skip)]
     #[builder(setter(custom), default)]
     clear_allowed_models: bool,
+    #[builder(setter(custom), default)]
+    content_filter_builtins: Option<Vec<ContentFilterBuiltinEntry>>,
+    #[serde(skip)]
+    #[builder(setter(custom), default)]
+    clear_content_filter_builtins: bool,
+    #[builder(setter(custom), default)]
+    content_filters: Option<Vec<ContentFilterEntry>>,
+    #[serde(skip)]
+    #[builder(setter(custom), default)]
+    clear_content_filters: bool,
     #[builder(setter(strip_option), default)]
     enforce_zdr: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enforce_zdr_anthropic: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enforce_zdr_openai: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enforce_zdr_google: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enforce_zdr_other: Option<bool>,
 }
 
 impl Serialize for UpdateGuardrailRequest {
@@ -139,8 +273,33 @@ impl Serialize for UpdateGuardrailRequest {
         } else if let Some(value) = &self.allowed_models {
             map.serialize_entry("allowed_models", value)?;
         }
+        if self.clear_content_filter_builtins {
+            map.serialize_entry(
+                "content_filter_builtins",
+                &Option::<Vec<ContentFilterBuiltinEntry>>::None,
+            )?;
+        } else if let Some(value) = &self.content_filter_builtins {
+            map.serialize_entry("content_filter_builtins", value)?;
+        }
+        if self.clear_content_filters {
+            map.serialize_entry("content_filters", &Option::<Vec<ContentFilterEntry>>::None)?;
+        } else if let Some(value) = &self.content_filters {
+            map.serialize_entry("content_filters", value)?;
+        }
         if let Some(value) = &self.enforce_zdr {
             map.serialize_entry("enforce_zdr", value)?;
+        }
+        if let Some(value) = &self.enforce_zdr_anthropic {
+            map.serialize_entry("enforce_zdr_anthropic", value)?;
+        }
+        if let Some(value) = &self.enforce_zdr_openai {
+            map.serialize_entry("enforce_zdr_openai", value)?;
+        }
+        if let Some(value) = &self.enforce_zdr_google {
+            map.serialize_entry("enforce_zdr_google", value)?;
+        }
+        if let Some(value) = &self.enforce_zdr_other {
+            map.serialize_entry("enforce_zdr_other", value)?;
         }
         map.end()
     }
@@ -176,6 +335,38 @@ impl UpdateGuardrailRequestBuilder {
     pub fn clear_allowed_models(&mut self) -> &mut Self {
         self.allowed_models = Some(None);
         self.clear_allowed_models = Some(true);
+        self
+    }
+
+    pub fn content_filter_builtins<T, S>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<ContentFilterBuiltinEntry>,
+    {
+        self.content_filter_builtins = Some(Some(items.into_iter().map(Into::into).collect()));
+        self.clear_content_filter_builtins = Some(false);
+        self
+    }
+
+    pub fn content_filters<T, S>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<ContentFilterEntry>,
+    {
+        self.content_filters = Some(Some(items.into_iter().map(Into::into).collect()));
+        self.clear_content_filters = Some(false);
+        self
+    }
+
+    pub fn clear_content_filter_builtins(&mut self) -> &mut Self {
+        self.content_filter_builtins = Some(None);
+        self.clear_content_filter_builtins = Some(true);
+        self
+    }
+
+    pub fn clear_content_filters(&mut self) -> &mut Self {
+        self.content_filters = Some(None);
+        self.clear_content_filters = Some(true);
         self
     }
 }

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -651,7 +651,12 @@ pub enum AnthropicMessagesStreamEvent {
         delta: Value,
         usage: Value,
     },
-    MessageStop,
+    MessageStop {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        openrouter_metadata: Option<Value>,
+        #[serde(flatten)]
+        extra: HashMap<String, Value>,
+    },
     ContentBlockStart {
         index: u32,
         content_block: Box<AnthropicContentPart>,
@@ -674,7 +679,7 @@ impl AnthropicMessagesStreamEvent {
         match self {
             Self::MessageStart { .. } => "message_start",
             Self::MessageDelta { .. } => "message_delta",
-            Self::MessageStop => "message_stop",
+            Self::MessageStop { .. } => "message_stop",
             Self::ContentBlockStart { .. } => "content_block_start",
             Self::ContentBlockDelta { .. } => "content_block_delta",
             Self::ContentBlockStop { .. } => "content_block_stop",

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -13,7 +13,7 @@ use crate::{
     transport::{
         request as transport_request, response as transport_response, sse::response_lines,
     },
-    types::ProviderPreferences,
+    types::{OpenRouterExperimentalMetadata, ProviderPreferences},
     utils::parse_sse_frames,
 };
 
@@ -470,6 +470,10 @@ pub struct AnthropicMessagesRequest {
     stream: Option<bool>,
 
     #[builder(setter(strip_option), default)]
+    #[serde(skip)]
+    experimental_metadata: Option<OpenRouterExperimentalMetadata>,
+
+    #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
 
@@ -586,6 +590,10 @@ impl AnthropicMessagesRequest {
         let mut req = self.clone();
         req.stream = Some(stream);
         req
+    }
+
+    pub fn experimental_metadata(&self) -> Option<OpenRouterExperimentalMetadata> {
+        self.experimental_metadata
     }
 }
 
@@ -718,13 +726,16 @@ pub(crate) async fn create_message_with_client(
     let url = format!("{base_url}/messages");
     let request = request.stream(false);
 
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
+    let response = transport_request::with_experimental_metadata_header(
+        transport_request::with_client_request_headers(
+            transport_request::post(http_client, &url),
+            api_key,
+            x_title,
+            http_referer,
+            app_categories,
+        )?,
+        &request.experimental_metadata,
+    )
     .json(&request)
     .send()
     .await?;
@@ -775,13 +786,16 @@ pub(crate) async fn stream_messages_with_client(
     let url = format!("{base_url}/messages");
     let request = request.stream(true);
 
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
+    let response = transport_request::with_experimental_metadata_header(
+        transport_request::with_client_request_headers(
+            transport_request::post(http_client, &url),
+            api_key,
+            x_title,
+            http_referer,
+            app_categories,
+        )?,
+        &request.experimental_metadata,
+    )
     .json(&request)
     .send()
     .await?;

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -20,6 +20,8 @@ pub struct Model {
     pub top_provider: TopProvider,
     pub pricing: Pricing,
     pub per_request_limits: Option<std::collections::HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_voices: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -13,7 +13,7 @@ use crate::{
     transport::{
         request as transport_request, response as transport_response, sse::response_lines,
     },
-    types::ProviderPreferences,
+    types::{OpenRouterExperimentalMetadata, ProviderPreferences},
     utils::parse_sse_frames,
 };
 
@@ -143,6 +143,10 @@ pub struct ResponsesRequest {
     stream: Option<bool>,
 
     #[builder(setter(strip_option), default)]
+    #[serde(skip)]
+    experimental_metadata: Option<OpenRouterExperimentalMetadata>,
+
+    #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<ProviderPreferences>,
 
@@ -194,6 +198,10 @@ impl ResponsesRequest {
         let mut req = self.clone();
         req.stream = Some(stream);
         req
+    }
+
+    pub fn experimental_metadata(&self) -> Option<OpenRouterExperimentalMetadata> {
+        self.experimental_metadata
     }
 }
 
@@ -261,13 +269,16 @@ pub(crate) async fn create_response_with_client(
     let url = format!("{base_url}/responses");
     let request = request.stream(false);
 
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
+    let response = transport_request::with_experimental_metadata_header(
+        transport_request::with_client_request_headers(
+            transport_request::post(http_client, &url),
+            api_key,
+            x_title,
+            http_referer,
+            app_categories,
+        )?,
+        &request.experimental_metadata,
+    )
     .json(&request)
     .send()
     .await?;
@@ -316,13 +327,16 @@ pub(crate) async fn stream_response_with_client(
     let url = format!("{base_url}/responses");
     let request = request.stream(true);
 
-    let response = transport_request::with_client_request_headers(
-        transport_request::post(http_client, &url),
-        api_key,
-        x_title,
-        http_referer,
-        app_categories,
-    )?
+    let response = transport_request::with_experimental_metadata_header(
+        transport_request::with_client_request_headers(
+            transport_request::post(http_client, &url),
+            api_key,
+            x_title,
+            http_referer,
+            app_categories,
+        )?,
+        &request.experimental_metadata,
+    )
     .json(&request)
     .send()
     .await?;

--- a/src/transport/request.rs
+++ b/src/transport/request.rs
@@ -1,5 +1,7 @@
 use reqwest::{Client, Method, RequestBuilder};
 
+use crate::types::OpenRouterExperimentalMetadata;
+
 pub(crate) fn request(client: &Client, method: Method, url: &str) -> RequestBuilder {
     client.request(method, url)
 }
@@ -62,6 +64,20 @@ pub(crate) fn with_client_request_headers(
     )
 }
 
+pub(crate) fn with_experimental_metadata_header(
+    req: RequestBuilder,
+    experimental_metadata: &Option<OpenRouterExperimentalMetadata>,
+) -> RequestBuilder {
+    if let Some(level) = experimental_metadata {
+        req.header(
+            "X-OpenRouter-Experimental-Metadata",
+            level.as_header_value(),
+        )
+    } else {
+        req
+    }
+}
+
 fn serialize_app_categories(
     app_categories: &[String],
 ) -> Result<String, crate::error::OpenRouterError> {
@@ -107,7 +123,9 @@ fn serialize_app_categories(
 mod tests {
     use reqwest::header::AUTHORIZATION;
 
-    use super::{post, with_client_request_headers};
+    use crate::types::OpenRouterExperimentalMetadata;
+
+    use super::{post, with_client_request_headers, with_experimental_metadata_header};
 
     #[test]
     fn test_with_client_request_headers_sets_auth_and_metadata() {
@@ -175,6 +193,25 @@ mod tests {
         assert!(
             matches!(error, crate::error::OpenRouterError::ConfigError(_)),
             "expected config error, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn test_with_experimental_metadata_header_sets_level() {
+        let client = reqwest::Client::new();
+        let request = with_experimental_metadata_header(
+            post(&client, "http://example.com/test"),
+            &Some(OpenRouterExperimentalMetadata::Enabled),
+        )
+        .build()
+        .expect("request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("X-OpenRouter-Experimental-Metadata")
+                .expect("experimental metadata header should exist"),
+            "enabled"
         );
     }
 }

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -578,4 +578,8 @@ pub struct CompletionsResponse {
     pub provider: Option<String>,
     pub system_fingerprint: Option<String>,
     pub usage: Option<ResponseUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openrouter_metadata: Option<Value>,
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -161,6 +161,24 @@ pub struct ApiResponse<T> {
     pub data: T,
 }
 
+/// Opt-in level for OpenRouter's experimental response metadata header.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum OpenRouterExperimentalMetadata {
+    Disabled,
+    Enabled,
+}
+
+impl OpenRouterExperimentalMetadata {
+    pub(crate) fn as_header_value(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Enabled => "enabled",
+        }
+    }
+}
+
 /// Message role in a conversation
 ///
 /// Specifies who or what is sending a message in a chat completion.

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -726,7 +726,7 @@ pub fn adapt_messages_stream(
                                 });
                             }
                         }
-                        AnthropicMessagesStreamEvent::MessageStop => {
+                        AnthropicMessagesStreamEvent::MessageStop { .. } => {
                             state.done_emitted = true;
                             state.pending.push_back(UnifiedStreamEvent::Done {
                                 source: UnifiedStreamSource::Messages,

--- a/tests/unit/chat_api.rs
+++ b/tests/unit/chat_api.rs
@@ -11,7 +11,7 @@ use openrouter_rs::{
     api::chat::{
         ChatCompletionRequestBuilder, Message, send_chat_completion, stream_chat_completion,
     },
-    types::Role,
+    types::{OpenRouterExperimentalMetadata, Role, completion::CompletionsResponse},
 };
 
 struct CapturedRequest {
@@ -113,6 +113,7 @@ async fn test_send_chat_completion_sets_stream_false_and_headers() {
     let request = ChatCompletionRequestBuilder::default()
         .model("openai/gpt-4o-mini")
         .messages(vec![Message::new(Role::User, "hello")])
+        .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("chat request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
@@ -172,13 +173,55 @@ async fn test_send_chat_completion_sets_stream_false_and_headers() {
         "x-openrouter-categories header should be present, headers:\n{}",
         captured.header_text
     );
+    assert!(
+        headers_lower.contains("x-openrouter-experimental-metadata: enabled")
+            || headers_lower.contains("x-openrouter-experimental-metadata:enabled"),
+        "experimental metadata header should be present, headers:\n{}",
+        captured.header_text
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
     assert_eq!(request_json["stream"], false);
     assert_eq!(request_json["model"], "openai/gpt-4o-mini");
+    assert!(request_json.get("experimental_metadata").is_none());
 
     server.join().expect("server thread should finish");
+}
+
+#[test]
+fn test_chat_completion_response_deserializes_openrouter_metadata_and_service_tier() {
+    let raw = r#"{
+        "id": "gen-123",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "Hello"
+            }
+        }],
+        "created": 1700000000,
+        "model": "openai/gpt-4o-mini",
+        "object": "chat.completion",
+        "service_tier": "priority",
+        "openrouter_metadata": {
+            "attempt": 1,
+            "is_byok": false,
+            "summary": "available=1, selected=OpenAI"
+        }
+    }"#;
+
+    let parsed: CompletionsResponse =
+        serde_json::from_str(raw).expect("chat completion response should deserialize");
+
+    assert_eq!(parsed.service_tier.as_deref(), Some("priority"));
+    assert_eq!(
+        parsed
+            .openrouter_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("attempt"))
+            .and_then(|value| value.as_i64()),
+        Some(1)
+    );
 }
 
 #[tokio::test]

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -122,6 +122,7 @@ fn test_models_for_user_response_deserialization() {
             },
             "per_request_limits": null,
             "supported_parameters": ["temperature", "top_p"],
+            "supported_voices": ["alloy", "verse"],
             "default_parameters": null,
             "expiration_date": null
         }]
@@ -132,6 +133,10 @@ fn test_models_for_user_response_deserialization() {
     assert_eq!(parsed.data.len(), 1);
     assert_eq!(parsed.data[0].canonical_slug, "openai/gpt-4.1");
     assert_eq!(parsed.data[0].supported_parameters.len(), 2);
+    assert_eq!(
+        parsed.data[0].supported_voices.as_deref(),
+        Some(["alloy".to_string(), "verse".to_string()].as_slice())
+    );
     assert!(matches!(
         parsed.data[0].pricing.prompt,
         BigNumber::String(_)

--- a/tests/unit/error_model.rs
+++ b/tests/unit/error_model.rs
@@ -86,6 +86,67 @@ async fn test_normalized_generic_api_error_shape() {
 }
 
 #[tokio::test]
+async fn test_api_error_preserves_top_level_openrouter_metadata() {
+    let (base_url, server) = spawn_error_server(
+        "403 Forbidden",
+        r#"{
+            "error": {
+                "code": 403,
+                "message": "Guardrail blocked request"
+            },
+            "openrouter_metadata": {
+                "attempt": 1,
+                "pipeline": [{
+                    "type": "guardrail",
+                    "guardrail_id": "gr_123",
+                    "data": {
+                        "action": "block",
+                        "patterns": ["secret"]
+                    }
+                }]
+            },
+            "user_id": "user_123"
+        }"#,
+        Some("req_guardrail"),
+    );
+
+    let result = models::list_models(&base_url, "test-key", None, None).await;
+    let error = result.expect_err("request should fail");
+    match error {
+        OpenRouterError::Api(api_error) => {
+            assert_eq!(api_error.status, StatusCode::FORBIDDEN);
+            assert_eq!(api_error.api_code, Some(403));
+            assert_eq!(api_error.message, "Guardrail blocked request");
+            assert_eq!(api_error.request_id.as_deref(), Some("req_guardrail"));
+            assert_eq!(
+                api_error
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("openrouter_metadata"))
+                    .and_then(|metadata| metadata.get("pipeline"))
+                    .and_then(|pipeline| pipeline.get(0))
+                    .and_then(|stage| stage.get("guardrail_id"))
+                    .and_then(|value| value.as_str()),
+                Some("gr_123")
+            );
+            assert_eq!(
+                api_error
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("user_id"))
+                    .and_then(|value| value.as_str()),
+                Some("user_123")
+            );
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+
+    server
+        .join()
+        .expect("server thread should join in reasonable time");
+}
+
+#[tokio::test]
 async fn test_unreadable_error_body_preserves_read_failure_context() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -144,7 +144,8 @@ fn test_generation_response_deserializes_num_fetches() {
             "is_byok": false,
             "native_tokens_reasoning": 8,
             "num_fetches": 3,
-            "response_cache_source_id": "gen_original"
+            "response_cache_source_id": "gen_original",
+            "service_tier": "priority"
         }
     }"#;
 
@@ -158,6 +159,7 @@ fn test_generation_response_deserializes_num_fetches() {
         parsed.data.response_cache_source_id.as_deref(),
         Some("gen_original")
     );
+    assert_eq!(parsed.data.service_tier.as_deref(), Some("priority"));
 }
 
 #[test]

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -9,8 +9,10 @@ use std::{
 use openrouter_rs::{
     api::guardrails::{
         self, AssignedCountResponse, BulkKeyAssignmentRequest, BulkMemberAssignmentRequest,
-        CreateGuardrailRequest, Guardrail, GuardrailKeyAssignmentsResponse, GuardrailListResponse,
-        GuardrailMemberAssignmentsResponse, UnassignedCountResponse, UpdateGuardrailRequest,
+        ContentFilterAction, ContentFilterBuiltinAction, ContentFilterBuiltinEntry,
+        ContentFilterBuiltinSlug, ContentFilterEntry, CreateGuardrailRequest, Guardrail,
+        GuardrailKeyAssignmentsResponse, GuardrailListResponse, GuardrailMemberAssignmentsResponse,
+        UnassignedCountResponse, UpdateGuardrailRequest,
     },
     types::{ApiResponse, PaginationOptions},
 };
@@ -134,6 +136,49 @@ fn test_create_guardrail_request_serialization() {
 }
 
 #[test]
+fn test_create_guardrail_request_serializes_content_filters_and_provider_zdr_flags() {
+    let request = CreateGuardrailRequest::builder()
+        .name("Filtered")
+        .content_filter_builtins([ContentFilterBuiltinEntry::new(
+            ContentFilterBuiltinSlug::RegexPromptInjection,
+            ContentFilterBuiltinAction::Block,
+        )
+        .label("[PROMPT_INJECTION]")])
+        .content_filters([ContentFilterEntry::new(
+            r"\b(sk-[a-zA-Z0-9]{48})\b",
+            ContentFilterAction::Redact,
+        )
+        .label("[API_KEY]")])
+        .enforce_zdr_anthropic(true)
+        .enforce_zdr_openai(false)
+        .enforce_zdr_google(true)
+        .enforce_zdr_other(false)
+        .build()
+        .expect("create guardrail request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(
+        value["content_filter_builtins"][0]["slug"],
+        "regex-prompt-injection"
+    );
+    assert_eq!(value["content_filter_builtins"][0]["action"], "block");
+    assert_eq!(
+        value["content_filter_builtins"][0]["label"],
+        "[PROMPT_INJECTION]"
+    );
+    assert_eq!(
+        value["content_filters"][0]["pattern"],
+        r"\b(sk-[a-zA-Z0-9]{48})\b"
+    );
+    assert_eq!(value["content_filters"][0]["action"], "redact");
+    assert_eq!(value["content_filters"][0]["label"], "[API_KEY]");
+    assert_eq!(value["enforce_zdr_anthropic"], true);
+    assert_eq!(value["enforce_zdr_openai"], false);
+    assert_eq!(value["enforce_zdr_google"], true);
+    assert_eq!(value["enforce_zdr_other"], false);
+}
+
+#[test]
 fn test_update_guardrail_request_serialization() {
     let request = UpdateGuardrailRequest::builder()
         .name("Updated")
@@ -146,6 +191,51 @@ fn test_update_guardrail_request_serialization() {
     assert_eq!(value["enforce_zdr"], false);
     assert!(value.get("description").is_none());
     assert!(value.get("allowed_models").is_none());
+}
+
+#[test]
+fn test_update_guardrail_request_serializes_and_clears_content_filters() {
+    let request = UpdateGuardrailRequest::builder()
+        .content_filter_builtins([ContentFilterBuiltinEntry::new(
+            ContentFilterBuiltinSlug::Email,
+            ContentFilterBuiltinAction::Redact,
+        )
+        .label("[EMAIL]")])
+        .content_filters([ContentFilterEntry::new(
+            "secret",
+            ContentFilterAction::Block,
+        )])
+        .enforce_zdr_anthropic(true)
+        .enforce_zdr_openai(true)
+        .enforce_zdr_google(false)
+        .enforce_zdr_other(false)
+        .build()
+        .expect("update guardrail request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["content_filter_builtins"][0]["slug"], "email");
+    assert_eq!(value["content_filter_builtins"][0]["action"], "redact");
+    assert_eq!(value["content_filters"][0]["pattern"], "secret");
+    assert_eq!(value["content_filters"][0]["action"], "block");
+    assert_eq!(value["enforce_zdr_anthropic"], true);
+    assert_eq!(value["enforce_zdr_openai"], true);
+    assert_eq!(value["enforce_zdr_google"], false);
+    assert_eq!(value["enforce_zdr_other"], false);
+
+    let cleared = UpdateGuardrailRequest::builder()
+        .clear_content_filter_builtins()
+        .clear_content_filters()
+        .build()
+        .expect("update guardrail request should build");
+    let cleared_value = serde_json::to_value(&cleared).expect("request should serialize");
+    assert_eq!(
+        cleared_value.get("content_filter_builtins"),
+        Some(&serde_json::Value::Null)
+    );
+    assert_eq!(
+        cleared_value.get("content_filters"),
+        Some(&serde_json::Value::Null)
+    );
 }
 
 #[test]
@@ -224,7 +314,21 @@ fn test_guardrail_response_deserialization() {
             "reset_interval": "monthly",
             "allowed_providers": ["openai"],
             "allowed_models": ["openai/gpt-4.1"],
+            "content_filter_builtins": [{
+                "slug": "regex-prompt-injection",
+                "action": "flag",
+                "label": "[PROMPT_INJECTION]"
+            }],
+            "content_filters": [{
+                "pattern": "secret",
+                "action": "block",
+                "label": null
+            }],
             "enforce_zdr": true,
+            "enforce_zdr_anthropic": true,
+            "enforce_zdr_openai": false,
+            "enforce_zdr_google": true,
+            "enforce_zdr_other": false,
             "workspace_id": "ws_123",
             "created_at": "2025-01-01T00:00:00.000Z",
             "updated_at": "2025-01-02T00:00:00.000Z"
@@ -237,6 +341,18 @@ fn test_guardrail_response_deserialization() {
     assert_eq!(parsed.data.name, "Production Guardrail");
     assert_eq!(parsed.data.allowed_providers.unwrap_or_default().len(), 1);
     assert_eq!(parsed.data.enforce_zdr, Some(true));
+    assert_eq!(parsed.data.enforce_zdr_anthropic, Some(true));
+    assert_eq!(parsed.data.enforce_zdr_openai, Some(false));
+    assert_eq!(parsed.data.enforce_zdr_google, Some(true));
+    assert_eq!(parsed.data.enforce_zdr_other, Some(false));
+    assert_eq!(
+        parsed.data.content_filter_builtins.unwrap_or_default()[0].slug,
+        ContentFilterBuiltinSlug::RegexPromptInjection
+    );
+    assert_eq!(
+        parsed.data.content_filters.unwrap_or_default()[0].action,
+        ContentFilterAction::Block
+    );
     assert_eq!(parsed.data.workspace_id.as_deref(), Some("ws_123"));
 }
 

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -17,6 +17,7 @@ use openrouter_rs::api::{
         create_message, stream_messages,
     },
 };
+use openrouter_rs::types::OpenRouterExperimentalMetadata;
 use serde_json::json;
 
 #[test]
@@ -248,6 +249,7 @@ async fn test_stream_messages_parses_event_and_data_lines() {
         .model("anthropic/claude-sonnet-4")
         .max_tokens(128)
         .messages(vec![AnthropicMessage::user("hello")])
+        .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("messages request should build");
 
@@ -350,6 +352,7 @@ async fn test_stream_messages_parses_multiline_sse_frames() {
         .model("anthropic/claude-sonnet-4")
         .max_tokens(128)
         .messages(vec![AnthropicMessage::user("hello")])
+        .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("messages request should build");
 
@@ -449,6 +452,7 @@ async fn test_create_message_sets_stream_false_and_headers() {
         .model("anthropic/claude-sonnet-4")
         .max_tokens(128)
         .messages(vec![AnthropicMessage::user("hello")])
+        .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("messages request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
@@ -501,10 +505,16 @@ async fn test_create_message_sets_stream_false_and_headers() {
             || headers_lower.contains("x-openrouter-categories:cli-agent"),
         "x-openrouter-categories header should be present, headers:\n{header_text}"
     );
+    assert!(
+        headers_lower.contains("x-openrouter-experimental-metadata: enabled")
+            || headers_lower.contains("x-openrouter-experimental-metadata:enabled"),
+        "experimental metadata header should be present, headers:\n{header_text}"
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&request_body).expect("request body should be valid json");
     assert_eq!(request_json["stream"], false);
+    assert!(request_json.get("experimental_metadata").is_none());
 
     server.join().expect("server thread should finish");
 }

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -161,6 +161,44 @@ fn test_anthropic_messages_stream_event_deserialization() {
     }
 }
 
+#[test]
+fn test_anthropic_message_stop_event_preserves_metadata() {
+    let raw = r#"{
+        "type": "message_stop",
+        "openrouter_metadata": {
+            "provider": "Anthropic",
+            "pipeline": [{
+                "type": "provider",
+                "provider_name": "anthropic"
+            }]
+        },
+        "trace_id": "trace_123"
+    }"#;
+
+    let event: AnthropicMessagesStreamEvent =
+        serde_json::from_str(raw).expect("message_stop event should deserialize");
+    assert_eq!(event.event_type(), "message_stop");
+    match event {
+        AnthropicMessagesStreamEvent::MessageStop {
+            openrouter_metadata,
+            extra,
+        } => {
+            assert_eq!(
+                openrouter_metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("provider"))
+                    .and_then(|value| value.as_str()),
+                Some("Anthropic")
+            );
+            assert_eq!(
+                extra.get("trace_id").and_then(|value| value.as_str()),
+                Some("trace_123")
+            );
+        }
+        other => panic!("expected message_stop, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn test_stream_messages_parses_event_and_data_lines() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
@@ -231,6 +269,9 @@ async fn test_stream_messages_parses_event_and_data_lines() {
             "event: content_block_delta\r\n",
             "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\r\n",
             "\r\n",
+            "event: message_stop\r\n",
+            "data: {\"type\":\"message_stop\",\"openrouter_metadata\":{\"provider\":\"Anthropic\",\"pipeline\":[{\"type\":\"provider\",\"provider_name\":\"anthropic\"}]}}\r\n",
+            "\r\n",
             "data: [DONE]\r\n",
             "\r\n"
         );
@@ -272,7 +313,7 @@ async fn test_stream_messages_parses_event_and_data_lines() {
         serde_json::from_str(&request_body).expect("request body should be valid JSON");
     assert_eq!(request_json["stream"], true);
 
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 3);
     assert_eq!(events[0].event, "message_start");
     assert_eq!(events[1].event, "content_block_delta");
     match &events[1].data {
@@ -281,6 +322,22 @@ async fn test_stream_messages_parses_event_and_data_lines() {
             assert_eq!(delta["text"], "Hi");
         }
         _ => panic!("expected content_block_delta"),
+    }
+    assert_eq!(events[2].event, "message_stop");
+    match &events[2].data {
+        AnthropicMessagesStreamEvent::MessageStop {
+            openrouter_metadata,
+            ..
+        } => {
+            assert_eq!(
+                openrouter_metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("provider"))
+                    .and_then(|value| value.as_str()),
+                Some("Anthropic")
+            );
+        }
+        _ => panic!("expected message_stop"),
     }
 
     server.join().expect("server thread should finish");

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -113,6 +113,46 @@ fn test_model_endpoints_pricing_allows_missing_optional_fields() {
     assert!(pricing.image.is_none());
 }
 
+#[test]
+fn test_model_response_deserializes_supported_voices() {
+    let raw = r#"{
+        "data": [{
+            "id": "openai/tts-1",
+            "name": "OpenAI TTS",
+            "created": 1735689600,
+            "description": "Test model data",
+            "context_length": 4096,
+            "architecture": {
+                "modality": "text->audio",
+                "tokenizer": "Other",
+                "instruct_type": null
+            },
+            "top_provider": {
+                "context_length": 4096,
+                "max_completion_tokens": null,
+                "is_moderated": false
+            },
+            "pricing": {
+                "prompt": "0",
+                "completion": "0",
+                "image": null,
+                "request": "0"
+            },
+            "per_request_limits": null,
+            "supported_voices": ["alloy", "verse"]
+        }]
+    }"#;
+
+    let parsed: ApiResponse<Vec<models::Model>> =
+        serde_json::from_str(raw).expect("model list should deserialize");
+
+    assert_eq!(parsed.data[0].id, "openai/tts-1");
+    assert_eq!(
+        parsed.data[0].supported_voices.as_deref(),
+        Some(["alloy".to_string(), "verse".to_string()].as_slice())
+    );
+}
+
 #[tokio::test]
 async fn test_list_model_endpoints_encodes_author_slug_and_auth_header() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -13,6 +13,7 @@ use openrouter_rs::api::{
         ResponsesRequest, ResponsesResponse, ResponsesStreamEvent, create_response, stream_response,
     },
 };
+use openrouter_rs::types::OpenRouterExperimentalMetadata;
 use serde_json::json;
 
 struct CapturedRequest {
@@ -256,6 +257,7 @@ async fn test_create_response_sets_stream_false_and_headers() {
     let request = ResponsesRequest::builder()
         .model("openai/gpt-5")
         .input(json!([{"role":"user","content":"hello"}]))
+        .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("responses request should build");
     let x_title = Some("openrouter-rs-tests".to_string());
@@ -312,11 +314,18 @@ async fn test_create_response_sets_stream_false_and_headers() {
         "x-openrouter-categories header should be present, headers:\n{}",
         captured.header_text
     );
+    assert!(
+        headers_lower.contains("x-openrouter-experimental-metadata: enabled")
+            || headers_lower.contains("x-openrouter-experimental-metadata:enabled"),
+        "experimental metadata header should be present, headers:\n{}",
+        captured.header_text
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
     assert_eq!(request_json["stream"], false);
     assert_eq!(request_json["model"], "openai/gpt-5");
+    assert!(request_json.get("experimental_metadata").is_none());
 
     server.join().expect("server thread should finish");
 }


### PR DESCRIPTION
## Summary
- add SDK support for the 2026-05-15 OpenAPI drift: experimental metadata headers, chat metadata fields, guardrail content filters/provider ZDR flags, supported voices, and generation service tiers
- refresh the tracked OpenAPI baseline and endpoint matrix for the accepted 52-operation snapshot
- update README, changelog, and the domain chat example for the new metadata opt-in

## Verification
- cargo test --test unit
- just openapi-drift-check
- just quality

Closes #210