### PR TITLE
fix: sanitize OpenAPI key examples

### DIFF
--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -7,12 +7,15 @@ import datetime as dt
 import difflib
 import hashlib
 import json
+import re
 import sys
 import urllib.request
 from pathlib import Path
 from typing import Any
 
 UPSTREAM_OPENAPI_URL = "https://openrouter.ai/openapi.json"
+OPENROUTER_EXAMPLE_TOKEN_PATTERN = re.compile(r"sk-or-v1-[A-Za-z0-9_-]{20,}")
+OPENROUTER_EXAMPLE_TOKEN_PLACEHOLDER = "sk-or-v1-[REDACTED]"
 HTTP_METHODS = ("get", "post", "put", "patch", "delete", "options", "head", "trace")
 DOC_ONLY_FIELDS = {"description", "example", "examples", "externalDocs", "summary", "title"}
 REPO_KNOWN_METADATA_PARAMETERS = frozenset(
@@ -154,7 +157,7 @@ def validate_openapi_spec(spec: Any, source: str) -> dict[str, Any]:
     if not isinstance(paths, dict):
         raise ValueError(f"{source} is not an OpenAPI document: missing top-level `paths` object.")
 
-    return spec
+    return redact_openrouter_example_tokens(spec)
 
 
 def decode_json_pointer_token(token: str) -> str:
@@ -832,7 +835,23 @@ def collect_operations(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
 def reduce_spec_for_baseline(spec: dict[str, Any]) -> dict[str, Any]:
     reduced = {field: spec[field] for field in BASELINE_TOP_LEVEL_FIELDS if field in spec}
     reduced["paths"] = spec.get("paths", {})
-    return reduced
+    return redact_openrouter_example_tokens(reduced)
+
+
+def redact_openrouter_example_tokens(value: Any) -> Any:
+    if isinstance(value, str):
+        return OPENROUTER_EXAMPLE_TOKEN_PATTERN.sub(
+            OPENROUTER_EXAMPLE_TOKEN_PLACEHOLDER,
+            value,
+        )
+    if isinstance(value, list):
+        return [redact_openrouter_example_tokens(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: redact_openrouter_example_tokens(item)
+            for key, item in value.items()
+        }
+    return value
 
 
 def build_snapshot(spec: dict[str, Any], source_url: str) -> dict[str, Any]:

--- a/specs/openrouter/README.md
+++ b/specs/openrouter/README.md
@@ -30,6 +30,10 @@ Refresh the baseline locally with:
 just openapi-refresh-baseline
 ```
 
+The refresh tooling sanitizes OpenRouter API-key-shaped example values from the upstream spec before
+writing the checked-in baseline. Keep placeholder examples redacted; real or real-looking API keys
+do not belong in the repository even when they originate from upstream examples.
+
 Compare the tracked baseline against the latest upstream spec with:
 
 ```bash

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -27817,18 +27817,18 @@
             "content": {
               "application/json": {
                 "example": {
-                  "key": "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",
+                  "key": "sk-or-v1-[REDACTED]",
                   "user_id": "user_2yOPcMpKoQhcd4bVgSMlELRaIah"
                 },
                 "schema": {
                   "example": {
-                    "key": "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",
+                    "key": "sk-or-v1-[REDACTED]",
                     "user_id": "user_2yOPcMpKoQhcd4bVgSMlELRaIah"
                   },
                   "properties": {
                     "key": {
                       "description": "The API key to use for OpenRouter requests",
-                      "example": "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",
+                      "example": "sk-or-v1-[REDACTED]",
                       "type": "string"
                     },
                     "user_id": {
@@ -32816,7 +32816,7 @@
                     "usage_weekly": 0,
                     "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                   },
-                  "key": "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"
+                  "key": "sk-or-v1-[REDACTED]"
                 },
                 "schema": {
                   "example": {
@@ -32843,7 +32843,7 @@
                       "usage_weekly": 0,
                       "workspace_id": "0df9e665-d932-5740-b2c7-b52af166bc11"
                     },
-                    "key": "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"
+                    "key": "sk-or-v1-[REDACTED]"
                   },
                   "properties": {
                     "data": {
@@ -33021,7 +33021,7 @@
                     },
                     "key": {
                       "description": "The actual API key string (only shown once)",
-                      "example": "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",
+                      "example": "sk-or-v1-[REDACTED]",
                       "type": "string"
                     }
                   },

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -64,6 +64,66 @@ def build_spec(
 
 
 class OpenApiDriftReportTests(unittest.TestCase):
+    def test_reduce_spec_for_baseline_sanitizes_openrouter_api_key_examples(self):
+        raw_key = "sk-or-v1-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        spec = build_spec(
+            method="post",
+            path="/keys",
+            operation_id="createKey",
+            response_properties={
+                "key": {
+                    "type": "string",
+                    "example": raw_key,
+                },
+                "label": {
+                    "type": "string",
+                    "example": "sk-or-v1-...1c96",
+                },
+            },
+        )
+        spec["paths"]["/keys"]["post"]["responses"]["200"]["content"][
+            "application/json"
+        ]["example"] = {"key": raw_key}
+
+        reduced = openapi_drift.reduce_spec_for_baseline(spec)
+
+        content = reduced["paths"]["/keys"]["post"]["responses"]["200"]["content"][
+            "application/json"
+        ]
+        self.assertEqual(content["example"]["key"], "sk-or-v1-[REDACTED]")
+        self.assertEqual(
+            content["schema"]["properties"]["key"]["example"],
+            "sk-or-v1-[REDACTED]",
+        )
+        self.assertEqual(
+            content["schema"]["properties"]["label"]["example"],
+            "sk-or-v1-...1c96",
+        )
+
+    def test_validate_openapi_spec_sanitizes_openrouter_api_key_examples(self):
+        raw_key = "sk-or-v1-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        spec = build_spec(
+            method="post",
+            path="/auth/keys",
+            operation_id="createAuthKey",
+            response_properties={
+                "key": {
+                    "type": "string",
+                    "example": raw_key,
+                },
+            },
+        )
+
+        validated = openapi_drift.validate_openapi_spec(spec, "test spec")
+
+        content = validated["paths"]["/auth/keys"]["post"]["responses"]["200"][
+            "content"
+        ]["application/json"]
+        self.assertEqual(
+            content["schema"]["properties"]["key"]["example"],
+            "sk-or-v1-[REDACTED]",
+        )
+
     def test_metadata_only_header_drift_is_classified_as_already_supported(self):
         baseline = build_spec()
         candidate = build_spec(


### PR DESCRIPTION
## Summary
- Redact OpenRouter API-key-shaped example values from the tracked OpenAPI baseline.
- Add sanitizer coverage to OpenAPI validation/refresh paths so future upstream examples do not reintroduce key-shaped strings.
- Document the baseline redaction rule for future refreshes.

## Validation
- python3 -m unittest tests.test_openapi_drift
- jq scan confirmed 0 full OpenRouter key-shaped values in specs/openrouter/openapi-baseline.json
- just quality
- just openapi-drift-check (completed comparison; exited 2 because current upstream has actionable drift: added=1, changed=62, actionable_changed=3)