### PR TITLE
feat: accept OpenAPI drift for rankings and presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added typed SDK support for `GET /datasets/rankings-daily`, including `api::discovery::RankingsDailyResponse` and the canonical `client.models().get_rankings_daily(...)` surface.
+- Added management-key SDK support for creating or updating presets from inference request bodies via `POST /presets/{slug}/chat/completions`, `POST /presets/{slug}/responses`, and `POST /presets/{slug}/messages`.
+- Added `AnthropicRole::System` and `AnthropicMessage::system(...)` for the refreshed `/messages` role schema.
+- Added typed `GenerationData::preset_id` support on `GET /generation` metadata responses.
+
+### Changed
+- Accepted the 2026-06-01 OpenAPI drift review, including daily rankings datasets, preset creation endpoints, generation metadata additions, and provider taxonomy refreshes, restoring the repository snapshot to `66 / 66` official OpenAPI endpoint coverage.
+
 ## [0.10.0] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 </div>
 
-`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, video generation, models, embeddings, and management APIs, plus a companion CLI in the same repository.
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, video generation, models, embeddings, presets, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `62 / 62` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `66 / 66` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
@@ -32,7 +32,7 @@ The current repo snapshot implements `62 / 62` official OpenAPI method/path entr
 - Typed tools, manual JSON-schema tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
 - Opt-in experimental response metadata for chat, Responses API, and Anthropic-compatible Messages requests
-- Discovery, rerank, audio speech/transcription, video generation, embeddings, API-key management, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Discovery, rankings datasets, rerank, audio speech/transcription, video generation, embeddings, API-key management, preset creation, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -106,8 +106,8 @@ The canonical public surface is domain-oriented:
 | `audio().speech()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
 | `audio().transcriptions()` | `create` | `/audio/transcriptions` | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
-| `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/endpoints/zdr`, `/embeddings*` | API key |
-| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
+| `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/datasets/rankings-daily`, `/endpoints/zdr`, `/embeddings*` | API key |
+| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
 At runtime, the builder/client exposes the values the SDK directly consumes:
@@ -225,7 +225,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`62 / 62`)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`66 / 66`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,15 +1,15 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-05-19
+Snapshot date: 2026-06-05
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `62` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `62 / 62` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 62` endpoints currently exercised.
+- Official OpenAPI endpoints: `66` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `66 / 66` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 66` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
@@ -30,6 +30,8 @@ Drift review note:
 - Upstream added BYOK provider credential management and observability destination management. The SDK now exposes those typed management-key surfaces, and the 2026-05-19 baseline refresh restores the accepted endpoint snapshot to `62 / 62`.
 - Upstream expanded embeddings multimodal content with audio, video, and file content parts. The SDK now exposes typed `EmbeddingContentPart` constructors for those media inputs.
 - Upstream refreshed Responses schemas including image detail `original` and response status shapes. The SDK already carries these through flexible `Value` and `String` fields, so no public API migration is required.
+- Upstream added `GET /datasets/rankings-daily` and preset creation endpoints for chat-completions, Responses, and Anthropic-compatible Messages request bodies. The SDK now exposes rankings through `client.models().get_rankings_daily(...)` and preset creation through `client.management().create_*_preset(...)`.
+- Upstream refreshed generation metadata, provider taxonomy values, plugin payload shapes, and Messages role variants. Existing flexible `String`, `Value`, `HashMap`, and `Option` fields carry those schema details without a public API migration.
 
 Legend:
 
@@ -57,6 +59,7 @@ Legend:
 | `POST /chat/completions` | `client.chat().create(...)` / `client.chat().stream(...)` | Yes | Contract | Yes | Keep |
 | `GET /credits` | `client.get_credits()` / `client.management().get_credits()` | Yes | Path | No | P2 |
 | `POST /credits/coinbase` | `client.create_coinbase_charge(...)` / `client.management().create_coinbase_charge(...)` | Yes | Path | No | P2 |
+| `GET /datasets/rankings-daily` | `client.models().get_rankings_daily(...)` | Yes | Path | No | P2 |
 | `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | Yes | Keep |
 | `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | Path | Yes | Keep |
 | `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | Yes | Keep |
@@ -91,6 +94,9 @@ Legend:
 | `PATCH /observability/destinations/{id}` | `client.management().update_observability_destination(...)` | Yes | Path | No | P1 |
 | `DELETE /observability/destinations/{id}` | `client.management().delete_observability_destination(...)` | Yes | Path | No | P1 |
 | `GET /organization/members` | `client.management().list_organization_members(...)` | Yes | Path | Yes | Keep |
+| `POST /presets/{slug}/chat/completions` | `client.management().create_chat_completion_preset(...)` | Yes | Path | No | P2 |
+| `POST /presets/{slug}/messages` | `client.management().create_message_preset(...)` | Yes | Path | No | P2 |
+| `POST /presets/{slug}/responses` | `client.management().create_response_preset(...)` | Yes | Path | No | P2 |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
 | `GET /workspaces` | `client.management().list_workspaces(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}` | `client.management().get_workspace(...)` | Yes | Path | No | P1 |
@@ -122,7 +128,7 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity`.
-3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due cost/side effects.
+3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets/rankings-daily`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
 4. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, and `/videos*` once stable fixtures and cost controls are defined.
 5. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
 6. P1: add management-key live validation for `/byok*` and `/observability/destinations*` once safe test credentials and destination fixtures are defined.

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -918,6 +918,7 @@
         "type": "object"
       },
       "AnthropicCitationsConfig": {
+        "default": null,
         "example": {
           "enabled": true
         },
@@ -1269,7 +1270,6 @@
           }
         },
         "required": [
-          "citations",
           "source",
           "title",
           "type"
@@ -1558,6 +1558,21 @@
           "output_tokens": 50,
           "type": "message"
         }
+      },
+      "AnthropicOutputTokensDetails": {
+        "example": {
+          "thinking_tokens": 0
+        },
+        "nullable": true,
+        "properties": {
+          "thinking_tokens": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "thinking_tokens"
+        ],
+        "type": "object"
       },
       "AnthropicPlainTextSource": {
         "example": {
@@ -2469,6 +2484,7 @@
           "inference_geo": null,
           "input_tokens": 100,
           "output_tokens": 50,
+          "output_tokens_details": null,
           "server_tool_use": null,
           "service_tier": "standard"
         },
@@ -2494,6 +2510,9 @@
           "output_tokens": {
             "type": "integer"
           },
+          "output_tokens_details": {
+            "$ref": "#/components/schemas/AnthropicOutputTokensDetails"
+          },
           "server_tool_use": {
             "$ref": "#/components/schemas/AnthropicServerToolUsage"
           },
@@ -2504,6 +2523,7 @@
         "required": [
           "input_tokens",
           "output_tokens",
+          "output_tokens_details",
           "cache_creation_input_tokens",
           "cache_read_input_tokens",
           "cache_creation",
@@ -2923,6 +2943,14 @@
       },
       "ApplyPatchCallOperation": {
         "description": "The patch operation requested by an `apply_patch_call`. `create_file` and `update_file` carry a V4A diff; `delete_file` omits it.",
+        "discriminator": {
+          "mapping": {
+            "create_file": "#/components/schemas/ApplyPatchCreateFileOperation",
+            "delete_file": "#/components/schemas/ApplyPatchDeleteFileOperation",
+            "update_file": "#/components/schemas/ApplyPatchUpdateFileOperation"
+          },
+          "propertyName": "type"
+        },
         "example": {
           "diff": "@@ function main() {\n+  console.log(\"hi\");\n }",
           "path": "/src/main.ts",
@@ -2930,66 +2958,13 @@
         },
         "oneOf": [
           {
-            "properties": {
-              "diff": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
-              },
-              "type": {
-                "enum": [
-                  "create_file"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "type",
-              "path",
-              "diff"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/ApplyPatchCreateFileOperation"
           },
           {
-            "properties": {
-              "diff": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
-              },
-              "type": {
-                "enum": [
-                  "update_file"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "type",
-              "path",
-              "diff"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/ApplyPatchUpdateFileOperation"
           },
           {
-            "properties": {
-              "path": {
-                "type": "string"
-              },
-              "type": {
-                "enum": [
-                  "delete_file"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "type",
-              "path"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/ApplyPatchDeleteFileOperation"
           }
         ]
       },
@@ -3121,6 +3096,68 @@
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
       },
+      "ApplyPatchCreateFileOperation": {
+        "description": "The `create_file` variant of an `apply_patch_call.operation`. Carries a V4A diff describing the new file contents.",
+        "example": {
+          "diff": "@@\n+console.log(\"hi\");\n",
+          "path": "/src/main.ts",
+          "type": "create_file"
+        },
+        "properties": {
+          "diff": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "create_file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "path",
+          "diff"
+        ],
+        "type": "object"
+      },
+      "ApplyPatchDeleteFileOperation": {
+        "description": "The `delete_file` variant of an `apply_patch_call.operation`. Identifies the file to remove; no diff is required.",
+        "example": {
+          "path": "/src/main.ts",
+          "type": "delete_file"
+        },
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "delete_file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "path"
+        ],
+        "type": "object"
+      },
+      "ApplyPatchEngineEnum": {
+        "description": "Which apply_patch engine to use. \"auto\" (default) uses native passthrough when the endpoint advertises native apply_patch support, otherwise falls back to OpenRouter's HITL validator. \"native\" forces native passthrough \u2014 when the endpoint does not support native, the request falls back to HITL. \"openrouter\" always runs the HITL validator. Native passthrough streams the diff incrementally via `apply_patch_call_operation_diff.delta` events; HITL buffers the diff for atomic delivery as a single delta.",
+        "enum": [
+          "auto",
+          "native",
+          "openrouter"
+        ],
+        "example": "auto",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "ApplyPatchServerTool": {
         "description": "Apply patch tool configuration",
         "example": {
@@ -3141,8 +3178,14 @@
       },
       "ApplyPatchServerToolConfig": {
         "description": "Configuration for the openrouter:apply_patch server tool",
-        "example": {},
-        "properties": {},
+        "example": {
+          "engine": "auto"
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/ApplyPatchEngineEnum"
+          }
+        },
         "type": "object"
       },
       "ApplyPatchServerTool_OpenRouter": {
@@ -3166,12 +3209,41 @@
         ],
         "type": "object"
       },
+      "ApplyPatchUpdateFileOperation": {
+        "description": "The `update_file` variant of an `apply_patch_call.operation`. Carries a V4A diff describing edits to an existing file.",
+        "example": {
+          "diff": "@@ function main() {\n+  console.log(\"hi\");\n }",
+          "path": "/src/main.ts",
+          "type": "update_file"
+        },
+        "properties": {
+          "diff": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "update_file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "path",
+          "diff"
+        ],
+        "type": "object"
+      },
       "AutoRouterPlugin": {
         "example": {
           "allowed_models": [
             "anthropic/*",
             "openai/gpt-4o"
           ],
+          "cost_quality_tradeoff": 7,
           "enabled": true,
           "id": "auto-router"
         },
@@ -3187,6 +3259,13 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "cost_quality_tradeoff": {
+            "description": "Controls cost vs. quality routing tradeoff (0\u201310). 0 = pure quality (best model regardless of cost), 10 = maximize for cost (cheapest model wins). Intermediate values blend quality and cost signals continuously. Defaults to 7.",
+            "example": 7,
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
           },
           "enabled": {
             "description": "Set to false to disable the auto-router plugin for this request. Defaults to true.",
@@ -3340,9 +3419,11 @@
           "cloudflare",
           "cohere",
           "crusoe",
+          "darkbloom",
           "deepinfra",
           "deepseek",
           "dekallm",
+          "digitalocean",
           "featherless",
           "fireworks",
           "friendli",
@@ -3350,7 +3431,6 @@
           "google-ai-studio",
           "google-vertex",
           "groq",
-          "hyperbolic",
           "inception",
           "inceptron",
           "inference-net",
@@ -4110,6 +4190,7 @@
               "inference_geo": null,
               "input_tokens": 100,
               "output_tokens": 50,
+              "output_tokens_details": null,
               "server_tool_use": null,
               "service_tier": "standard"
             }
@@ -4568,6 +4649,7 @@
             "items": {
               "discriminator": {
                 "mapping": {
+                  "apply_patch_call": "#/components/schemas/OutputItemApplyPatchCall",
                   "custom_tool_call": "#/components/schemas/OutputItemCustomToolCall",
                   "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
                   "function_call": "#/components/schemas/OutputItemFunctionCall",
@@ -4599,6 +4681,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputItemApplyPatchCall"
                 }
               ]
             },
@@ -6156,7 +6241,8 @@
                   "moderation": "#/components/schemas/ModerationPlugin",
                   "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
-                  "web": "#/components/schemas/WebSearchPlugin"
+                  "web": "#/components/schemas/WebSearchPlugin",
+                  "web-fetch": "#/components/schemas/WebFetchPlugin"
                 },
                 "propertyName": "id"
               },
@@ -6169,6 +6255,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/WebSearchPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchPlugin"
                 },
                 {
                   "$ref": "#/components/schemas/FileParserPlugin"
@@ -6286,7 +6375,7 @@
             "x-speakeasy-unknown-values": "allow"
           },
           "session_id": {
-            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
+            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow). When provided, OpenRouter uses it as the sticky routing key, routing all requests in the session to the same provider to maximize prompt cache hits. Also used for observability grouping. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
             "maxLength": 256,
             "type": "string"
           },
@@ -6310,6 +6399,9 @@
             "example": [
               ""
             ]
+          },
+          "stop_server_tools_when": {
+            "$ref": "#/components/schemas/StopServerToolsWhen"
           },
           "stream": {
             "default": false,
@@ -6470,6 +6562,23 @@
             "enum": [
               "openrouter:experimental__search_models"
             ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ChatServerToolChoice": {
+        "description": "OpenRouter extension: force a specific server tool by naming it directly in `tool_choice.type` instead of wrapping it in `{ type: \"function\", function: { name } }`.",
+        "example": {
+          "type": "openrouter:web_search"
+        },
+        "properties": {
+          "type": {
+            "description": "OpenRouter server-tool type to force (e.g. `openrouter:web_search`, `web_search`, `web_search_preview`).",
+            "example": "openrouter:web_search",
             "type": "string"
           }
         },
@@ -6992,6 +7101,9 @@
           },
           {
             "$ref": "#/components/schemas/ChatNamedToolChoice"
+          },
+          {
+            "$ref": "#/components/schemas/ChatServerToolChoice"
           }
         ],
         "description": "Tool choice configuration",
