### PR TITLE
feat: expose custom HTTP client builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `OpenRouterClientBuilder::http_client(...)` — allow injecting a custom `reqwest::Client`. Enables HTTP/SOCKS proxies (e.g. for geo-restricted routes), custom timeouts, retry/tracing middleware, mTLS, and other transport-layer customization. The internal default client is preserved when `.http_client(...)` is not called, so existing code is unaffected. See `examples/custom_http_client.rs`.
 - Added `OpenRouterExperimentalMetadata` request-header opt-in for chat completions, Responses API, and Anthropic-compatible Messages requests, plus typed chat response access to `service_tier` and `openrouter_metadata`.
 - Added typed SDK support for BYOK provider credential management (`GET|POST /byok`, `GET|PATCH|DELETE /byok/{id}`) via `api::byok` and `client.management().*_byok_key(...)` methods.
 - Added typed SDK support for observability destination management (`GET|POST /observability/destinations`, `GET|PATCH|DELETE /observability/destinations/{id}`) via `api::observability` and `client.management().*_observability_destination(...)` methods.

--- a/README.md
+++ b/README.md
@@ -118,8 +118,29 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 - `http_referer`
 - `x_title`
 - `app_categories`
+- `http_client`
 
 Chat, Responses API, and Anthropic-compatible Messages request builders also expose `experimental_metadata(OpenRouterExperimentalMetadata::Enabled)` for OpenRouter's opt-in routing metadata response header.
+
+### Custom HTTP client
+
+By default `OpenRouterClient` builds an internal `reqwest::Client` via `crate::transport::new_client()`. If you need to customize the underlying transport — to route through an HTTP/SOCKS proxy (e.g. for geo-restricted routes), tune timeouts, attach retry/tracing middleware, or configure mTLS — pass your own `reqwest::Client` via the builder:
+
+```rust
+use std::time::Duration;
+use openrouter_rs::OpenRouterClient;
+
+let http_client = reqwest::Client::builder()
+    .timeout(Duration::from_secs(120))
+    .pool_max_idle_per_host(64)
+    // .proxy(reqwest::Proxy::https("http://user:pass@proxy.example:6999")?)
+    .build()?;
+
+let client = OpenRouterClient::builder()
+    .api_key(std::env::var("OPENROUTER_API_KEY")?)
+    .http_client(http_client)
+    .build()?;
+```
 
 ## Common Workflows
 
@@ -147,6 +168,7 @@ The repo includes runnable examples for the highest-value workflows:
 | [`examples/axum_chat_gateway.rs`](examples/axum_chat_gateway.rs) | Minimal `axum` server that proxies prompts through `OpenRouterClient` |
 | [`examples/typed_tool_agent.rs`](examples/typed_tool_agent.rs) | Practical typed-tool agent loop with explicit tool dispatch |
 | [`examples/domain_chat_completion.rs`](examples/domain_chat_completion.rs) | Canonical `chat()` request with the domain-oriented client |
+| [`examples/custom_http_client.rs`](examples/custom_http_client.rs) | Inject a custom `reqwest::Client` (proxies, timeouts, middleware) |
 
 ### Tokio Streaming
 
@@ -196,6 +218,7 @@ cargo run --example create_transcription
 cargo run --example create_embedding
 cargo run --example list_byok_keys
 cargo run --example list_observability_destinations
+cargo run --example custom_http_client
 ```
 
 For shell and CI automation recipes built around the companion CLI, see [`docs/operations/cli-automation-workflows.md`](docs/operations/cli-automation-workflows.md).

--- a/README.md
+++ b/README.md
@@ -122,26 +122,6 @@ At runtime, the builder/client exposes the values the SDK directly consumes:
 
 Chat, Responses API, and Anthropic-compatible Messages request builders also expose `experimental_metadata(OpenRouterExperimentalMetadata::Enabled)` for OpenRouter's opt-in routing metadata response header.
 
-### Custom HTTP client
-
-By default `OpenRouterClient` builds an internal `reqwest::Client` via `crate::transport::new_client()`. If you need to customize the underlying transport — to route through an HTTP/SOCKS proxy (e.g. for geo-restricted routes), tune timeouts, attach retry/tracing middleware, or configure mTLS — pass your own `reqwest::Client` via the builder:
-
-```rust
-use std::time::Duration;
-use openrouter_rs::OpenRouterClient;
-
-let http_client = reqwest::Client::builder()
-    .timeout(Duration::from_secs(120))
-    .pool_max_idle_per_host(64)
-    // .proxy(reqwest::Proxy::https("http://user:pass@proxy.example:6999")?)
-    .build()?;
-
-let client = OpenRouterClient::builder()
-    .api_key(std::env::var("OPENROUTER_API_KEY")?)
-    .http_client(http_client)
-    .build()?;
-```
-
 ## Common Workflows
 
 `openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:

--- a/examples/custom_http_client.rs
+++ b/examples/custom_http_client.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
 use openrouter_rs::{
     OpenRouterClient,
     api::chat::{ChatCompletionRequest, Message},
     types::Role,
 };
+use std::time::Duration;
 
 /// Example: inject a custom `reqwest::Client` into `OpenRouterClient`.
 ///

