### PR TITLE
fix: refresh live contract model pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,9 @@ OPENROUTER_MANAGEMENT_KEY=sk-your-openrouter-management-key
 
 # Optional integration-test overrides
 # OPENROUTER_INTEGRATION_TIER=stable
-# OPENROUTER_TEST_CHAT_MODEL=x-ai/grok-code-fast-1
+# OPENROUTER_TEST_CHAT_MODEL=x-ai/grok-4.3
 # OPENROUTER_TEST_REASONING_MODEL=deepseek/deepseek-r1
-# OPENROUTER_TEST_STABLE_MODELS=x-ai/grok-code-fast-1,openai/gpt-4o-mini,deepseek/deepseek-r1
+# OPENROUTER_TEST_STABLE_MODELS=x-ai/grok-4.3,openai/gpt-4o-mini,deepseek/deepseek-r1
 # OPENROUTER_TEST_HOT_RESPONSES_MODELS=openai/gpt-5.4-pro,x-ai/grok-4.20-beta
 # OPENROUTER_TEST_HOT_RESPONSES_MODELS_LIMIT=10
 # OPENROUTER_RUN_MANAGEMENT_TESTS=1

--- a/examples/test_grok_model.rs
+++ b/examples/test_grok_model.rs
@@ -15,11 +15,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .x_title("openrouter-rs-grok-test")
         .build()?;
 
-    println!("Testing Grok model: x-ai/grok-code-fast-1");
+    println!("Testing Grok model: x-ai/grok-4.3");
     println!("=========================================\n");
 
     let chat_request = ChatCompletionRequest::builder()
-        .model("x-ai/grok-code-fast-1")
+        .model("x-ai/grok-4.3")
         .messages(vec![Message::new(
             Role::User,
             "Say 'Hello from Rust!' in exactly those words.",

--- a/scripts/sync_hot_models.sh
+++ b/scripts/sync_hot_models.sh
@@ -320,14 +320,14 @@ while IFS= read -r model; do
 done < <(read_existing_array '.stable.regression')
 
 if [ -z "$stable_chat" ]; then
-  stable_chat="x-ai/grok-code-fast-1"
+  stable_chat="x-ai/grok-4.3"
 fi
 if [ -z "$stable_reasoning" ]; then
   stable_reasoning="deepseek/deepseek-r1"
 fi
 if [ "${#stable_regression[@]}" -eq 0 ]; then
   stable_regression=(
-    "x-ai/grok-code-fast-1"
+    "x-ai/grok-4.3"
     "openai/gpt-4o-mini"
     "deepseek/deepseek-r1"
   )

--- a/tests/integration/model_pool.json
+++ b/tests/integration/model_pool.json
@@ -1,16 +1,16 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-03-02T00:00:00Z",
+  "generated_at": "2026-05-20T08:21:53Z",
   "source": {
-    "type": "bootstrap",
-    "endpoint": "https://openrouter.ai/rankings",
+    "type": "models-endpoint-fallback",
+    "endpoint": "https://openrouter.ai/api/v1/models",
     "top_n": 10
   },
   "stable": {
-    "chat": "x-ai/grok-code-fast-1",
+    "chat": "x-ai/grok-4.3",
     "reasoning": "deepseek/deepseek-r1",
     "regression": [
-      "x-ai/grok-code-fast-1",
+      "x-ai/grok-4.3",
       "openai/gpt-4o-mini",
       "deepseek/deepseek-r1"
     ]
@@ -18,16 +18,16 @@
   "responses": {
     "hot": {
       "models": [
-        "minimax/minimax-m2.5",
-        "google/gemini-3-flash-preview",
-        "deepseek/deepseek-v3.2",
-        "moonshotai/kimi-k2.5",
-        "anthropic/claude-opus-4.6",
-        "x-ai/grok-4.1-fast",
-        "anthropic/claude-sonnet-4.6",
-        "z-ai/glm-5",
-        "arcee-ai/trinity-large-preview:free",
-        "anthropic/claude-sonnet-4.5"
+        "google/gemini-3.5-flash",
+        "anthropic/claude-opus-4.7-fast",
+        "perceptron/perceptron-mk1",
+        "inclusionai/ring-2.6-1t",
+        "google/gemini-3.1-flash-lite",
+        "baidu/cobuddy:free",
+        "openai/gpt-chat-latest",
+        "x-ai/grok-4.3",
+        "ibm-granite/granite-4.1-8b",
+        "mistralai/mistral-medium-3-5"
       ]
     }
   }

--- a/tests/integration/model_pool.rs
+++ b/tests/integration/model_pool.rs
@@ -3,10 +3,10 @@ use std::{collections::HashSet, env, fs, path::PathBuf};
 
 const DEFAULT_MODEL_POOL_FILE: &str = "tests/integration/model_pool.json";
 const LEGACY_MODEL_POOL_FILE: &str = "tests/integration/hot_models.json";
-const DEFAULT_CHAT_MODEL: &str = "x-ai/grok-code-fast-1";
+const DEFAULT_CHAT_MODEL: &str = "x-ai/grok-4.3";
 const DEFAULT_REASONING_MODEL: &str = "deepseek/deepseek-r1";
 const DEFAULT_STABLE_REGRESSION_MODELS: [&str; 3] = [
-    "x-ai/grok-code-fast-1",
+    "x-ai/grok-4.3",
     "openai/gpt-4o-mini",
     "deepseek/deepseek-r1",
 ];
@@ -225,8 +225,8 @@ mod tests {
     #[test]
     fn test_model_pool_config_deserializes_missing_fields() {
         let parsed: ModelPoolConfig =
-            serde_json::from_str(r#"{"stable":{"chat":"x-ai/grok-code-fast-1"}}"#).unwrap();
-        assert_eq!(parsed.stable.chat.as_deref(), Some("x-ai/grok-code-fast-1"));
+            serde_json::from_str(r#"{"stable":{"chat":"x-ai/grok-4.3"}}"#).unwrap();
+        assert_eq!(parsed.stable.chat.as_deref(), Some("x-ai/grok-4.3"));
         assert!(parsed.stable.regression.is_empty());
         assert!(parsed.responses.hot.models.is_empty());
         assert!(parsed.hot.models.is_empty());

--- a/tests/unit/completion.rs
+++ b/tests/unit/completion.rs
@@ -45,7 +45,7 @@ fn test_response_with_index_field() {
             }
         }],
         "created": 1700000000,
-        "model": "x-ai/grok-code-fast-1",
+        "model": "x-ai/grok-4.3",
         "object": "chat.completion"
     }"#;
 


### PR DESCRIPTION
## Summary
- replace the deprecated x-ai/grok-code-fast-1 live contract default with x-ai/grok-4.3
- refresh tests/integration/model_pool.json from the current OpenRouter models endpoint
- update local examples and env override comments so future live checks do not point at the removed model

## Verification
- just quality
- cargo test --test integration model_pool:: -- --nocapture

Note: I could not rerun just test-live-contract locally because OPENROUTER_API_KEY is not configured in this environment. The GitHub live contract workflow should cover that with repository secrets.