@@ -7652,19 +7764,51 @@
       "ContentFilterBuiltinEntry": {
         "description": "A builtin content filter entry. Builtin filters include PII detectors and the regex-based prompt injection detector.",
         "example": {
-          "action": "block",
-          "label": "[PROMPT_INJECTION]",
-          "slug": "regex-prompt-injection"
+          "action": "redact",
+          "label": "[EMAIL]",
+          "slug": "email"
         },
         "properties": {
           "action": {
             "$ref": "#/components/schemas/ContentFilterBuiltinAction"
           },
           "label": {
-            "description": "Optional label used in redaction placeholders (e.g. \"[PROMPT_INJECTION]\")",
-            "example": "[PROMPT_INJECTION]",
+            "description": "Read-only, system-assigned redaction placeholder derived from the slug (e.g. \"[EMAIL]\", \"[PHONE]\"). Not settable by the caller.",
+            "example": "[EMAIL]",
             "maxLength": 100,
             "type": "string"
+          },
+          "scan_scope": {
+            "$ref": "#/components/schemas/PromptInjectionScanScope"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/ContentFilterBuiltinSlug"
+          }
+        },
+        "required": [
+          "slug",
+          "action"
+        ],
+        "type": "object"
+      },
+      "ContentFilterBuiltinEntryInput": {
+        "description": "A builtin content filter entry for create/update requests. Labels are system-assigned and cannot be set by the caller.",
+        "example": {
+          "action": "redact",
+          "slug": "email"
+        },
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/ContentFilterBuiltinAction"
+          },
+          "label": {
+            "deprecated": true,
+            "description": "Deprecated: labels are system-assigned and cannot be set by the caller. Accepted for backward compatibility but silently ignored.",
+            "maxLength": 100,
+            "type": "string"
+          },
+          "scan_scope": {
+            "$ref": "#/components/schemas/PromptInjectionScanScope"
           },
           "slug": {
             "$ref": "#/components/schemas/ContentFilterBuiltinSlug"
@@ -8133,7 +8277,7 @@
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/ContentFilterBuiltinEntry"
+              "$ref": "#/components/schemas/ContentFilterBuiltinEntryInput"
             },
             "nullable": true,
             "type": "array"
@@ -8255,9 +8399,9 @@
             ],
             "content_filter_builtins": [
               {
-                "action": "block",
-                "label": "[PROMPT_INJECTION]",
-                "slug": "regex-prompt-injection"
+                "action": "redact",
+                "label": "[EMAIL]",
+                "slug": "email"
               }
             ],
             "content_filters": null,
@@ -8349,7 +8493,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -8424,6 +8568,46 @@
                 "description": "The newly created observability destination."
               }
             ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "CreatePresetFromInferenceResponse": {
+        "description": "Response containing the created preset with its designated version.",
+        "example": {
+          "data": {
+            "created_at": "2026-04-20T10:00:00Z",
+            "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+            "description": null,
+            "designated_version": {
+              "config": {
+                "model": "openai/gpt-4o",
+                "temperature": 0.7
+              },
+              "created_at": "2026-04-20T10:00:00Z",
+              "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+              "system_prompt": "You are a helpful assistant.",
+              "updated_at": "2026-04-20T10:00:00Z",
+              "version": 1
+            },
+            "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+            "id": "650e8400-e29b-41d4-a716-446655440001",
+            "name": "my-preset",
+            "slug": "my-preset",
+            "status": "active",
+            "status_updated_at": null,
+            "updated_at": "2026-04-20T10:00:00Z",
+            "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PresetWithDesignatedVersion"
           }
         },
         "required": [
@@ -9917,6 +10101,11 @@
             "minItems": 1,
             "type": "array"
           },
+          "max_completion_tokens": {
+            "description": "Maximum number of output tokens (including reasoning tokens) each panelist and the judge model may produce per inner call. Controls the total output budget so reasoning-heavy models like GPT-5.5 do not exhaust their token allowance before producing visible text. When omitted, the provider's default applies.",
+            "example": 16384,
+            "type": "integer"
+          },
           "max_tool_calls": {
             "description": "Maximum number of tool-calling steps each panelist (analysis model) and the judge model may take during their agentic web-research loop. Models with web_search/web_fetch enabled iterate until they produce a text response or hit this ceiling. Defaults to 8. Capped at 16.",
             "example": 12,
@@ -9928,6 +10117,35 @@
             "description": "Slug of the judge model that produces the structured analysis JSON. Defaults to the model used in the outer API request.",
             "example": "~anthropic/claude-opus-latest",
             "type": "string"
+          },
+          "reasoning": {
+            "description": "Reasoning configuration forwarded to panelist and judge inner calls. Use this to control reasoning effort and token budget for models that support extended thinking.",
+            "properties": {
+              "effort": {
+                "description": "Reasoning effort level for panelist and judge inner calls.",
+                "enum": [
+                  "xhigh",
+                  "high",
+                  "medium",
+                  "low",
+                  "minimal",
+                  "none"
+                ],
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
+              },
+              "max_tokens": {
+                "description": "Maximum number of reasoning tokens each panelist and judge model may use. Helps bound cost when models allocate too much budget to chain-of-thought.",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "temperature": {
+            "description": "Sampling temperature forwarded to panelist and judge inner calls. When omitted, the provider's default applies.",
+            "example": 0.7,
+            "format": "double",
+            "type": "number"
           }
         },
         "type": "object"
@@ -10128,6 +10346,7 @@
                   "tts",
                   "stt",
                   "video",
+                  "image",
                   null
                 ],
                 "nullable": true,
@@ -10282,6 +10501,12 @@
                 "example": "https://openrouter.ai/",
                 "type": "string"
               },
+              "preset_id": {
+                "description": "ID of the preset used for this generation, null if no preset was used",
+                "example": "a9e8d400-592a-494f-908c-375efa66cafd",
+                "nullable": true,
+                "type": "string"
+              },
               "provider_name": {
                 "description": "Name of the provider that served the request",
                 "example": "Infermatic",
@@ -10415,6 +10640,7 @@
               "native_finish_reason",
               "external_user",
               "api_type",
+              "preset_id",
               "router",
               "provider_responses",
               "user_agent",
@@ -10473,9 +10699,9 @@
             ],
             "content_filter_builtins": [
               {
-                "action": "block",
-                "label": "[PROMPT_INJECTION]",
-                "slug": "regex-prompt-injection"
+                "action": "redact",
+                "label": "[EMAIL]",
+                "slug": "email"
               }
             ],
             "content_filters": null,
@@ -10654,9 +10880,9 @@
           ],
           "content_filter_builtins": [
             {
-              "action": "block",
-              "label": "[PROMPT_INJECTION]",
-              "slug": "regex-prompt-injection"
+              "action": "redact",
+              "label": "[EMAIL]",
+              "slug": "email"
             }
           ],
           "content_filters": null,