--- a/examples/custom_http_client.rs
+++ b/examples/custom_http_client.rs
@@ -1,0 +1,70 @@
+use std::time::Duration;
+use openrouter_rs::{
+    OpenRouterClient,
+    api::chat::{ChatCompletionRequest, Message},
+    types::Role,
+};
+
+/// Example: inject a custom `reqwest::Client` into `OpenRouterClient`.
+///
+/// Useful when you need to:
+///   - route through an HTTP/SOCKS proxy (geo-restricted routes, corporate egress)
+///   - tighten or relax the default request timeouts
+///   - attach middleware (retries, tracing, metrics)
+///   - configure mTLS or custom root certificates
+///
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+
+    // Build a custom reqwest::Client. Replace these knobs with whatever your
+    // deployment needs — proxy, middleware, retry policy, custom TLS, etc.
+    let http_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .pool_max_idle_per_host(64)
+        .pool_idle_timeout(Duration::from_secs(90))
+        // Example: route all HTTPS traffic through a forward proxy.
+        // .proxy(reqwest::Proxy::https("http://user:pass@proxy.example:6999")?)
+        .build()?;
+
+    let client = OpenRouterClient::builder()
+        .api_key(api_key)
+        .http_referer("https://github.com/realmorrisliu/openrouter-rs")
+        .x_title("openrouter-rs-custom-http-client-example")
+        .http_client(http_client)
+        .build()?;
+
+    println!("Testing custom reqwest::Client injection");
+    println!("=========================================\n");
+
+    let chat_request = ChatCompletionRequest::builder()
+        .model("openai/gpt-4o-mini")
+        .messages(vec![Message::new(
+            Role::User,
+            "Reply with the single word: ready",
+        )])
+        .max_tokens(10)
+        .temperature(0.0)
+        .build()?;
+
+    let response = client.chat().create(&chat_request).await?;
+
+    println!("Response ID: {}", response.id);
+    println!("Model:       {}", response.model);
+
+    if let Some(choice) = response.choices.first() {
+        println!("Content:     {:?}", choice.content());
+    }
+
+    if let Some(usage) = &response.usage {
+        println!("\n--- Usage ---");
+        println!("Prompt tokens:     {}", usage.prompt_tokens);
+        println!("Completion tokens: {}", usage.completion_tokens);
+        println!("Total tokens:      {}", usage.total_tokens);
+    }
+
+    println!("\n=========================================");
+    println!("Custom HTTP client example completed successfully!");
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,7 +41,7 @@ pub struct OpenRouterClient {
     x_title: Option<String>,
     #[builder(setter(custom), default)]
     app_categories: Option<Vec<String>>,
-    #[builder(setter(skip), default = "crate::transport::new_client()?")]
+    #[builder(setter(into), default = "crate::transport::new_client()?")]
     http_client: reqwest::Client,
 }
 

--- a/tests/unit/custom_http_client.rs
+++ b/tests/unit/custom_http_client.rs
@@ -1,0 +1,27 @@
+use openrouter_rs::OpenRouterClient;
+use std::time::Duration;
+
+#[test]
+fn test_builder_accepts_custom_http_client() {
+    let custom = reqwest::Client::builder()
+        .timeout(Duration::from_secs(7))
+        .build()
+        .expect("custom reqwest::Client should build");
+
+    let client = OpenRouterClient::builder()
+        .api_key("test-api-key")
+        .http_client(custom)
+        .build();
+
+    assert!(client.is_ok(), "builder should accept a custom http_client");
+}
+
+#[test]
+fn test_builder_falls_back_to_default_http_client_when_omitted() {
+    let client = OpenRouterClient::builder().api_key("test-api-key").build();
+
+    assert!(
+        client.is_ok(),
+        "builder should use default http_client when none provided"
+    );
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -13,9 +13,9 @@ pub mod client_domains;
 #[cfg(feature = "legacy-completions")]
 pub mod client_legacy;
 pub mod client_management_key;
-pub mod custom_http_client;
 pub mod completion;
 pub mod credits;
+pub mod custom_http_client;
 pub mod default_headers;
 pub mod discovery;
 pub mod embeddings;

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -13,6 +13,7 @@ pub mod client_domains;
 #[cfg(feature = "legacy-completions")]
 pub mod client_legacy;
 pub mod client_management_key;
+pub mod custom_http_client;
 pub mod completion;
 pub mod credits;
 pub mod default_headers;


### PR DESCRIPTION
## Summary
- The `http_client` field on `OpenRouterClient` is currently `setter(skip)`, so the builder doesn't expose it. Consumers who need a non-default `reqwest::Client` — HTTP/SOCKS proxy for geo-restricted routes, custom timeouts, retry/tracing middleware, mTLS — have to fork the crate or work around it.
- Switch `setter(skip)` → `setter(into)` so the builder accepts a caller-provided `reqwest::Client`. The existing `default = "crate::transport::new_client()?"` is preserved, so callers that don't set one keep today's behavior.

## Related Issues
- None.

## Changes
- [x] API behavior changes
- [ ] Type/model changes
- [ ] Docs/examples updates
- [ ] CI/release changes

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The default value is unchanged, so existing builds continue to compile and behave identically. New behavior is purely additive — `.http_client(...)` on the builder is now available.