@@ -10707,9 +10933,9 @@
             "description": "Builtin content filters applied to requests. Includes PII detectors and the regex-based prompt injection detector.",
             "example": [
               {
-                "action": "block",
-                "label": "[PROMPT_INJECTION]",
-                "slug": "regex-prompt-injection"
+                "action": "redact",
+                "label": "[EMAIL]",
+                "slug": "email"
               }
             ],
             "items": {
@@ -11087,7 +11313,7 @@
         "description": "OpenRouter built-in server tool: generates images from text prompts using an image generation model",
         "example": {
           "parameters": {
-            "model": "openai/gpt-image-1",
+            "model": "openai/gpt-5-image",
             "quality": "high",
             "size": "1024x1024"
           },
@@ -12160,9 +12386,9 @@
               ],
               "content_filter_builtins": [
                 {
-                  "action": "block",
-                  "label": "[PROMPT_INJECTION]",
-                  "slug": "regex-prompt-injection"
+                  "action": "redact",
+                  "label": "[EMAIL]",
+                  "slug": "email"
                 }
               ],
               "content_filters": null,
@@ -13247,6 +13473,9 @@
               "output_tokens": {
                 "type": "integer"
               },
+              "output_tokens_details": {
+                "$ref": "#/components/schemas/AnthropicOutputTokensDetails"
+              },
               "server_tool_use": {
                 "nullable": true,
                 "properties": {
@@ -13267,6 +13496,7 @@
             "required": [
               "input_tokens",
               "output_tokens",
+              "output_tokens_details",
               "cache_creation_input_tokens",
               "cache_read_input_tokens",
               "server_tool_use"
@@ -13646,7 +13876,8 @@
           "role": {
             "enum": [
               "user",
-              "assistant"
+              "assistant",
+              "system"
             ],
             "type": "string",
             "x-speakeasy-unknown-values": "allow"
@@ -13964,7 +14195,8 @@
                   "moderation": "#/components/schemas/ModerationPlugin",
                   "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
-                  "web": "#/components/schemas/WebSearchPlugin"
+                  "web": "#/components/schemas/WebSearchPlugin",
+                  "web-fetch": "#/components/schemas/WebFetchPlugin"
                 },
                 "propertyName": "id"
               },
@@ -13977,6 +14209,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/WebSearchPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchPlugin"
                 },
                 {
                   "$ref": "#/components/schemas/FileParserPlugin"
@@ -14007,7 +14242,7 @@
             "type": "string"
           },
           "session_id": {
-            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
+            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow). When provided, OpenRouter uses it as the sticky routing key, routing all requests in the session to the same provider to maximize prompt cache hits. Also used for observability grouping. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
             "maxLength": 256,
             "type": "string"
           },
@@ -14027,6 +14262,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "stop_server_tools_when": {
+            "$ref": "#/components/schemas/StopServerToolsWhen"
           },
           "stream": {
             "type": "boolean"
@@ -14551,7 +14789,7 @@
                   "input_tokens": 100,
                   "output_tokens": 50,
                   "server_tool_use": null,
-                  "service_tier": "standard"
+                  "service_tier": "default"
                 }
               }
             },
@@ -14583,7 +14821,7 @@
             "input_tokens": 12,
             "output_tokens": 15,
             "server_tool_use": null,
-            "service_tier": "standard"
+            "service_tier": "default"
           }
         }
       },
@@ -14633,6 +14871,7 @@
                   "Enfer",
                   "GoPomelo",
                   "HuggingFace",
+                  "Hyperbolic",
                   "Hyperbolic 2",
                   "InoCloud",
                   "Kluster",
@@ -14678,9 +14917,11 @@
                   "Cohere",
                   "Crucible",
                   "Crusoe",
+                  "Darkbloom",
                   "DeepInfra",
                   "DeepSeek",
                   "DekaLLM",
+                  "DigitalOcean",
                   "Featherless",
                   "Fireworks",
                   "Friendli",
@@ -14688,7 +14929,6 @@
                   "Google",
                   "Google AI Studio",
                   "Groq",
-                  "Hyperbolic",
                   "Inception",
                   "Inceptron",
                   "InferenceNet",
@@ -14790,7 +15030,7 @@
                   "input_tokens": 100,
                   "output_tokens": 50,
                   "server_tool_use": null,
-                  "service_tier": "standard"
+                  "service_tier": "default"
                 }
               }
             },
@@ -15677,7 +15917,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -15804,7 +16044,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -15944,7 +16184,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -16074,7 +16314,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -16390,7 +16630,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -16517,7 +16757,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -16649,7 +16889,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -16775,7 +17015,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -16903,7 +17143,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17018,7 +17258,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17139,7 +17379,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17261,7 +17501,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17409,7 +17649,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17530,7 +17770,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17668,7 +17908,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17801,7 +18041,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -17924,7 +18164,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate for events sent to this destination, between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate for events sent to this destination, between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -19578,6 +19818,10 @@
                 "model": {
                   "description": "Slug of the analysis model that failed.",
                   "type": "string"
+                },
+                "status_code": {
+                  "description": "HTTP status code from the upstream response, when available (e.g. 402, 429).",
+                  "type": "integer"
                 }
               },
               "required": [
@@ -19587,6 +19831,10 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "failure_reason": {
+            "description": "Typed failure reason when the fusion run failed. Possible values include: all_panels_failed, insufficient_credits, rate_limited, judge_not_valid_json, judge_schema_mismatch, judge_upstream_error, judge_empty_completion.",
+            "type": "string"
           },
           "id": {
             "type": "string"
@@ -19700,6 +19948,7 @@
           "item": {
             "discriminator": {
               "mapping": {
+                "apply_patch_call": "#/components/schemas/OutputItemApplyPatchCall",
                 "custom_tool_call": "#/components/schemas/OutputItemCustomToolCall",
                 "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
                 "function_call": "#/components/schemas/OutputItemFunctionCall",
@@ -19731,6 +19980,9 @@
               },
               {
                 "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemApplyPatchCall"
               }
             ]
           },
@@ -19752,6 +20004,73 @@
           "output_index",
           "item",
           "sequence_number"
+        ],
+        "type": "object"
+      },
+      "OutputItemApplyPatchCall": {
+        "example": {
+          "call_id": "call_abc123",
+          "id": "apc_abc123",
+          "operation": {
+            "diff": "@@ function main() {\n+  console.log(\"hi\");\n }",
+            "path": "/src/main.ts",
+            "type": "update_file"
+          },
+          "status": "completed",
+          "type": "apply_patch_call"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "operation": {
+            "discriminator": {
+              "mapping": {
+                "create_file": "#/components/schemas/ApplyPatchCreateFileOperation",
+                "delete_file": "#/components/schemas/ApplyPatchDeleteFileOperation",
+                "update_file": "#/components/schemas/ApplyPatchUpdateFileOperation"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ApplyPatchCreateFileOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ApplyPatchUpdateFileOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ApplyPatchDeleteFileOperation"
+              }
+            ]
+          },
+          "status": {
+            "enum": [
+              "in_progress",
+              "completed"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "type": {
+            "enum": [
+              "apply_patch_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "operation",
+          "status"
         ],
         "type": "object"
       },
@@ -19819,6 +20138,7 @@
           "item": {
             "discriminator": {
               "mapping": {
+                "apply_patch_call": "#/components/schemas/OutputItemApplyPatchCall",
                 "custom_tool_call": "#/components/schemas/OutputItemCustomToolCall",
                 "file_search_call": "#/components/schemas/OutputItemFileSearchCall",
                 "function_call": "#/components/schemas/OutputItemFunctionCall",
@@ -19850,6 +20170,9 @@
               },
               {
                 "$ref": "#/components/schemas/OutputItemImageGenerationCall"
+              },
+              {
+                "$ref": "#/components/schemas/OutputItemApplyPatchCall"
               }
             ]
           },
@@ -21254,6 +21577,157 @@
         "description": "Preferred minimum throughput (in tokens per second). Can be a number (applies to p50) or an object with percentile-specific cutoffs. Endpoints below the threshold(s) may still be used, but are deprioritized in routing. When using fallback models, this may cause a fallback model to be used instead of the primary model if it meets the threshold.",
         "example": 100
       },
+      "PresetDesignatedVersion": {
+        "description": "A specific version of a preset, containing config and optional system prompt.",
+        "example": {
+          "config": {
+            "model": "openai/gpt-4o",
+            "temperature": 0.7
+          },
+          "created_at": "2026-04-20T10:00:00Z",
+          "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+          "system_prompt": "You are a helpful assistant.",
+          "updated_at": "2026-04-20T10:00:00Z",
+          "version": 1
+        },
+        "nullable": true,
+        "properties": {
+          "config": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "creator_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "preset_id": {
+            "type": "string"
+          },
+          "system_prompt": {
+            "nullable": true,
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "preset_id",
+          "creator_id",
+          "version",
+          "system_prompt",
+          "config",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "PresetWithDesignatedVersion": {
+        "description": "A preset with its currently designated version.",
+        "example": {
+          "created_at": "2026-04-20T10:00:00Z",
+          "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+          "description": null,
+          "designated_version": {
+            "config": {
+              "model": "openai/gpt-4o",
+              "temperature": 0.7
+            },
+            "created_at": "2026-04-20T10:00:00Z",
+            "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+            "system_prompt": "You are a helpful assistant.",
+            "updated_at": "2026-04-20T10:00:00Z",
+            "version": 1
+          },
+          "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+          "id": "650e8400-e29b-41d4-a716-446655440001",
+          "name": "my-preset",
+          "slug": "my-preset",
+          "status": "active",
+          "status_updated_at": null,
+          "updated_at": "2026-04-20T10:00:00Z",
+          "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+        },
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "creator_user_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "designated_version": {
+            "$ref": "#/components/schemas/PresetDesignatedVersion"
+          },
+          "designated_version_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "disabled",
+              "archived"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "status_updated_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "creator_user_id",
+          "workspace_id",
+          "name",
+          "slug",
+          "description",
+          "status",
+          "designated_version_id",
+          "created_at",
+          "updated_at",
+          "status_updated_at",
+          "designated_version"
+        ],
+        "type": "object"
+      },
       "Preview_20250311_WebSearchServerTool": {
         "description": "Web search preview tool configuration (2025-03-11 version)",
         "example": {
@@ -21362,6 +21836,16 @@
         ],
         "type": "object"
       },
+      "PromptInjectionScanScope": {
+        "description": "Which message roles to scan for prompt injection. Only applies to the regex-prompt-injection builtin. Defaults to all_messages.",
+        "enum": [
+          "user_only",
+          "all_messages"
+        ],
+        "example": "user_only",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "ProviderName": {
         "enum": [
           "AkashML",
@@ -21388,9 +21872,11 @@
           "Cohere",
           "Crucible",
           "Crusoe",
+          "Darkbloom",
           "DeepInfra",
           "DeepSeek",
           "DekaLLM",
+          "DigitalOcean",
           "Featherless",
           "Fireworks",
           "Friendli",
@@ -21398,7 +21884,6 @@
           "Google",
           "Google AI Studio",
           "Groq",
-          "Hyperbolic",
           "Inception",
           "Inceptron",
           "InferenceNet",
@@ -21634,6 +22119,12 @@
             },
             "type": "object"
           },
+          "darkbloom": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
           "deepinfra": {
             "additionalProperties": {
               "nullable": true
@@ -21647,6 +22138,12 @@
             "type": "object"
           },
           "dekallm": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "digitalocean": {
             "additionalProperties": {
               "nullable": true
             },
@@ -22412,6 +22909,7 @@
               "Enfer",
               "GoPomelo",
               "HuggingFace",
+              "Hyperbolic",
               "Hyperbolic 2",
               "InoCloud",
               "Kluster",
@@ -22457,9 +22955,11 @@
               "Cohere",
               "Crucible",
               "Crusoe",
+              "Darkbloom",
               "DeepInfra",
               "DeepSeek",
               "DekaLLM",
+              "DigitalOcean",
               "Featherless",
               "Fireworks",
               "Friendli",
@@ -22467,7 +22967,6 @@
               "Google",
               "Google AI Studio",
               "Groq",
-              "Hyperbolic",
               "Inception",
               "Inceptron",
               "InferenceNet",
@@ -23031,6 +23530,114 @@
         "example": "fp16",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "RankingsDailyItem": {
+        "example": {
+          "date": "2026-05-11",
+          "model_permaslug": "openai/gpt-4o-2024-05-13",
+          "total_tokens": "12345678"
+        },
+        "properties": {
+          "date": {
+            "description": "UTC calendar date the row is aggregated over (YYYY-MM-DD).",
+            "example": "2026-05-11",
+            "type": "string"
+          },
+          "model_permaslug": {
+            "description": "Model variant permaslug (e.g. `openai/gpt-4o-2024-05-13`, `openai/gpt-4o-2024-05-13:free`). Non-default variants include a `:variant` suffix and are ranked as their own entry. The reserved value `other` denotes the aggregated row covering every model outside the daily top 50 for that date \u2014 always sorted last within its date.",
+            "example": "openai/gpt-4o-2024-05-13",
+            "type": "string"
+          },
+          "total_tokens": {
+            "description": "Sum of `prompt_tokens + completion_tokens` for the day, returned as a decimal string so 64-bit values are not truncated.",
+            "example": "12345678",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "model_permaslug",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "RankingsDailyMeta": {
+        "example": {
+          "as_of": "2026-05-12T02:00:00Z",
+          "end_date": "2026-05-11",
+          "start_date": "2026-04-12",
+          "version": "v1"
+        },
+        "properties": {
+          "as_of": {
+            "description": "ISO-8601 timestamp of when the response was generated. Reflects data-freshness because the underlying materialized view continuously ingests upstream events.",
+            "example": "2026-05-12T02:00:00Z",
+            "type": "string"
+          },
+          "end_date": {
+            "description": "Resolved end of the date window (UTC, inclusive).",
+            "example": "2026-05-11",
+            "type": "string"
+          },
+          "start_date": {
+            "description": "Resolved start of the date window (UTC, inclusive).",
+            "example": "2026-04-12",
+            "type": "string"
+          },
+          "version": {
+            "description": "Dataset version. Field names and grain are stable for the life of `v1`.",
+            "enum": [
+              "v1"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "as_of",
+          "version",
+          "start_date",
+          "end_date"
+        ],
+        "type": "object"
+      },
+      "RankingsDailyResponse": {
+        "example": {
+          "data": [
+            {
+              "date": "2026-05-11",
+              "model_permaslug": "openai/gpt-4o-2024-05-13",
+              "total_tokens": "12345678"
+            },
+            {
+              "date": "2026-05-11",
+              "model_permaslug": "anthropic/claude-3.5-sonnet-20241022",
+              "total_tokens": "9876543"
+            }
+          ],
+          "meta": {
+            "as_of": "2026-05-12T02:00:00Z",
+            "end_date": "2026-05-11",
+            "start_date": "2026-04-12",
+            "version": "v1"
+          }
+        },
+        "properties": {
+          "data": {
+            "description": "Up to 51 rows per day \u2014 the top 50 public models by `total_tokens` for each UTC calendar date in the window, plus one aggregated `other` row summing every model outside that top 50 (omitted when the long tail is empty). Rows are sorted by `date` ascending, then by `total_tokens` descending, with `other` pinned last within its date. Ties between real models break alphabetically on `model_permaslug` so the order is stable across requests.",
+            "items": {
+              "$ref": "#/components/schemas/RankingsDailyItem"
+            },
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/RankingsDailyMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object"
       },
       "ReasoningConfig": {
         "allOf": [
@@ -23818,7 +24425,8 @@
                   "moderation": "#/components/schemas/ModerationPlugin",
                   "pareto-router": "#/components/schemas/ParetoRouterPlugin",
                   "response-healing": "#/components/schemas/ResponseHealingPlugin",
-                  "web": "#/components/schemas/WebSearchPlugin"
+                  "web": "#/components/schemas/WebSearchPlugin",
+                  "web-fetch": "#/components/schemas/WebFetchPlugin"
                 },
                 "propertyName": "id"
               },
@@ -23831,6 +24439,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/WebSearchPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchPlugin"
                 },
                 {
                   "$ref": "#/components/schemas/FileParserPlugin"
@@ -23895,9 +24506,12 @@
             "x-speakeasy-unknown-values": "allow"
           },
           "session_id": {
-            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
+            "description": "A unique identifier for grouping related requests (e.g., a conversation or agent workflow). When provided, OpenRouter uses it as the sticky routing key, routing all requests in the session to the same provider to maximize prompt cache hits. Also used for observability grouping. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.",
             "maxLength": 256,
             "type": "string"
+          },
+          "stop_server_tools_when": {
+            "$ref": "#/components/schemas/StopServerToolsWhen"
           },
           "store": {
             "const": false,
@@ -24588,6 +25202,176 @@
           "model",
           "input",
           "voice"
+        ],
+        "type": "object"
+      },
+      "StopServerToolsWhen": {
+        "description": "Stop conditions for the server-tool agent loop. Any condition firing halts the loop (OR logic). When set, this overrides `max_tool_calls`.",
+        "example": [
+          {
+            "step_count": 5,
+            "type": "step_count_is"
+          },
+          {
+            "max_cost_in_dollars": 0.5,
+            "type": "max_cost"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/StopServerToolsWhenCondition"
+        },
+        "minItems": 1,
+        "type": "array"
+      },
+      "StopServerToolsWhenCondition": {
+        "description": "A single condition that, when met, halts the server-tool agent loop.",
+        "discriminator": {
+          "mapping": {
+            "finish_reason_is": "#/components/schemas/StopServerToolsWhenFinishReasonIs",
+            "has_tool_call": "#/components/schemas/StopServerToolsWhenHasToolCall",
+            "max_cost": "#/components/schemas/StopServerToolsWhenMaxCost",
+            "max_tokens_used": "#/components/schemas/StopServerToolsWhenMaxTokensUsed",
+            "step_count_is": "#/components/schemas/StopServerToolsWhenStepCountIs"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "step_count": 5,
+          "type": "step_count_is"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/StopServerToolsWhenStepCountIs"
+          },
+          {
+            "$ref": "#/components/schemas/StopServerToolsWhenHasToolCall"
+          },
+          {
+            "$ref": "#/components/schemas/StopServerToolsWhenMaxTokensUsed"
+          },
+          {
+            "$ref": "#/components/schemas/StopServerToolsWhenMaxCost"
+          },
+          {
+            "$ref": "#/components/schemas/StopServerToolsWhenFinishReasonIs"
+          }
+        ]
+      },
+      "StopServerToolsWhenFinishReasonIs": {
+        "description": "Stop when the upstream model emits this finish reason (e.g. `length`).",
+        "example": {
+          "reason": "length",
+          "type": "finish_reason_is"
+        },
+        "properties": {
+          "reason": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "finish_reason_is"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "StopServerToolsWhenHasToolCall": {
+        "description": "Stop after a tool with this name has been called.",
+        "example": {
+          "tool_name": "finalize",
+          "type": "has_tool_call"
+        },
+        "properties": {
+          "tool_name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "has_tool_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_name"
+        ],
+        "type": "object"
+      },
+      "StopServerToolsWhenMaxCost": {
+        "description": "Stop once cumulative cost across the loop exceeds this dollar threshold.",
+        "example": {
+          "max_cost_in_dollars": 0.5,
+          "type": "max_cost"
+        },
+        "properties": {
+          "max_cost_in_dollars": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "max_cost"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "max_cost_in_dollars"
+        ],
+        "type": "object"
+      },
+      "StopServerToolsWhenMaxTokensUsed": {
+        "description": "Stop once cumulative token usage across the loop exceeds this threshold.",
+        "example": {
+          "max_tokens": 10000,
+          "type": "max_tokens_used"
+        },
+        "properties": {
+          "max_tokens": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "max_tokens_used"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "max_tokens"
+        ],
+        "type": "object"
+      },
+      "StopServerToolsWhenStepCountIs": {
+        "description": "Stop after the agent loop has executed this many steps.",
+        "example": {
+          "step_count": 5,
+          "type": "step_count_is"
+        },
+        "properties": {
+          "step_count": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "step_count_is"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "step_count"
         ],
         "type": "object"
       },
@@ -25606,7 +26390,7 @@
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/ContentFilterBuiltinEntry"
+              "$ref": "#/components/schemas/ContentFilterBuiltinEntryInput"
             },
             "nullable": true,
             "type": "array"
@@ -25711,9 +26495,9 @@
             ],
             "content_filter_builtins": [
               {
-                "action": "block",
-                "label": "[PROMPT_INJECTION]",
-                "slug": "regex-prompt-injection"
+                "action": "redact",
+                "label": "[EMAIL]",
+                "slug": "email"
               }
             ],
             "content_filters": null,
@@ -25805,7 +26589,7 @@
             "type": "boolean"
           },
           "sampling_rate": {
-            "description": "Sampling rate between 0 and 1 (1 = 100%).",
+            "description": "Sampling rate between 0.0001 and 1 (1 = 100%).",
             "example": 1,
             "format": "double",
             "type": "number"
@@ -26470,17 +27254,58 @@
         "type": "object"
       },
       "WebFetchEngineEnum": {
-        "description": "Which fetch engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in fetch. \"exa\" uses Exa Contents API. \"openrouter\" uses direct HTTP fetch. \"firecrawl\" uses Firecrawl scrape (requires BYOK).",
+        "description": "Which fetch engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in fetch. \"exa\" uses Exa Contents API. \"openrouter\" uses direct HTTP fetch. \"firecrawl\" uses Firecrawl scrape (requires BYOK). \"parallel\" uses the Parallel extract API.",
         "enum": [
           "auto",
           "native",
           "openrouter",
-          "firecrawl",
-          "exa"
+          "exa",
+          "parallel",
+          "firecrawl"
         ],
         "example": "auto",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "WebFetchPlugin": {
+        "example": {
+          "id": "web-fetch",
+          "max_uses": 10
+        },
+        "properties": {
+          "allowed_domains": {
+            "description": "Only fetch from these domains.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "blocked_domains": {
+            "description": "Never fetch from these domains.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "enum": [
+              "web-fetch"
+            ],
+            "type": "string"
+          },
+          "max_content_tokens": {
+            "description": "Maximum content length in approximate tokens. Content exceeding this limit is truncated.",
+            "type": "integer"
+          },
+          "max_uses": {
+            "description": "Maximum number of web fetches per request. Once exceeded, the tool returns an error.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
       },
       "WebFetchServerTool": {
         "description": "OpenRouter built-in server tool: fetches full content from a URL (web page or PDF)",
@@ -26685,8 +27510,8 @@
           "auto",
           "native",
           "exa",
-          "firecrawl",
-          "parallel"
+          "parallel",
+          "firecrawl"
         ],
         "example": "auto",
         "type": "string",
@@ -28206,9 +29031,11 @@
                 "cloudflare",
                 "cohere",
                 "crusoe",
+                "darkbloom",
                 "deepinfra",
                 "deepseek",
                 "dekallm",
+                "digitalocean",
                 "featherless",
                 "fireworks",
                 "friendli",
@@ -28216,7 +29043,6 @@
                 "google-ai-studio",
                 "google-vertex",
                 "groq",
-                "hyperbolic",
                 "inception",
                 "inceptron",
                 "inference-net",
@@ -29325,6 +30151,143 @@
         "x-fern-ignore": true,
         "x-speakeasy-ignore": true,
         "x-speakeasy-name-override": "createCoinbaseCharge"
+      }
+    },
+    "/datasets/rankings-daily": {
+      "get": {
+        "description": "Returns the top 50 public models per day by total token usage on OpenRouter, plus a\nsingle aggregated `other` row per day that sums every model outside that top 50.\nToken totals are `prompt_tokens + completion_tokens`, matching the public rankings\nchart on openrouter.ai/rankings.\n\nEach row is a distinct `(date, model_permaslug)` pair. The `other` row uses the\nreserved permaslug `other` and is always returned last within its date, so callers\ncan compute `top-50 traffic / total daily traffic` without a second request.\n\nAuthenticate with any valid OpenRouter API key (same key used for inference).\nRate-limited to 30 requests/minute per key and 500 requests/day per account.\n\nWhen republishing or quoting this dataset, OpenRouter must be cited as:\n\"Source: OpenRouter (openrouter.ai/rankings), as of {as_of}.\"\n\nToken counts come from each upstream provider's own tokenizer (Anthropic counts\nare as reported by Anthropic, OpenAI counts are as reported by OpenAI, etc.), so\na token in one row is not directly comparable to a token in another row from a\ndifferent provider.",
+        "operationId": "getRankingsDaily",
+        "parameters": [
+          {
+            "description": "Start of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to 30 days before `end_date`. The dataset begins at 2025-01-01; earlier values are clamped forward to that floor and the resolved value is echoed in `meta.start_date`.",
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "description": "Start of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to 30 days before `end_date`. The dataset begins at 2025-01-01; earlier values are clamped forward to that floor and the resolved value is echoed in `meta.start_date`.",
+              "example": "2026-04-12",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "End of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to the most recent completed UTC day. Must be on or after 2025-01-01; earlier values are rejected with a 400.",
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "description": "End of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to the most recent completed UTC day. Must be on or after 2025-01-01; earlier values are rejected with a 400.",
+              "example": "2026-05-11",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "date": "2026-05-11",
+                      "model_permaslug": "openai/gpt-4o-2024-05-13",
+                      "total_tokens": "12345678"
+                    },
+                    {
+                      "date": "2026-05-11",
+                      "model_permaslug": "anthropic/claude-3.5-sonnet-20241022",
+                      "total_tokens": "9876543"
+                    },
+                    {
+                      "date": "2026-05-11",
+                      "model_permaslug": "other",
+                      "total_tokens": "4321098"
+                    }
+                  ],
+                  "meta": {
+                    "as_of": "2026-05-12T02:00:00Z",
+                    "end_date": "2026-05-11",
+                    "start_date": "2026-04-12",
+                    "version": "v1"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RankingsDailyResponse"
+                }
+              }
+            },
+            "description": "Up to 51 rows per day \u2014 the top 50 public models by `total_tokens` plus a single aggregated `other` row covering every model outside that top 50. Sorted by `date` ascending, then by `total_tokens` descending, with `other` pinned last within its date."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Daily token totals for top 50 models",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/embeddings": {
@@ -35567,6 +36530,560 @@
         }
       }
     },
+    "/presets/{slug}/chat/completions": {
+      "post": {
+        "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
+        "operationId": "createPresetsChatCompletions",
+        "parameters": [
+          {
+            "description": "URL-safe slug identifying the preset. Created if it does not exist.",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "URL-safe slug identifying the preset. Created if it does not exist.",
+              "example": "my-preset",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "messages": [
+                  {
+                    "content": "You are a helpful assistant.",
+                    "role": "system"
+                  },
+                  {
+                    "content": "Hello!",
+                    "role": "user"
+                  }
+                ],
+                "model": "openai/gpt-5.4",
+                "temperature": 0.7
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2026-04-20T10:00:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "description": null,
+                    "designated_version": {
+                      "config": {
+                        "model": "openai/gpt-5.4",
+                        "temperature": 0.7
+                      },
+                      "created_at": "2026-04-20T10:00:00Z",
+                      "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+                      "system_prompt": "You are a helpful assistant.",
+                      "updated_at": "2026-04-20T10:00:00Z",
+                      "version": 1
+                    },
+                    "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "id": "650e8400-e29b-41d4-a716-446655440001",
+                    "name": "my-preset",
+                    "slug": "my-preset",
+                    "status": "active",
+                    "status_updated_at": null,
+                    "updated_at": "2026-04-20T10:00:00Z",
+                    "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePresetFromInferenceResponse"
+                }
+              }
+            },
+            "description": "Preset created or updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 409,
+                    "message": "Resource conflict. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictResponse"
+                }
+              }
+            },
+            "description": "Conflict - Resource conflict or concurrent modification"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "Create a preset from a chat-completions request body",
+        "tags": [
+          "Presets"
+        ]
+      }
+    },
+    "/presets/{slug}/messages": {
+      "post": {
+        "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
+        "operationId": "createPresetsMessages",
+        "parameters": [
+          {
+            "description": "URL-safe slug identifying the preset. Created if it does not exist.",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "URL-safe slug identifying the preset. Created if it does not exist.",
+              "example": "my-preset",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "max_tokens": 1024,
+                "messages": [
+                  {
+                    "content": "Hello!",
+                    "role": "user"
+                  }
+                ],
+                "model": "anthropic/claude-4.6-sonnet",
+                "system": "You are a helpful assistant."
+              },
+              "schema": {
+                "$ref": "#/components/schemas/MessagesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2026-04-20T10:00:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "description": null,
+                    "designated_version": {
+                      "config": {
+                        "max_tokens": 1024,
+                        "model": "anthropic/claude-4.6-sonnet"
+                      },
+                      "created_at": "2026-04-20T10:00:00Z",
+                      "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+                      "system_prompt": "You are a helpful assistant.",
+                      "updated_at": "2026-04-20T10:00:00Z",
+                      "version": 1
+                    },
+                    "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "id": "650e8400-e29b-41d4-a716-446655440001",
+                    "name": "my-preset",
+                    "slug": "my-preset",
+                    "status": "active",
+                    "status_updated_at": null,
+                    "updated_at": "2026-04-20T10:00:00Z",
+                    "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePresetFromInferenceResponse"
+                }
+              }
+            },
+            "description": "Preset created or updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 409,
+                    "message": "Resource conflict. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictResponse"
+                }
+              }
+            },
+            "description": "Conflict - Resource conflict or concurrent modification"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "Create a preset from a messages request body",
+        "tags": [
+          "Presets"
+        ]
+      }
+    },
+    "/presets/{slug}/responses": {
+      "post": {
+        "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
+        "operationId": "createPresetsResponses",
+        "parameters": [
+          {
+            "description": "URL-safe slug identifying the preset. Created if it does not exist.",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "URL-safe slug identifying the preset. Created if it does not exist.",
+              "example": "my-preset",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "input": "Hello!",
+                "instructions": "You are a helpful assistant.",
+                "model": "openai/gpt-5.4"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ResponsesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2026-04-20T10:00:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "description": null,
+                    "designated_version": {
+                      "config": {
+                        "model": "openai/gpt-5.4"
+                      },
+                      "created_at": "2026-04-20T10:00:00Z",
+                      "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+                      "system_prompt": "You are a helpful assistant.",
+                      "updated_at": "2026-04-20T10:00:00Z",
+                      "version": 1
+                    },
+                    "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "id": "650e8400-e29b-41d4-a716-446655440001",
+                    "name": "my-preset",
+                    "slug": "my-preset",
+                    "status": "active",
+                    "status_updated_at": null,
+                    "updated_at": "2026-04-20T10:00:00Z",
+                    "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePresetFromInferenceResponse"
+                }
+              }
+            },
+            "description": "Preset created or updated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 409,
+                    "message": "Resource conflict. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictResponse"
+                }
+              }
+            },
+            "description": "Conflict - Resource conflict or concurrent modification"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "Create a preset from a responses request body",
+        "tags": [
+          "Presets"
+        ]
+      }
+    },
     "/providers": {
       "get": {
         "operationId": "listProviders",
@@ -38347,6 +39864,10 @@
       "name": "Credits"
     },
     {
+      "description": "Datasets endpoints",
+      "name": "Datasets"
+    },
+    {
       "description": "Text embedding endpoints",
       "name": "Embeddings"
     },
@@ -38377,6 +39898,10 @@
     {
       "description": "Organization endpoints",
       "name": "Organization"
+    },
+    {
+      "description": "Presets endpoints",
+      "name": "Presets"
     },
     {
       "description": "Provider information endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-05-19T11:09:59+00:00",
+  "captured_at": "2026-06-05T06:33:03+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,7 +14,7 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 62,
+  "operation_count": 66,
   "operations": [
     {
       "deprecated": false,
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4107b67b850306f3",
+      "fingerprint": "b5a2e4bad2c286d2",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "44df7c172632e2d0",
+      "fingerprint": "c3ad5385094e5317",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -117,6 +117,17 @@
     },
     {
       "deprecated": false,
+      "fingerprint": "32a5aa933d91ab37",
+      "id": "GET /datasets/rankings-daily",
+      "method": "GET",
+      "operation_id": "getRankingsDaily",
+      "path": "/datasets/rankings-daily",
+      "tags": [
+        "Datasets"
+      ]
+    },
+    {
+      "deprecated": false,
       "fingerprint": "c83853c4260db3c5",
       "id": "GET /embeddings/models",
       "method": "GET",
@@ -128,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b2e4d7f17e7ec2b1",
+      "fingerprint": "f159f2f6d6b1ad93",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -139,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1fb2cd7855c02223",
+      "fingerprint": "de4301db9bed6040",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -161,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "264aa20a1d9cbc98",
+      "fingerprint": "c971fe86ab8e6f1e",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -194,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b9eb37561bc9cf3e",
+      "fingerprint": "7e90108dc4db6649",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -293,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a33d2e3dc88d6365",
+      "fingerprint": "ebbf719d1b1de4f9",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -403,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dad0322285e3ec9d",
+      "fingerprint": "7d6f5c7e477dc7e0",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -414,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e927a97f82d97c98",
+      "fingerprint": "4f57a8b8f08fbbee",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -458,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e9f162d1133bac67",
+      "fingerprint": "e866e241015fc95b",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -469,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7b7b1e3ef6e95379",
+      "fingerprint": "cec87f5a232cd68d",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -502,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ae1842cd453f2aa0",
+      "fingerprint": "a3fe8792a450affe",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -513,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5363f5b6080a61b7",
+      "fingerprint": "78840a08479a8674",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -535,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6df7b43bc216e7c0",
+      "fingerprint": "cb013d3338781561",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -546,7 +557,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ad2b9ec1db9c46f1",
+      "fingerprint": "1fce35e980af57e9",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -612,7 +623,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d7754357f9e76ce2",
+      "fingerprint": "9aa4cf34ec7c5ecf",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -634,7 +645,40 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "62c81bdf62f2b7b7",
+      "fingerprint": "c0bc5853e1ed88e7",
+      "id": "POST /presets/{slug}/chat/completions",
+      "method": "POST",
+      "operation_id": "createPresetsChatCompletions",
+      "path": "/presets/{slug}/chat/completions",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "2b036bf52bcd2b20",
+      "id": "POST /presets/{slug}/messages",
+      "method": "POST",
+      "operation_id": "createPresetsMessages",
+      "path": "/presets/{slug}/messages",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "89e8fdd07288bffc",
+      "id": "POST /presets/{slug}/responses",
+      "method": "POST",
+      "operation_id": "createPresetsResponses",
+      "path": "/presets/{slug}/responses",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "f993967db2d45188",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -645,7 +689,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d07149e2fe298988",
+      "fingerprint": "a6984cef3488a0af",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -656,7 +700,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c9db226fcb6c90df",
+      "fingerprint": "fbc874edb0776005",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -200,6 +200,37 @@ pub struct ActivityItem {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// One daily model-ranking row returned by `GET /datasets/rankings-daily`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct RankingsDailyItem {
+    pub date: String,
+    pub model_permaslug: String,
+    pub total_tokens: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Metadata for a daily rankings dataset response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct RankingsDailyMeta {
+    pub as_of: String,
+    pub version: String,
+    pub start_date: String,
+    pub end_date: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Daily token totals for top public models plus an aggregated `other` row.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct RankingsDailyResponse {
+    pub data: Vec<RankingsDailyItem>,
+    pub meta: RankingsDailyMeta,
+}
+
 /// List all providers (`GET /providers`).
 pub async fn list_providers(
     base_url: &str,
@@ -284,6 +315,53 @@ pub(crate) async fn count_models_with_client(
         let parsed: ApiResponse<ModelsCountData> =
             transport_response::parse_json_response(response, "model count").await?;
         Ok(parsed.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Return daily token totals for top public models (`GET /datasets/rankings-daily`).
+pub async fn get_rankings_daily(
+    base_url: &str,
+    api_key: &str,
+    start_date: Option<&str>,
+    end_date: Option<&str>,
+) -> Result<RankingsDailyResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_rankings_daily_with_client(&http_client, base_url, api_key, start_date, end_date).await
+}
+
+pub(crate) async fn get_rankings_daily_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    start_date: Option<&str>,
+    end_date: Option<&str>,
+) -> Result<RankingsDailyResponse, OpenRouterError> {
+    #[derive(Serialize)]
+    struct RankingsDailyQuery<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        start_date: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_date: Option<&'a str>,
+    }
+
+    let url = format!("{base_url}/datasets/rankings-daily");
+    let query = RankingsDailyQuery {
+        start_date,
+        end_date,
+    };
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response = if query.start_date.is_none() && query.end_date.is_none() {
+        req.send().await?
+    } else {
+        req.query(&query).send().await?
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "rankings daily").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -40,6 +40,7 @@ pub struct GenerationData {
     pub num_media_prompt: Option<u32>,
     pub num_media_completion: Option<u32>,
     pub num_search_results: Option<u32>,
+    pub preset_id: Option<String>,
     pub response_cache_source_id: Option<String>,
     pub service_tier: Option<String>,
 }

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -24,6 +24,7 @@ use crate::{
 pub enum AnthropicRole {
     User,
     Assistant,
+    System,
 }
 
 /// Text block for `system` prompts.
@@ -265,6 +266,10 @@ impl AnthropicMessage {
 
     pub fn assistant(content: impl Into<AnthropicMessageContent>) -> Self {
         Self::new(AnthropicRole::Assistant, content)
+    }
+
+    pub fn system(content: impl Into<AnthropicMessageContent>) -> Self {
+        Self::new(AnthropicRole::System, content)
     }
 
     pub fn with_parts(role: AnthropicRole, parts: Vec<AnthropicContentPart>) -> Self {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,7 +12,7 @@
 //! - `client.audio().speech()` / `client.audio().transcriptions()` -> [`audio`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
-//! - `client.management()` -> [`api_keys`], [`auth`], [`byok`], [`credits`], [`generation`], [`guardrails`], [`observability`], [`organization`], [`workspaces`]
+//! - `client.management()` -> [`api_keys`], [`auth`], [`byok`], [`credits`], [`generation`], [`guardrails`], [`observability`], [`organization`], [`presets`], [`workspaces`]
 //! - `client.legacy()` -> [`legacy`] (feature `legacy-completions`)
 //!
 //! Endpoint families currently implemented here:
@@ -23,12 +23,13 @@
 //! - rerank
 //! - audio speech generation and transcription
 //! - video generation and polling
-//! - model discovery, providers, user model filters, model counts, and ZDR endpoints
+//! - model discovery, providers, user model filters, model counts, rankings, and ZDR endpoints
 //! - embeddings
 //! - API-key and auth-code flows
 //! - credits, Coinbase charge creation, generation lookup/content, and activity
 //! - BYOK provider credential management
 //! - observability destination management
+//! - preset creation from inference request bodies
 //! - guardrails and guardrail assignments
 //! - organization member listing
 //! - workspace CRUD and membership management
@@ -130,6 +131,7 @@ pub mod messages;
 pub mod models;
 pub mod observability;
 pub mod organization;
+pub mod presets;
 pub mod rerank;
 pub mod responses;
 #[deprecated(note = "use api::audio for the canonical /audio/speech surface")]

--- a/src/api/presets.rs
+++ b/src/api/presets.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use urlencoding::encode;
+
+use crate::{
+    api::{
+        chat::ChatCompletionRequest, messages::AnthropicMessagesRequest,
+        responses::ResponsesRequest,
+    },
+    error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
+    types::ApiResponse,
+};
+
+/// A specific version of a preset, containing persisted config and optional system prompt.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct PresetDesignatedVersion {
+    pub id: String,
+    pub preset_id: String,
+    pub creator_id: String,
+    pub version: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    pub config: HashMap<String, Value>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Preset metadata returned after creating or updating a preset from an inference request body.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct PresetWithDesignatedVersion {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creator_user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    pub name: String,
+    pub slug: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub designated_version_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub designated_version: Option<PresetDesignatedVersion>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+fn preset_url(base_url: &str, slug: &str, suffix: &str) -> String {
+    let encoded_slug = encode(slug);
+    format!("{base_url}/presets/{encoded_slug}/{suffix}")
+}
+
+async fn create_preset_with_client<T: Serialize + ?Sized>(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    suffix: &str,
+    request: &T,
+    context: &str,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    let url = preset_url(base_url, slug, suffix);
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let parsed: ApiResponse<PresetWithDesignatedVersion> =
+            transport_response::parse_json_response(response, context).await?;
+        Ok(parsed.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Create or update a preset from a chat-completions request body.
+pub async fn create_chat_completion_preset(
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    request: &ChatCompletionRequest,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_chat_completion_preset_with_client(&http_client, base_url, management_key, slug, request)
+        .await
+}
+
+pub(crate) async fn create_chat_completion_preset_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    request: &ChatCompletionRequest,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    create_preset_with_client(
+        http_client,
+        base_url,
+        management_key,
+        slug,
+        "chat/completions",
+        request,
+        "chat completion preset",
+    )
+    .await
+}
+
+/// Create or update a preset from a Responses API request body.
+pub async fn create_response_preset(
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    request: &ResponsesRequest,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_response_preset_with_client(&http_client, base_url, management_key, slug, request).await
+}
+
+pub(crate) async fn create_response_preset_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    request: &ResponsesRequest,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    create_preset_with_client(
+        http_client,
+        base_url,
+        management_key,
+        slug,
+        "responses",
+        request,
+        "response preset",
+    )
+    .await
+}
+
+/// Create or update a preset from an Anthropic-compatible Messages request body.
+pub async fn create_message_preset(
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    request: &AnthropicMessagesRequest,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_message_preset_with_client(&http_client, base_url, management_key, slug, request).await
+}
+
+pub(crate) async fn create_message_preset_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    request: &AnthropicMessagesRequest,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    create_preset_with_client(
+        http_client,
+        base_url,
+        management_key,
+        slug,
+        "messages",
+        request,
+        "message preset",
+    )
+    .await
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,8 @@ use crate::api::legacy::completion;
 use crate::{
     api::{
         api_keys, audio, auth, byok, chat, credits, discovery, embeddings, generation, guardrails,
-        messages, models, observability, organization, rerank, responses, videos, workspaces,
+        messages, models, observability, organization, presets, rerank, responses, videos,
+        workspaces,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -1063,6 +1064,72 @@ impl OpenRouterClient {
         Ok(adapt_messages_stream(raw_stream))
     }
 
+    /// Create or update a preset from a chat-completions request body.
+    ///
+    /// Equivalent to `POST /presets/{slug}/chat/completions`.
+    pub async fn create_chat_completion_preset(
+        &self,
+        slug: &str,
+        request: &chat::ChatCompletionRequest,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::create_chat_completion_preset_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                slug,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Create or update a preset from a Responses API request body.
+    ///
+    /// Equivalent to `POST /presets/{slug}/responses`.
+    pub async fn create_response_preset(
+        &self,
+        slug: &str,
+        request: &responses::ResponsesRequest,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::create_response_preset_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                slug,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Create or update a preset from an Anthropic-compatible Messages request body.
+    ///
+    /// Equivalent to `POST /presets/{slug}/messages`.
+    pub async fn create_message_preset(
+        &self,
+        slug: &str,
+        request: &messages::AnthropicMessagesRequest,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::create_message_preset_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                slug,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Submit an embeddings request.
     ///
     /// # Arguments
@@ -1556,6 +1623,28 @@ impl OpenRouterClient {
     pub async fn count_models(&self) -> Result<discovery::ModelsCountData, OpenRouterError> {
         if let Some(api_key) = &self.api_key {
             discovery::count_models_with_client(self.http_client(), &self.base_url, api_key).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Return daily token totals for top public models.
+    ///
+    /// Equivalent to `GET /datasets/rankings-daily`.
+    pub async fn get_rankings_daily(
+        &self,
+        start_date: Option<&str>,
+        end_date: Option<&str>,
+    ) -> Result<discovery::RankingsDailyResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            discovery::get_rankings_daily_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                start_date,
+                end_date,
+            )
+            .await
         } else {
             Err(OpenRouterError::KeyNotConfigured)
         }
@@ -2217,6 +2306,15 @@ impl<'a> ModelsClient<'a> {
         self.client.count_models().await
     }
 
+    /// Return daily token totals for top public models (`GET /datasets/rankings-daily`).
+    pub async fn get_rankings_daily(
+        &self,
+        start_date: Option<&str>,
+        end_date: Option<&str>,
+    ) -> Result<discovery::RankingsDailyResponse, OpenRouterError> {
+        self.client.get_rankings_daily(start_date, end_date).await
+    }
+
     /// List ZDR-compatible endpoints (`GET /endpoints/zdr`).
     pub async fn list_zdr_endpoints(
         &self,
@@ -2271,6 +2369,35 @@ impl<'a> ManagementClient<'a> {
         &self,
     ) -> Result<api_keys::ApiKeyDetails, OpenRouterError> {
         self.client.get_current_api_key_info().await
+    }
+
+    /// Create or update a preset from a chat-completions request body.
+    pub async fn create_chat_completion_preset(
+        &self,
+        slug: &str,
+        request: &chat::ChatCompletionRequest,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        self.client
+            .create_chat_completion_preset(slug, request)
+            .await
+    }
+
+    /// Create or update a preset from a Responses API request body.
+    pub async fn create_response_preset(
+        &self,
+        slug: &str,
+        request: &responses::ResponsesRequest,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        self.client.create_response_preset(slug, request).await
+    }
+
+    /// Create or update a preset from an Anthropic-compatible Messages request body.
+    pub async fn create_message_preset(
+        &self,
+        slug: &str,
+        request: &messages::AnthropicMessagesRequest,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        self.client.create_message_preset(slug, request).await
     }
 
     /// Delete an API key (`DELETE /keys/{hash}`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! `openrouter-rs` is a type-safe, async Rust SDK for the [OpenRouter API](https://openrouter.ai/),
 //! providing typed access to chat, responses, messages, rerank, audio speech/transcription, video generation,
-//! discovery, embeddings, and management endpoints.
+//! discovery, embeddings, presets, and management endpoints.
 //!
 //! ## ✨ Key Features
 //!

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -311,6 +311,9 @@ async fn test_models_domain_renamed_methods_require_api_key() {
         Err(OpenRouterError::KeyNotConfigured)
     ));
 
+    let rankings = client.models().get_rankings_daily(None, None).await;
+    assert!(matches!(rankings, Err(OpenRouterError::KeyNotConfigured)));
+
     let by_category = client
         .models()
         .list_by_category(ModelCategory::Programming)
@@ -523,9 +526,46 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
             .name("Updated Langfuse")
             .build()
             .expect("update observability request should build");
+    let chat_preset_request = chat::ChatCompletionRequest::builder()
+        .model("openai/gpt-5")
+        .messages(vec![chat::Message::new(Role::User, "hello")])
+        .build()
+        .expect("chat preset request should build");
+    let response_preset_request = responses::ResponsesRequest::builder()
+        .model("openai/gpt-5")
+        .input(serde_json::json!("hello"))
+        .build()
+        .expect("response preset request should build");
+    let message_preset_request = messages::AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(128)
+        .messages(vec![messages::AnthropicMessage::user("hello")])
+        .build()
+        .expect("message preset request should build");
 
     assert!(matches!(
         client.management().get_current_api_key_info().await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .create_chat_completion_preset("my-preset", &chat_preset_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .create_response_preset("my-preset", &response_preset_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .create_message_preset("my-preset", &message_preset_request)
+            .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -8,7 +8,8 @@ use std::{
 
 use openrouter_rs::{
     api::discovery::{
-        self, ActivityItem, BigNumber, ModelsCountData, Provider, PublicEndpoint, UserModel,
+        self, ActivityItem, BigNumber, ModelsCountData, Provider, PublicEndpoint,
+        RankingsDailyResponse, UserModel,
     },
     types::ApiResponse,
 };
@@ -219,6 +220,34 @@ fn test_activity_response_deserialization() {
     assert_eq!(parsed.data[0].requests, 5.0);
 }
 
+#[test]
+fn test_rankings_daily_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "date": "2026-05-11",
+            "model_permaslug": "openai/gpt-4o-2024-05-13",
+            "total_tokens": "12345678"
+        }, {
+            "date": "2026-05-11",
+            "model_permaslug": "other",
+            "total_tokens": "4321098"
+        }],
+        "meta": {
+            "as_of": "2026-05-12T02:00:00Z",
+            "version": "v1",
+            "start_date": "2026-04-12",
+            "end_date": "2026-05-11"
+        }
+    }"#;
+
+    let parsed: RankingsDailyResponse =
+        serde_json::from_str(raw).expect("rankings daily response should deserialize");
+    assert_eq!(parsed.data.len(), 2);
+    assert_eq!(parsed.data[0].total_tokens, "12345678");
+    assert_eq!(parsed.data[1].model_permaslug, "other");
+    assert_eq!(parsed.meta.version, "v1");
+}
+
 #[tokio::test]
 async fn test_list_models_for_user_request_path() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
@@ -407,6 +436,38 @@ async fn test_list_zdr_endpoints_request_path_and_auth_header() {
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture request");
     assert_eq!(captured.request_line, "GET /api/v1/endpoints/zdr HTTP/1.1");
+
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include API key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_rankings_daily_with_date_query_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[],"meta":{"as_of":"2026-05-12T02:00:00Z","version":"v1","start_date":"2026-04-12","end_date":"2026-05-11"}}"#,
+    );
+
+    let rankings =
+        discovery::get_rankings_daily(&base_url, "api-key", Some("2026-04-12"), Some("2026-05-11"))
+            .await
+            .expect("rankings daily request should succeed");
+    assert!(rankings.data.is_empty(), "response payload should parse");
+    assert_eq!(rankings.meta.start_date, "2026-04-12");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/datasets/rankings-daily?start_date=2026-04-12&end_date=2026-05-11 HTTP/1.1"
+    );
 
     let request_lower = captured.request_text.to_ascii_lowercase();
     assert!(

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -144,6 +144,7 @@ fn test_generation_response_deserializes_num_fetches() {
             "is_byok": false,
             "native_tokens_reasoning": 8,
             "num_fetches": 3,
+            "preset_id": "preset_123",
             "response_cache_source_id": "gen_original",
             "service_tier": "priority"
         }
@@ -155,6 +156,7 @@ fn test_generation_response_deserializes_num_fetches() {
     assert_eq!(parsed.data.id, "gen_123");
     assert_eq!(parsed.data.native_tokens_reasoning, Some(8));
     assert_eq!(parsed.data.num_fetches, Some(3));
+    assert_eq!(parsed.data.preset_id.as_deref(), Some("preset_123"));
     assert_eq!(
         parsed.data.response_cache_source_id.as_deref(),
         Some("gen_original")

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -138,6 +138,18 @@ fn test_anthropic_messages_response_deserialization() {
 }
 
 #[test]
+fn test_anthropic_messages_system_role_roundtrip() {
+    let message = AnthropicMessage::system("Follow the policy.");
+    let value = serde_json::to_value(&message).expect("system message should serialize");
+    assert_eq!(value["role"], "system");
+    assert_eq!(value["content"], "Follow the policy.");
+
+    let parsed: AnthropicMessage =
+        serde_json::from_value(value).expect("system message should deserialize");
+    assert_eq!(parsed.role, AnthropicRole::System);
+}
+
+#[test]
 fn test_anthropic_messages_stream_event_deserialization() {
     let raw = r#"{
         "type": "content_block_delta",

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -27,6 +27,7 @@ pub mod models;
 pub mod observability;
 pub mod organization;
 pub mod pagination;
+pub mod presets;
 pub mod provider;
 pub mod rerank;
 pub mod response_format;

--- a/tests/unit/presets.rs
+++ b/tests/unit/presets.rs
@@ -1,0 +1,284 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::{
+    api::{
+        chat::{self, Message},
+        messages::{self, AnthropicMessage},
+        presets::{self, PresetWithDesignatedVersion},
+        responses,
+    },
+    types::Role,
+};
+use serde_json::json;
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+fn preset_response_body() -> &'static str {
+    r#"{
+        "data": {
+            "id": "preset_1",
+            "creator_user_id": "user_1",
+            "workspace_id": "ws_1",
+            "name": "my preset",
+            "slug": "my-preset",
+            "description": null,
+            "status": "active",
+            "designated_version_id": "version_1",
+            "created_at": "2026-04-20T10:00:00Z",
+            "updated_at": "2026-04-20T10:00:00Z",
+            "status_updated_at": null,
+            "designated_version": {
+                "id": "version_1",
+                "preset_id": "preset_1",
+                "creator_id": "user_1",
+                "version": 1,
+                "system_prompt": "You are concise.",
+                "config": {
+                    "model": "openai/gpt-5",
+                    "temperature": 0.7
+                },
+                "created_at": "2026-04-20T10:00:00Z",
+                "updated_at": "2026-04-20T10:00:00Z"
+            }
+        }
+    }"#
+}
+
+#[test]
+fn test_preset_response_deserializes() {
+    let parsed: serde_json::Value =
+        serde_json::from_str(preset_response_body()).expect("response should parse as JSON");
+    let preset: PresetWithDesignatedVersion =
+        serde_json::from_value(parsed["data"].clone()).expect("preset should deserialize");
+
+    assert_eq!(preset.id, "preset_1");
+    assert_eq!(preset.status, "active");
+    let version = preset
+        .designated_version
+        .expect("designated version should be present");
+    assert_eq!(version.version, 1);
+    assert_eq!(
+        version.config.get("model").and_then(|value| value.as_str()),
+        Some("openai/gpt-5")
+    );
+}
+
+#[tokio::test]
+async fn test_create_chat_completion_preset_path_body_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(preset_response_body());
+    let request = chat::ChatCompletionRequest::builder()
+        .model("openai/gpt-5")
+        .messages(vec![Message::new(Role::User, "hello")])
+        .temperature(0.7)
+        .build()
+        .expect("chat request should build");
+
+    let preset =
+        presets::create_chat_completion_preset(&base_url, "management-key", "my preset", &request)
+            .await
+            .expect("create chat preset should succeed");
+    assert_eq!(preset.slug, "my-preset");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/presets/my%20preset/chat/completions HTTP/1.1"
+    );
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("authorization: bearer management-key")
+            || captured
+                .request_text
+                .to_ascii_lowercase()
+                .contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be JSON");
+    assert_eq!(body["model"], "openai/gpt-5");
+    assert_eq!(body["temperature"], 0.7);
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_create_response_preset_path_body_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(preset_response_body());
+    let request = responses::ResponsesRequest::builder()
+        .model("openai/gpt-5")
+        .input(json!("hello"))
+        .instructions("You are concise.")
+        .build()
+        .expect("responses request should build");
+
+    let preset =
+        presets::create_response_preset(&base_url, "management-key", "my-preset", &request)
+            .await
+            .expect("create response preset should succeed");
+    assert_eq!(preset.id, "preset_1");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/presets/my-preset/responses HTTP/1.1"
+    );
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("authorization: bearer management-key")
+            || captured
+                .request_text
+                .to_ascii_lowercase()
+                .contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be JSON");
+    assert_eq!(body["model"], "openai/gpt-5");
+    assert_eq!(body["instructions"], "You are concise.");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_create_message_preset_path_body_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(preset_response_body());
+    let request = messages::AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(128)
+        .messages(vec![AnthropicMessage::user("hello")])
+        .build()
+        .expect("messages request should build");
+
+    let preset = presets::create_message_preset(&base_url, "management-key", "my-preset", &request)
+        .await
+        .expect("create message preset should succeed");
+    assert_eq!(preset.id, "preset_1");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/presets/my-preset/messages HTTP/1.1"
+    );
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("authorization: bearer management-key")
+            || captured
+                .request_text
+                .to_ascii_lowercase()
+                .contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be JSON");
+    assert_eq!(body["model"], "anthropic/claude-sonnet-4");
+    assert_eq!(body["max_tokens"], 128);
+
+    server.join().expect("server thread should finish");
+}


### PR DESCRIPTION
## Summary
- add typed `GET /datasets/rankings-daily` support under `client.models().get_rankings_daily(...)`
- add management-key preset creation surfaces for chat completions, Responses, and Messages request bodies
- refresh the tracked OpenAPI baseline and endpoint matrix to 66/66, including `AnthropicRole::System` and `GenerationData::preset_id`

## Tests
- `just openapi-refresh-baseline`
- `just openapi-drift-check`
- `just quality`

Fixes #218