### PR TITLE
feat: accept OpenAPI drift for issue 220

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,36 @@
   - `chat()`
   - `responses()`
   - `messages()`
+  - `rerank()`
+  - `audio()`
+  - `videos()`
+  - `files()`
   - `models()`
   - `management()`
   - `legacy()` behind `legacy-completions`
 - `src/api/` contains endpoint modules:
-  - `chat`
-  - `responses`
-  - `messages`
-  - `models`
-  - `embeddings`
-  - `discovery`
+  - `analytics`
   - `api_keys`
-  - `credits`
+  - `audio`
   - `auth`
+  - `byok`
+  - `chat`
+  - `credits`
+  - `discovery`
+  - `embeddings`
+  - `files`
   - `generation`
   - `guardrails`
   - `legacy/completion`
+  - `messages`
+  - `models`
+  - `observability`
+  - `organization`
+  - `presets`
+  - `rerank`
+  - `responses`
+  - `videos`
+  - `workspaces`
 - `src/types/` contains shared request/response, streaming, pagination, tool, and typed-tool types.
 - `crates/openrouter-cli/` contains the workspace CLI companion, including file/profile config resolution.
 - `tests/unit/` contains fast serde/config/domain tests.
@@ -74,15 +88,26 @@ Direct cargo entrypoints:
 - Management smoke requires `OPENROUTER_MANAGEMENT_KEY` and `OPENROUTER_RUN_MANAGEMENT_TESTS=1`.
 - CLI live smoke uses `OPENROUTER_CLI_RUN_LIVE=1`; write smoke also requires `OPENROUTER_CLI_RUN_LIVE_WRITE=1`.
 - If you touch migration docs or canonical naming guidance, run `just check-migration-docs` and `cargo test --test migration_smoke --all-features`.
+- If you change public SDK request/response types, domain client surfaces, CLI behavior, migration docs, or CI-aligned release/test surfaces, run `just quality-ci` before opening or updating a PR.
+
+## OpenAPI Drift Workflow
+
+- For OpenAPI drift issues, inspect the issue/drift report first, implement accepted SDK surface changes, then run `just openapi-refresh-baseline`.
+- Always finish drift work with `just openapi-drift-check`; the expected final state is `added=0, removed=0, changed=0`.
+- If upstream OpenAPI changes again before PR checks run, refresh the tracked baseline again only after confirming no new SDK/API work is required.
+- Update `README.md`, `CHANGELOG.md`, and `docs/operations/official-endpoint-test-matrix.md` when accepted endpoint coverage or public API surface changes.
+- When upstream schema drift changes public SDK field types or default serialization, audit `crates/openrouter-cli/` call sites and snapshot tests that consume those SDK types.
 
 ## Commit And Pull Request Guidelines
 
 - Follow the existing commit style: `feat:`, `fix:`, `docs:`, `chore:`.
+- PR titles must use the same conventional prefix style (`feat:`, `fix:`, `docs:`, etc.); do not prefix titles with `[codex]`.
 - Keep PRs focused and include rationale plus behavior changes.
 - Do not close pull requests automatically unless the user explicitly asks for that action.
 - When API surface changes, update `README.md`, relevant example(s), and `CHANGELOG.md` in the same change.
 - Before opening a PR, run `just quality`.
-- If you touched CLI behavior, migration docs, or CI-aligned release/test surfaces, also run `just quality-ci`.
+- If you touched CLI behavior, public SDK request/response types, migration docs, or CI-aligned release/test surfaces, also run `just quality-ci`.
+- After opening or updating a PR, run `gh pr checks <pr>` and inspect failing Actions logs before assuming local validation is enough.
 
 ## Security And Configuration Tips
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added typed SDK support for the Files API (`GET|POST /files`, `GET|DELETE /files/{file_id}`, and `GET /files/{file_id}/content`) via `api::files` and the canonical `client.files()` surface.
+- Added typed management-key SDK support for analytics metadata and query endpoints (`GET /analytics/meta`, `POST /analytics/query`) via `api::analytics` and `client.management().get_analytics_meta(...)` / `query_analytics(...)`.
+- Added typed SDK support for `GET /datasets/app-rankings`, `GET /datasets/benchmarks/artificial-analysis`, and `GET /datasets/benchmarks/design-arena` through the `models()` domain client.
+- Added typed SDK support for `GET /model/{author}/{slug}` and expanded `GET /models` filtering through `ListModelsParams`.
+- Added management-key SDK support for listing, reading, and versioning presets via `GET /presets`, `GET /presets/{slug}`, `GET /presets/{slug}/versions`, and `GET /presets/{slug}/versions/{version}`.
 - Added typed SDK support for `GET /datasets/rankings-daily`, including `api::discovery::RankingsDailyResponse` and the canonical `client.models().get_rankings_daily(...)` surface.
 - Added management-key SDK support for creating or updating presets from inference request bodies via `POST /presets/{slug}/chat/completions`, `POST /presets/{slug}/responses`, and `POST /presets/{slug}/messages`.
 - Added `AnthropicRole::System` and `AnthropicMessage::system(...)` for the refreshed `/messages` role schema.
 - Added typed `GenerationData::preset_id` support on `GET /generation` metadata responses.
 
 ### Changed
+- Accepted the 2026-06-16 OpenAPI drift review, including analytics, files, app rankings, benchmark datasets, singular model lookup, preset read/version endpoints, model filter/schema refreshes, rerank multimodal documents, and video input reference refreshes, restoring the repository snapshot to `81 / 81` official OpenAPI endpoint coverage.
+- Changed the opt-in OpenRouter metadata request header sent by chat, Responses, and Messages requests from `X-OpenRouter-Experimental-Metadata` to the upstream `X-OpenRouter-Metadata` spelling while preserving the existing request-builder method names.
+- Refreshed model and generation metadata deserialization for nullable model context lengths, model links/benchmarks, default parameters, generation `data_region`, floating-point latency, and integer status values.
 - Accepted the 2026-06-01 OpenAPI drift review, including daily rankings datasets, preset creation endpoints, generation metadata additions, and provider taxonomy refreshes, restoring the repository snapshot to `66 / 66` official OpenAPI endpoint coverage.
 
 ## [0.10.0] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accepted the 2026-06-16 OpenAPI drift review, including analytics, files, app rankings, benchmark datasets, singular model lookup, preset read/version endpoints, model filter/schema refreshes, rerank multimodal documents, and video input reference refreshes, restoring the repository snapshot to `81 / 81` official OpenAPI endpoint coverage.
 - Changed the opt-in OpenRouter metadata request header sent by chat, Responses, and Messages requests from `X-OpenRouter-Experimental-Metadata` to the upstream `X-OpenRouter-Metadata` spelling while preserving the existing request-builder method names.
 - Refreshed model and generation metadata deserialization for nullable model context lengths, model links/benchmarks, default parameters, generation `data_region`, floating-point latency, and integer status values.
+- Refreshed rerank response document echoes so successful image-only multimodal rerank results deserialize with optional `text` and `image` fields.
 - Accepted the 2026-06-01 OpenAPI drift review, including daily rankings datasets, preset creation endpoints, generation metadata additions, and provider taxonomy refreshes, restoring the repository snapshot to `66 / 66` official OpenAPI endpoint coverage.
 
 ## [0.10.0] - 2026-05-20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1304,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1876,6 +1887,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ legacy-completions = []
 dotenvy_macro = "0.15.7"
 futures-util = "0.3.31"
 http = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 </div>
 
-`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, video generation, models, embeddings, presets, and management APIs, plus a companion CLI in the same repository.
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, video generation, models, embeddings, files, presets, analytics, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `66 / 66` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `81 / 81` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
-- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`, and opt-in `legacy()`
+- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `files()`, `models()`, `management()`, and opt-in `legacy()`
 - Typed request/response models with builder-style ergonomics
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, and messages, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
-- Opt-in experimental response metadata for chat, Responses API, and Anthropic-compatible Messages requests
-- Discovery, rankings datasets, rerank, audio speech/transcription, video generation, embeddings, API-key management, preset creation, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Opt-in OpenRouter response metadata for chat, Responses API, and Anthropic-compatible Messages requests
+- Discovery, rankings and benchmark datasets, rerank, audio speech/transcription, video generation, files, embeddings, API-key management, preset creation/readback/versioning, analytics, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -106,8 +106,9 @@ The canonical public surface is domain-oriented:
 | `audio().speech()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
 | `audio().transcriptions()` | `create` | `/audio/transcriptions` | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
-| `models()` | `list`, `list_by_category`, `list_by_parameters`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/models*`, `/providers`, `/datasets/rankings-daily`, `/endpoints/zdr`, `/embeddings*` | API key |
-| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
+| `files()` | `list`, `upload`, `get_metadata`, `download_content`, `delete` | `/files*` | API key |
+| `models()` | `list`, `list_filtered`, `list_by_category`, `list_by_parameters`, `get`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `get_app_rankings`, `get_benchmarks_artificial_analysis`, `get_benchmarks_design_arena`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/model*`, `/models*`, `/providers`, `/datasets/*`, `/endpoints/zdr`, `/embeddings*` | API key |
+| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_presets`, `get_preset`, `list_preset_versions`, `get_preset_version`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `get_analytics_meta`, `query_analytics`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/analytics*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
 At runtime, the builder/client exposes the values the SDK directly consumes:
@@ -131,9 +132,9 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 - unified streaming across chat, responses, and messages
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
-- model discovery, provider discovery, embeddings, and ZDR endpoints
-- typed generation metadata, model voice metadata, workspace I/O logging controls, and video callback URL support
-- management-key workflows for keys, workspace-scoped keys, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
+- model discovery, provider discovery, app rankings, benchmark datasets, embeddings, and ZDR endpoints
+- typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
+- management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 
@@ -225,7 +226,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`66 / 66`)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`81 / 81`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
@@ -255,7 +256,7 @@ Full migration guide: [`MIGRATION.md`](MIGRATION.md)
 - `OpenRouterError::HttpRequest(surf::Error)` -> `OpenRouterError::HttpRequest(HttpRequestError)`
 - `ApiErrorContext.status: surf::StatusCode` -> `ApiErrorContext.status: http::StatusCode`
 - `openrouter_rs::utils::{with_bearer_auth, with_request_metadata, with_client_request_headers, handle_error}` -> caller-owned transport helpers or direct use of the canonical domain clients
-- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `models()`, `management()`, and `legacy()`
+- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `files()`, `models()`, `management()`, and `legacy()`
 
 ### 🔁 0.6 Naming/Pagination Migration
 
@@ -325,6 +326,11 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 - [`docs/community/awesome-openrouter/README.md`](docs/community/awesome-openrouter/README.md) for the Awesome OpenRouter submission kit and directory-safe assets
 
 ## 📈 Release History
+
+### Unreleased
+
+- Added typed SDK coverage for files, analytics, app rankings, benchmark datasets, singular model lookup, preset listing/readback/versioning, extended model filters, multimodal rerank documents, and richer video input references.
+- Accepted OpenAPI drift through the 2026-06-16 review and restored the tracked endpoint snapshot to `81 / 81`.
 
 ### Version 0.10.0 *(Latest)*
 

--- a/crates/openrouter-cli/src/main.rs
+++ b/crates/openrouter-cli/src/main.rs
@@ -280,6 +280,12 @@ fn resolve_enforce_zdr_flag(enforce_zdr: bool, no_enforce_zdr: bool) -> Option<b
     }
 }
 
+fn display_optional<T: ToString>(value: Option<T>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
 fn print_models(models: &[models::Model], output: OutputFormat) -> Result<()> {
     match output {
         OutputFormat::Json => print_json(models)?,
@@ -290,7 +296,7 @@ fn print_models(models: &[models::Model], output: OutputFormat) -> Result<()> {
                     vec![
                         model.id.clone(),
                         model.name.clone(),
-                        model.context_length.to_string(),
+                        display_optional(model.context_length),
                         model.pricing.prompt.clone(),
                         model.pricing.completion.clone(),
                     ]
@@ -318,10 +324,16 @@ fn print_model(model: &models::Model, output: OutputFormat) -> Result<()> {
             println!("id: {}", model.id);
             println!("name: {}", model.name);
             println!("created: {}", model.created);
-            println!("context_length: {}", model.context_length);
+            println!("context_length: {}", display_optional(model.context_length));
             println!("description: {}", model.description);
-            println!("modality: {}", model.architecture.modality);
-            println!("tokenizer: {}", model.architecture.tokenizer);
+            println!(
+                "modality: {}",
+                display_optional(model.architecture.modality.as_deref())
+            );
+            println!(
+                "tokenizer: {}",
+                display_optional(model.architecture.tokenizer.as_deref())
+            );
             println!("prompt_price: {}", model.pricing.prompt);
             println!("completion_price: {}", model.pricing.completion);
         }

--- a/crates/openrouter-cli/tests/discovery_commands.rs
+++ b/crates/openrouter-cli/tests/discovery_commands.rs
@@ -141,6 +141,7 @@ fn test_models_list_json_snapshot() {
         "created": 1710000000.0,
         "description": "Test model",
         "context_length": 128000.0,
+        "supported_parameters": [],
         "architecture": {
             "modality": "text->text",
             "tokenizer": "GPT",

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,15 +1,15 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-06-05
+Snapshot date: 2026-06-16
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `66` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `66 / 66` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 66` endpoints currently exercised.
+- Official OpenAPI endpoints: `81` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `81 / 81` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 81` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
@@ -32,11 +32,13 @@ Drift review note:
 - Upstream refreshed Responses schemas including image detail `original` and response status shapes. The SDK already carries these through flexible `Value` and `String` fields, so no public API migration is required.
 - Upstream added `GET /datasets/rankings-daily` and preset creation endpoints for chat-completions, Responses, and Anthropic-compatible Messages request bodies. The SDK now exposes rankings through `client.models().get_rankings_daily(...)` and preset creation through `client.management().create_*_preset(...)`.
 - Upstream refreshed generation metadata, provider taxonomy values, plugin payload shapes, and Messages role variants. Existing flexible `String`, `Value`, `HashMap`, and `Option` fields carry those schema details without a public API migration.
+- Upstream added analytics metadata/query endpoints, the Files API, app rankings and benchmark datasets, singular model lookup, and preset list/read/version endpoints. The SDK now exposes files through `client.files()`, the new datasets and singular lookup through `client.models()`, and analytics plus preset read/version workflows through `client.management()`.
+- Upstream expanded model list filters, nullable model metadata, generation metadata fields, rerank document input shapes, video input references, auth-code workspace IDs, and the request metadata header spelling. The SDK now exposes typed builders/fields for those surfaces and sends `X-OpenRouter-Metadata` for opt-in metadata.
 
 Legend:
 
 - `SDK`: endpoint implemented in `openrouter-rs`.
-- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
+- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `files()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
 - `Unit`: unit coverage depth.
   - `Path` = test asserts HTTP method/path (often with header/body checks).
   - `Contract` = serde/request-shape/parser coverage only.
@@ -49,6 +51,8 @@ Legend:
 | Official endpoint | SDK surface | SDK | Unit | Live | Priority |
 | --- | --- | --- | --- | --- | --- |
 | `GET /activity` | `client.management().get_activity(...)` | Yes | Path | No | P1 |
+| `GET /analytics/meta` | `client.management().get_analytics_meta()` | Yes | Path | No | P1 |
+| `POST /analytics/query` | `client.management().query_analytics(...)` | Yes | Path | No | P1 |
 | `POST /auth/keys` | `client.management().create_api_key_from_auth_code(...)` | Yes | Path | No | P2 |
 | `POST /auth/keys/code` | `client.management().create_auth_code(...)` | Yes | Path | No | P2 |
 | `GET /byok` | `client.management().list_byok_keys(...)` | Yes | Path | No | P1 |
@@ -59,10 +63,18 @@ Legend:
 | `POST /chat/completions` | `client.chat().create(...)` / `client.chat().stream(...)` | Yes | Contract | Yes | Keep |
 | `GET /credits` | `client.get_credits()` / `client.management().get_credits()` | Yes | Path | No | P2 |
 | `POST /credits/coinbase` | `client.create_coinbase_charge(...)` / `client.management().create_coinbase_charge(...)` | Yes | Path | No | P2 |
+| `GET /datasets/app-rankings` | `client.models().get_app_rankings(...)` | Yes | Path | No | P2 |
+| `GET /datasets/benchmarks/artificial-analysis` | `client.models().get_benchmarks_artificial_analysis(...)` | Yes | Path | No | P2 |
+| `GET /datasets/benchmarks/design-arena` | `client.models().get_benchmarks_design_arena(...)` | Yes | Path | No | P2 |
 | `GET /datasets/rankings-daily` | `client.models().get_rankings_daily(...)` | Yes | Path | No | P2 |
 | `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | Yes | Keep |
 | `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | Path | Yes | Keep |
 | `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | Yes | Keep |
+| `GET /files` | `client.files().list(...)` | Yes | Path | No | P1 |
+| `POST /files` | `client.files().upload(...)` | Yes | Path | No | P1 |
+| `GET /files/{file_id}` | `client.files().get_metadata(...)` | Yes | Path | No | P1 |
+| `DELETE /files/{file_id}` | `client.files().delete(...)` | Yes | Path | No | P1 |
+| `GET /files/{file_id}/content` | `client.files().download_content(...)` | Yes | Path | No | P1 |
 | `GET /generation` | `client.get_generation(...)` / `client.management().get_generation(...)` | Yes | Path | No | P2 |
 | `GET /generation/content` | `client.get_generation_content(...)` / `client.management().get_generation_content(...)` | Yes | Path | No | P2 |
 | `GET /guardrails` | `client.management().list_guardrails(...)` / `client.management().list_guardrails_in_workspace(...)` | Yes | Path | Yes | Keep |
@@ -84,6 +96,7 @@ Legend:
 | `GET /keys/{hash}` | `client.get_api_key(...)` / `client.management().get_api_key(...)` | Yes | Path | Yes | Keep |
 | `PATCH /keys/{hash}` | `client.update_api_key(...)` / `client.management().update_api_key(...)` | Yes | Path | Yes | Keep |
 | `DELETE /keys/{hash}` | `client.delete_api_key(...)` / `client.management().delete_api_key(...)` | Yes | Path | Yes | Keep |
+| `GET /model/{author}/{slug}` | `client.models().get(...)` | Yes | Path | No | P2 |
 | `GET /models` | `client.list_models()` / `client.models().list()` | Yes | Contract | Yes | Keep |
 | `GET /models/{author}/{slug}/endpoints` | `client.list_model_endpoints(...)` / `client.models().list_endpoints(...)` | Yes | Path | Yes | Keep |
 | `GET /models/count` | `client.count_models()` / `client.models().get_model_count()` | Yes | Contract | Yes | Keep |
@@ -94,9 +107,13 @@ Legend:
 | `PATCH /observability/destinations/{id}` | `client.management().update_observability_destination(...)` | Yes | Path | No | P1 |
 | `DELETE /observability/destinations/{id}` | `client.management().delete_observability_destination(...)` | Yes | Path | No | P1 |
 | `GET /organization/members` | `client.management().list_organization_members(...)` | Yes | Path | Yes | Keep |
+| `GET /presets` | `client.management().list_presets(...)` | Yes | Path | No | P2 |
+| `GET /presets/{slug}` | `client.management().get_preset(...)` | Yes | Path | No | P2 |
 | `POST /presets/{slug}/chat/completions` | `client.management().create_chat_completion_preset(...)` | Yes | Path | No | P2 |
 | `POST /presets/{slug}/messages` | `client.management().create_message_preset(...)` | Yes | Path | No | P2 |
 | `POST /presets/{slug}/responses` | `client.management().create_response_preset(...)` | Yes | Path | No | P2 |
+| `GET /presets/{slug}/versions` | `client.management().list_preset_versions(...)` | Yes | Path | No | P2 |
+| `GET /presets/{slug}/versions/{version}` | `client.management().get_preset_version(...)` | Yes | Path | No | P2 |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
 | `GET /workspaces` | `client.management().list_workspaces(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}` | `client.management().get_workspace(...)` | Yes | Path | No | P1 |
@@ -127,11 +144,12 @@ The endpoint below is intentionally kept as legacy compatibility and is not part
 ## Incremental Test Plan
 
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
-2. P1: add management-key live smoke coverage for `/activity`.
-3. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets/rankings-daily`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
-4. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, and `/videos*` once stable fixtures and cost controls are defined.
-5. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
-6. P1: add management-key live validation for `/byok*` and `/observability/destinations*` once safe test credentials and destination fixtures are defined.
+2. P1: add management-key live smoke coverage for `/activity` and `/analytics*`.
+3. P1: add controlled file lifecycle live coverage for `/files*` once upload/download fixtures and cleanup guarantees are defined.
+4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets*`, `/model/{author}/{slug}`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
+5. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, and `/videos*` once stable fixtures and cost controls are defined.
+6. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
+7. P1: add management-key live validation for `/byok*` and `/observability/destinations*` once safe test credentials and destination fixtures are defined.
 
 ## Reproduce Snapshot
 

--- a/examples/create_rerank.rs
+++ b/examples/create_rerank.rs
@@ -19,8 +19,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let response = client.rerank().create(&request).await?;
     for result in response.results {
         println!(
-            "index={} score={} text={}",
-            result.index, result.relevance_score, result.document.text
+            "index={} score={} text={} image={}",
+            result.index,
+            result.relevance_score,
+            result.document.text.as_deref().unwrap_or("-"),
+            result.document.image.as_deref().unwrap_or("-")
         );
     }
 

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,13 +1,23 @@
 {
   "components": {
     "parameters": {
+      "AppCategories": {
+        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
+        "in": "header",
+        "name": "X-OpenRouter-Categories",
+        "schema": {
+          "type": "string"
+        },
+        "x-speakeasy-name-override": "appCategories"
+      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-Title",
+        "name": "X-OpenRouter-Title",
         "schema": {
           "type": "string"
-        }
+        },
+        "x-speakeasy-name-override": "appTitle"
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -19,6 +29,43 @@
       }
     },
     "schemas": {
+      "AABenchmarkEntry": {
+        "description": "Artificial Analysis benchmark index scores.",
+        "example": {
+          "agentic_index": 55.8,
+          "coding_index": 63.2,
+          "intelligence_index": 71.4
+        },
+        "properties": {
+          "agentic_index": {
+            "description": "Artificial Analysis Agentic Index score",
+            "example": 55.8,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "coding_index": {
+            "description": "Artificial Analysis Coding Index score",
+            "example": 63.2,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "intelligence_index": {
+            "description": "Artificial Analysis Intelligence Index score",
+            "example": 71.4,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "intelligence_index",
+          "coding_index",
+          "agentic_index"
+        ],
+        "type": "object"
+      },
       "ActivityItem": {
         "example": {
           "byok_usage_inference": 0.012,
@@ -136,6 +183,147 @@
         },
         "required": [
           "data"
+        ],
+        "type": "object"
+      },
+      "AdvisorNestedTool": {
+        "additionalProperties": {
+          "nullable": true
+        },
+        "description": "A tool made available to the advisor sub-agent. Only OpenRouter server tools (e.g. openrouter:web_search) are supported; function tools are rejected because the advisor has no way to execute them. The advisor tool may not list itself.",
+        "example": {
+          "type": "openrouter:web_search"
+        },
+        "properties": {
+          "parameters": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "AdvisorReasoning": {
+        "description": "Reasoning configuration forwarded to the advisor call. Use this to control reasoning effort and token budget for models that support extended thinking.",
+        "example": {
+          "effort": "high"
+        },
+        "properties": {
+          "effort": {
+            "description": "Reasoning effort level for the advisor call.",
+            "enum": [
+              "xhigh",
+              "high",
+              "medium",
+              "low",
+              "minimal",
+              "none"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "max_tokens": {
+            "description": "Maximum number of reasoning tokens the advisor may use.",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AdvisorServerToolConfig": {
+        "description": "Configuration for one openrouter:advisor server tool entry.",
+        "example": {
+          "model": "~anthropic/claude-opus-latest",
+          "name": "reviewer"
+        },
+        "properties": {
+          "forward_transcript": {
+            "description": "When true, the full parent conversation is forwarded to the advisor so it sees the same context the executor does (and the tool-call `prompt`, if given, is appended as a final user turn). When false or omitted, the advisor receives only the `prompt` the executor passes in the tool call.",
+            "example": false,
+            "type": "boolean"
+          },
+          "instructions": {
+            "description": "System instructions for the advisor sub-agent. When omitted, the advisor responds with no system prompt of its own.",
+            "example": "You are a senior staff engineer. Give a focused, decisive plan.",
+            "type": "string"
+          },
+          "max_completion_tokens": {
+            "description": "Maximum number of output tokens (including reasoning) the advisor may produce. When omitted, the provider's default applies.",
+            "example": 2048,
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "description": "Maximum number of tool-calling steps the advisor sub-agent may take during its agentic loop. Capped at 25. Only relevant when the advisor is given tools.",
+            "example": 5,
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "model": {
+            "description": "Slug of the advisor model to consult (any OpenRouter model). When omitted, the executor can choose it via the tool call's `model` argument; if neither is set, the model from the outer API request is used. The advisor tool itself cannot be the advisor model.",
+            "example": "~anthropic/claude-opus-latest",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional name for this advisor. The model sees one tool per named advisor (and one default for an unnamed entry). Names must be unique across advisor entries. Letters, digits, spaces, underscores, and dashes; trimmed; 1\u201364 chars.",
+            "example": "reviewer",
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "type": "string"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/AdvisorReasoning"
+          },
+          "stream": {
+            "description": "When true, the advisor's advice streams incrementally as it is produced. In the Responses API this emits `response.output_text.delta` events targeting the advisor output item; the final `advice` field is still set on the completed item. Has no effect on the Chat Completions API (where the advice arrives only as the final tool result). When false or omitted, the advice arrives only as the final result.",
+            "example": false,
+            "type": "boolean"
+          },
+          "temperature": {
+            "description": "Sampling temperature forwarded to the advisor call. When omitted, the provider's default applies.",
+            "example": 0.7,
+            "format": "double",
+            "type": "number"
+          },
+          "tools": {
+            "description": "Tools the advisor sub-agent may use while forming its advice. The advisor runs as an agentic sub-agent over these tools, then returns its text. Only OpenRouter server tools are supported \u2014 function tools are rejected \u2014 and the list must not include the advisor tool itself.",
+            "items": {
+              "$ref": "#/components/schemas/AdvisorNestedTool"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "AdvisorServerTool_OpenRouter": {
+        "description": "OpenRouter built-in server tool: consults a higher-intelligence advisor model (any OpenRouter model) for guidance mid-generation and returns its response. The advisor may run as a sub-agent with its own tools. Include multiple entries to offer several named advisors; at most one entry may omit `name` to act as the default advisor.",
+        "example": {
+          "parameters": {
+            "model": "~anthropic/claude-opus-latest",
+            "name": "reviewer"
+          },
+          "type": "openrouter:advisor"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/AdvisorServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:advisor"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
         ],
         "type": "object"
       },
@@ -1537,6 +1725,9 @@
           },
           {
             "properties": {
+              "model": {
+                "type": "string"
+              },
               "type": {
                 "enum": [
                   "message"
@@ -2899,6 +3090,93 @@
         ],
         "type": "object"
       },
+      "AppRankingsItem": {
+        "example": {
+          "app_id": 12345,
+          "app_name": "Cline",
+          "rank": 1,
+          "total_requests": 4321,
+          "total_tokens": "12345678"
+        },
+        "properties": {
+          "app_id": {
+            "description": "Stable numeric identifier of the app on OpenRouter.",
+            "example": 12345,
+            "type": "integer"
+          },
+          "app_name": {
+            "description": "Public display name of the app.",
+            "example": "Cline",
+            "type": "string"
+          },
+          "rank": {
+            "description": "1-based position of the app within this response, per the requested `sort`.",
+            "example": 1,
+            "type": "integer"
+          },
+          "total_requests": {
+            "description": "Number of requests attributed to the app inside the date window.",
+            "example": 4321,
+            "type": "integer"
+          },
+          "total_tokens": {
+            "description": "Sum of `prompt_tokens + completion_tokens` attributed to the app inside the date window, returned as a decimal string so 64-bit values are not truncated.",
+            "example": "12345678",
+            "type": "string"
+          }
+        },
+        "required": [
+          "rank",
+          "app_id",
+          "app_name",
+          "total_tokens",
+          "total_requests"
+        ],
+        "type": "object"
+      },
+      "AppRankingsResponse": {
+        "example": {
+          "data": [
+            {
+              "app_id": 12345,
+              "app_name": "Cline",
+              "rank": 1,
+              "total_requests": 4321,
+              "total_tokens": "12345678"
+            },
+            {
+              "app_id": 67890,
+              "app_name": "Roo Code",
+              "rank": 2,
+              "total_requests": 2109,
+              "total_tokens": "9876543"
+            }
+          ],
+          "meta": {
+            "as_of": "2026-05-12T02:00:00Z",
+            "end_date": "2026-05-11",
+            "start_date": "2026-04-12",
+            "version": "v1"
+          }
+        },
+        "properties": {
+          "data": {
+            "description": "Apps ranked per the requested `sort`, re-numbered 1..N after category filtering. `popular` sorts by `total_tokens` descending; `trending` sorts by absolute excess token growth descending and may return fewer than `limit` rows when few apps are growing.",
+            "items": {
+              "$ref": "#/components/schemas/AppRankingsItem"
+            },
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/RankingsDailyMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object"
+      },
       "ApplyPatchCallItem": {
         "description": "A tool call emitted by the model requesting a V4A patch operation. The client applies the patch and echoes an `apply_patch_call_output` on the next turn.",
         "example": {
@@ -3420,6 +3698,7 @@
           "cohere",
           "crusoe",
           "darkbloom",
+          "decart",
           "deepinfra",
           "deepseek",
           "dekallm",
@@ -3473,6 +3752,7 @@
           "together",
           "upstage",
           "venice",
+          "wafer",
           "wandb",
           "xai",
           "xiaomi",
@@ -4609,7 +4889,8 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField"
+            "$ref": "#/components/schemas/ResponsesErrorField",
+            "nullable": true
           },
           "frequency_penalty": {
             "format": "double",
@@ -4620,10 +4901,12 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails"
+            "$ref": "#/components/schemas/IncompleteDetails",
+            "nullable": true
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs"
+            "$ref": "#/components/schemas/BaseInputs",
+            "nullable": true
           },
           "max_output_tokens": {
             "nullable": true,
@@ -4712,7 +4995,8 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig"
+            "$ref": "#/components/schemas/BaseReasoningConfig",
+            "nullable": true
           },
           "safety_identifier": {
             "nullable": true,
@@ -4733,7 +5017,8 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig"
+            "$ref": "#/components/schemas/TextConfig",
+            "nullable": true
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -4822,6 +5107,7 @@
             "type": "array"
           },
           "top_logprobs": {
+            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -4830,7 +5116,8 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation"
+            "$ref": "#/components/schemas/Truncation",
+            "nullable": true
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -4961,6 +5248,525 @@
           "text",
           "sequence_number",
           "logprobs"
+        ],
+        "type": "object"
+      },
+      "BashServerTool": {
+        "description": "OpenRouter built-in server tool: runs shell commands server-side in a sandboxed container",
+        "example": {
+          "parameters": {
+            "environment": {
+              "type": "container_auto"
+            }
+          },
+          "type": "openrouter:bash"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/BashServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:bash"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "BashServerToolConfig": {
+        "description": "Configuration for the openrouter:bash server tool",
+        "example": {
+          "environment": {
+            "type": "container_auto"
+          }
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/BashServerToolEngine"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/BashServerToolEnvironment"
+          },
+          "sleep_after_seconds": {
+            "$ref": "#/components/schemas/SandboxSleepAfterSeconds"
+          }
+        },
+        "type": "object"
+      },
+      "BashServerToolEngine": {
+        "description": "Which bash engine to use. \"openrouter\" runs commands server-side in the OpenRouter sandbox. \"auto\" (default) and \"native\" use native passthrough, returning the tool call to your application to run client-side; OpenRouter does not execute the commands.",
+        "enum": [
+          "auto",
+          "native",
+          "openrouter"
+        ],
+        "example": "auto",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "BashServerToolEnvironment": {
+        "description": "Execution environment for the bash server tool.",
+        "discriminator": {
+          "mapping": {
+            "container_auto": "#/components/schemas/ContainerAutoEnvironment",
+            "container_reference": "#/components/schemas/ContainerReferenceEnvironment"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "type": "container_auto"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ContainerAutoEnvironment"
+          },
+          {
+            "$ref": "#/components/schemas/ContainerReferenceEnvironment"
+          }
+        ]
+      },
+      "BenchmarkPricing": {
+        "description": "OpenRouter pricing per token for this model. Null if pricing is unavailable.",
+        "example": {
+          "completion": "0.000015",
+          "prompt": "0.000003"
+        },
+        "nullable": true,
+        "properties": {
+          "completion": {
+            "description": "Cost per output token (USD, decimal string).",
+            "example": "0.000015",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "Cost per input token (USD, decimal string).",
+            "example": "0.000003",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt",
+          "completion"
+        ],
+        "type": "object"
+      },
+      "BenchmarksAAItem": {
+        "example": {
+          "aa_name": "GPT-4o",
+          "agentic_index": 58.3,
+          "coding_index": 65.8,
+          "intelligence_index": 71.2,
+          "model_permaslug": "openai/gpt-4o",
+          "pricing": {
+            "completion": "0.00001",
+            "prompt": "0.0000025"
+          }
+        },
+        "properties": {
+          "aa_name": {
+            "description": "Model name as listed on Artificial Analysis.",
+            "example": "GPT-4o",
+            "type": "string"
+          },
+          "agentic_index": {
+            "description": "Artificial Analysis Agentic Index composite score. Higher is better.",
+            "example": 58.3,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "coding_index": {
+            "description": "Artificial Analysis Coding Index composite score. Higher is better.",
+            "example": 65.8,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "intelligence_index": {
+            "description": "Artificial Analysis Intelligence Index composite score. Higher is better.",
+            "example": 71.2,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "model_permaslug": {
+            "description": "Stable OpenRouter model identifier.",
+            "example": "openai/gpt-4o",
+            "type": "string"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/BenchmarkPricing"
+          }
+        },
+        "required": [
+          "model_permaslug",
+          "aa_name",
+          "intelligence_index",
+          "coding_index",
+          "agentic_index",
+          "pricing"
+        ],
+        "type": "object"
+      },
+      "BenchmarksAAMeta": {
+        "example": {
+          "as_of": "2026-06-03T12:00:00Z",
+          "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+          "model_count": 50,
+          "source": "artificial-analysis",
+          "source_url": "https://artificialanalysis.ai",
+          "version": "v1"
+        },
+        "properties": {
+          "as_of": {
+            "description": "ISO-8601 timestamp of when this data was last updated.",
+            "example": "2026-06-03T12:00:00Z",
+            "type": "string"
+          },
+          "citation": {
+            "description": "Required attribution when republishing this data.",
+            "example": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+            "type": "string"
+          },
+          "model_count": {
+            "description": "Number of unique models in the response.",
+            "type": "integer"
+          },
+          "source": {
+            "description": "Data source identifier.",
+            "enum": [
+              "artificial-analysis"
+            ],
+            "type": "string"
+          },
+          "source_url": {
+            "description": "URL of the upstream data source.",
+            "enum": [
+              "https://artificialanalysis.ai"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "description": "Dataset version.",
+            "enum": [
+              "v1"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "as_of",
+          "version",
+          "source",
+          "source_url",
+          "citation",
+          "model_count"
+        ],
+        "type": "object"
+      },
+      "BenchmarksAAResponse": {
+        "example": {
+          "data": [
+            {
+              "aa_name": "GPT-4o",
+              "agentic_index": 58.3,
+              "coding_index": 65.8,
+              "intelligence_index": 71.2,
+              "model_permaslug": "openai/gpt-4o",
+              "pricing": {
+                "completion": "0.00001",
+                "prompt": "0.0000025"
+              }
+            }
+          ],
+          "meta": {
+            "as_of": "2026-06-03T12:00:00Z",
+            "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+            "model_count": 1,
+            "source": "artificial-analysis",
+            "source_url": "https://artificialanalysis.ai",
+            "version": "v1"
+          }
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarksAAItem"
+            },
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BenchmarksAAMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object"
+      },
+      "BenchmarksDAItem": {
+        "example": {
+          "arena": "models",
+          "avg_generation_time_ms": 3200,
+          "category": "codecategories",
+          "display_name": "Claude Sonnet 4",
+          "elo": 1423,
+          "model_permaslug": "anthropic/claude-sonnet-4",
+          "pricing": {
+            "completion": "0.000015",
+            "prompt": "0.000003"
+          },
+          "tournament_stats": {
+            "first_place": 12,
+            "fourth_place": 2,
+            "second_place": 8,
+            "third_place": 5,
+            "total": 27
+          },
+          "win_rate": 72
+        },
+        "properties": {
+          "arena": {
+            "description": "Arena this ranking belongs to.",
+            "example": "models",
+            "type": "string"
+          },
+          "avg_generation_time_ms": {
+            "description": "Average generation time in milliseconds.",
+            "example": 3200,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "category": {
+            "description": "Category within the arena.",
+            "example": "codecategories",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "Human-readable model name from Design Arena.",
+            "example": "Claude Sonnet 4",
+            "type": "string"
+          },
+          "elo": {
+            "description": "ELO rating from head-to-head arena battles.",
+            "example": 1423,
+            "format": "double",
+            "type": "number"
+          },
+          "model_permaslug": {
+            "description": "Stable OpenRouter model identifier when the model is on OpenRouter; otherwise the upstream Design Arena model id. Use pricing != null to detect OpenRouter-mapped models.",
+            "example": "anthropic/claude-sonnet-4",
+            "type": "string"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/BenchmarkPricing"
+          },
+          "tournament_stats": {
+            "description": "Placement distribution from tournament matches.",
+            "properties": {
+              "first_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "fourth_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "second_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "third_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "total": {
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "first_place",
+              "second_place",
+              "third_place",
+              "fourth_place",
+              "total"
+            ],
+            "type": "object"
+          },
+          "win_rate": {
+            "description": "Win rate as a percentage (0\u2013100).",
+            "example": 72,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "model_permaslug",
+          "display_name",
+          "arena",
+          "category",
+          "elo",
+          "win_rate",
+          "avg_generation_time_ms",
+          "tournament_stats",
+          "pricing"
+        ],
+        "type": "object"
+      },
+      "BenchmarksDAMeta": {
+        "example": {
+          "arena": "models",
+          "as_of": "2026-06-03T12:00:00Z",
+          "category": null,
+          "citation": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
+          "elo_bounds": {
+            "max": 1600,
+            "min": 900
+          },
+          "model_count": 50,
+          "source": "design-arena",
+          "source_url": "https://www.designarena.ai",
+          "version": "v1"
+        },
+        "properties": {
+          "arena": {
+            "description": "The arena filter applied.",
+            "type": "string"
+          },
+          "as_of": {
+            "description": "ISO-8601 timestamp of when this data was generated.",
+            "example": "2026-06-03T12:00:00Z",
+            "type": "string"
+          },
+          "category": {
+            "description": "The category filter applied, or null if showing all.",
+            "nullable": true,
+            "type": "string"
+          },
+          "citation": {
+            "description": "Required attribution when republishing this data.",
+            "example": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
+            "type": "string"
+          },
+          "elo_bounds": {
+            "description": "ELO range across all returned models for normalization.",
+            "properties": {
+              "max": {
+                "description": "Maximum ELO in the result set.",
+                "format": "double",
+                "type": "number"
+              },
+              "min": {
+                "description": "Minimum ELO in the result set.",
+                "format": "double",
+                "type": "number"
+              }
+            },
+            "required": [
+              "min",
+              "max"
+            ],
+            "type": "object"
+          },
+          "model_count": {
+            "description": "Number of unique models in the response.",
+            "type": "integer"
+          },
+          "source": {
+            "description": "Data source identifier.",
+            "enum": [
+              "design-arena"
+            ],
+            "type": "string"
+          },
+          "source_url": {
+            "description": "URL of the upstream data source.",
+            "enum": [
+              "https://www.designarena.ai"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "description": "Dataset version.",
+            "enum": [
+              "v1"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "as_of",
+          "version",
+          "source",
+          "source_url",
+          "citation",
+          "model_count",
+          "arena",
+          "category",
+          "elo_bounds"
+        ],
+        "type": "object"
+      },
+      "BenchmarksDAResponse": {
+        "example": {
+          "data": [
+            {
+              "arena": "models",
+              "avg_generation_time_ms": 3200,
+              "category": "codecategories",
+              "display_name": "Claude Sonnet 4",
+              "elo": 1423,
+              "model_permaslug": "anthropic/claude-sonnet-4",
+              "pricing": {
+                "completion": "0.000015",
+                "prompt": "0.000003"
+              },
+              "tournament_stats": {
+                "first_place": 12,
+                "fourth_place": 2,
+                "second_place": 8,
+                "third_place": 5,
+                "total": 27
+              },
+              "win_rate": 72
+            }
+          ],
+          "meta": {
+            "arena": "models",
+            "as_of": "2026-06-03T12:00:00Z",
+            "category": null,
+            "citation": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
+            "elo_bounds": {
+              "max": 1600,
+              "min": 900
+            },
+            "model_count": 1,
+            "source": "design-arena",
+            "source_url": "https://www.designarena.ai",
+            "version": "v1"
+          }
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarksDAItem"
+            },
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BenchmarksDAMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
         ],
         "type": "object"
       },
@@ -5892,6 +6698,12 @@
             "type": "object"
           },
           {
+            "$ref": "#/components/schemas/AdvisorServerTool_OpenRouter"
+          },
+          {
+            "$ref": "#/components/schemas/BashServerTool"
+          },
+          {
             "$ref": "#/components/schemas/DatetimeServerTool"
           },
           {
@@ -5899,6 +6711,9 @@
           },
           {
             "$ref": "#/components/schemas/ChatSearchModelsServerTool"
+          },
+          {
+            "$ref": "#/components/schemas/SubagentServerTool_OpenRouter"
           },
           {
             "$ref": "#/components/schemas/WebFetchServerTool"
@@ -6200,6 +7015,13 @@
             },
             "type": "object"
           },
+          "min_p": {
+            "description": "Minimum probability threshold relative to the most likely token. Tokens with probability below min_p * (probability of top token) are filtered out. Not all providers support this parameter.",
+            "example": 0.1,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
           "modalities": {
             "description": "Output modalities for the response. Supported values are \"text\", \"image\", and \"audio\".",
             "example": [
@@ -6316,6 +7138,29 @@
               }
             },
             "type": "object"
+          },
+          "reasoning_effort": {
+            "description": "Shorthand for setting reasoning effort. Equivalent to setting reasoning.effort. Cannot be used simultaneously with reasoning.effort if they differ.",
+            "enum": [
+              "xhigh",
+              "high",
+              "medium",
+              "low",
+              "minimal",
+              "none",
+              null
+            ],
+            "example": "medium",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "repetition_penalty": {
+            "description": "Penalizes tokens based on how much they have already appeared in the text. A value of 1.0 means no penalty. Values above 1.0 penalize repeated tokens more strongly. Not all providers support this parameter.",
+            "example": 1,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
           },
           "response_format": {
             "description": "Response format configuration",
@@ -6437,6 +7282,19 @@
               "$ref": "#/components/schemas/ChatFunctionTool"
             },
             "type": "array"
+          },
+          "top_a": {
+            "description": "Consider only tokens with \"sufficiently high\" probabilities based on the probability of the most likely token. Not all providers support this parameter.",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "top_k": {
+            "description": "Limits the model to choose from the top K most likely tokens at each step. A value of 1 means the model will always pick the most likely next token. Not all providers support this parameter.",
+            "example": 40,
+            "nullable": true,
+            "type": "integer"
           },
           "top_logprobs": {
             "description": "Number of top log probabilities to return (0-20)",
@@ -7302,7 +8160,7 @@
         },
         "properties": {
           "allowed_domains": {
-            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Perplexity. Cannot be used with excluded_domains.",
+            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, and most native providers (Anthropic, OpenAI, xAI). Cannot be used with excluded_domains.",
             "items": {
               "type": "string"
             },
@@ -7312,14 +8170,19 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Anthropic, and xAI. Not supported with OpenAI (silently ignored) or Perplexity. Cannot be used with allowed_domains.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, and xAI. Not supported with OpenAI (silently ignored). Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
+          "max_characters": {
+            "description": "Exact maximum number of characters of content per search result. Applies to the Exa, Parallel, and Perplexity engines; ignored with native provider search and Firecrawl. For Exa, caps highlight content per result. For Parallel, caps excerpt content per result (default 1,500 when omitted). For Perplexity, maps to the native `max_tokens_per_page` parameter (converted from characters to tokens) and trims the response to the exact character cap. When both `max_characters` and `search_context_size` are set, `max_characters` takes precedence. When omitted, falls back to `search_context_size` mapping (Exa) or engine defaults (Parallel, Perplexity).",
+            "example": 2000,
+            "type": "integer"
+          },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -7740,6 +8603,52 @@
         ],
         "type": "object"
       },
+      "ContainerAutoEnvironment": {
+        "description": "An OpenRouter-managed, auto-provisioned ephemeral container.",
+        "example": {
+          "type": "container_auto"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "container_auto"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ContainerReferenceEnvironment": {
+        "description": "Reference to a previously created container to reuse.",
+        "example": {
+          "container_id": "cntr_abc123",
+          "type": "container_reference"
+        },
+        "properties": {
+          "container_id": {
+            "description": "Identifier of an existing container to reuse (max 20 characters).",
+            "example": "cntr_abc123",
+            "maxLength": 20,
+            "minLength": 1,
+            "pattern": "^[\\w-]+$",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "container_reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "container_id"
+        ],
+        "type": "object"
+      },
       "ContentFilterAction": {
         "description": "Action taken when the pattern matches",
         "enum": [
@@ -7905,6 +8814,38 @@
           "type": "response.content_part.added"
         }
       },
+      "ContentPartAudio": {
+        "example": {
+          "audio_url": {
+            "url": "https://example.com/audio.mp3"
+          },
+          "type": "audio_url"
+        },
+        "properties": {
+          "audio_url": {
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "audio_url"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "audio_url"
+        ],
+        "type": "object"
+      },
       "ContentPartDoneEvent": {
         "allOf": [
           {
@@ -8047,6 +8988,38 @@
         "required": [
           "type",
           "input_video"
+        ],
+        "type": "object"
+      },
+      "ContentPartVideo": {
+        "example": {
+          "type": "video_url",
+          "video_url": {
+            "url": "https://example.com/clip.mp4"
+          }
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "video_url"
+            ],
+            "type": "string"
+          },
+          "video_url": {
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "type",
+          "video_url"
         ],
         "type": "object"
       },
@@ -8990,6 +9963,53 @@
           "type": "custom_tool_call_output"
         }
       },
+      "DABenchmarkEntry": {
+        "description": "A single Design Arena benchmark entry for a specific arena+category",
+        "example": {
+          "arena": "models",
+          "category": "website",
+          "elo": 1385.2,
+          "rank": 5,
+          "win_rate": 62.5
+        },
+        "properties": {
+          "arena": {
+            "description": "Arena type (e.g. models, builders, agents)",
+            "example": "models",
+            "type": "string"
+          },
+          "category": {
+            "description": "Category within the arena (e.g. website, gamedev, uicomponent)",
+            "example": "website",
+            "type": "string"
+          },
+          "elo": {
+            "description": "ELO rating from head-to-head arena battles",
+            "example": 1385.2,
+            "format": "double",
+            "type": "number"
+          },
+          "rank": {
+            "description": "Rank position within this arena+category among models available on OpenRouter (1 = highest ELO)",
+            "example": 5,
+            "type": "integer"
+          },
+          "win_rate": {
+            "description": "Win rate percentage in arena battles",
+            "example": 62.5,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "arena",
+          "category",
+          "elo",
+          "win_rate",
+          "rank"
+        ],
+        "type": "object"
+      },
       "DatetimeServerTool": {
         "description": "OpenRouter built-in server tool: returns the current date and time",
         "example": {
@@ -9483,6 +10503,129 @@
           "file_id",
           "filename",
           "index"
+        ],
+        "type": "object"
+      },
+      "FileDeleteResponse": {
+        "description": "Confirmation that a file was deleted.",
+        "example": {
+          "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "type": "file_deleted"
+        },
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file_deleted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "FileListResponse": {
+        "description": "A page of files belonging to the requesting workspace.",
+        "example": {
+          "cursor": null,
+          "data": [
+            {
+              "created_at": "2025-01-01T00:00:00Z",
+              "downloadable": false,
+              "filename": "document.pdf",
+              "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "mime_type": "application/pdf",
+              "size_bytes": 1024000,
+              "type": "file"
+            }
+          ],
+          "first_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "has_more": false,
+          "last_id": "file_011CNha8iCJcU1wXNR6q4V8w"
+        },
+        "properties": {
+          "cursor": {
+            "description": "Opaque cursor for the next page; null when there are no more results.",
+            "nullable": true,
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FileMetadata"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "last_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "has_more",
+          "first_id",
+          "last_id",
+          "cursor"
+        ],
+        "type": "object"
+      },
+      "FileMetadata": {
+        "description": "Metadata describing a stored file.",
+        "example": {
+          "created_at": "2025-01-01T00:00:00Z",
+          "downloadable": false,
+          "filename": "document.pdf",
+          "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "mime_type": "application/pdf",
+          "size_bytes": 1024000,
+          "type": "file"
+        },
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "downloadable": {
+            "type": "boolean"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "size_bytes": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "filename",
+          "mime_type",
+          "size_bytes",
+          "created_at",
+          "downloadable"
         ],
         "type": "object"
       },
@@ -10023,6 +11166,502 @@
         ],
         "type": "object"
       },
+      "FusionAnalysisResult": {
+        "description": "Structured analysis produced by the fusion judge model.",
+        "example": {
+          "blind_spots": [
+            "No model considered the impact on existing API consumers."
+          ],
+          "consensus": [
+            "All panel models agree the request is asking for a concise summary."
+          ],
+          "contradictions": [
+            {
+              "stances": [
+                {
+                  "model": "openai/gpt-5",
+                  "stance": "Favors an incremental rollout."
+                },
+                {
+                  "model": "anthropic/claude-sonnet-4.5",
+                  "stance": "Favors a single coordinated migration."
+                }
+              ],
+              "topic": "Recommended approach"
+            }
+          ],
+          "partial_coverage": [
+            {
+              "models": [
+                "openai/gpt-5"
+              ],
+              "point": "Only one model addressed the rollback strategy."
+            }
+          ],
+          "unique_insights": [
+            {
+              "insight": "Highlighted a backwards-compatibility risk the other models missed.",
+              "model": "anthropic/claude-sonnet-4.5"
+            }
+          ]
+        },
+        "properties": {
+          "blind_spots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "consensus": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "contradictions": {
+            "items": {
+              "properties": {
+                "stances": {
+                  "items": {
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "stance": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "model",
+                      "stance"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "topic": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "topic",
+                "stances"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "partial_coverage": {
+            "items": {
+              "properties": {
+                "models": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "point": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "models",
+                "point"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "unique_insights": {
+            "items": {
+              "properties": {
+                "insight": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model",
+                "insight"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "consensus",
+          "contradictions",
+          "partial_coverage",
+          "unique_insights",
+          "blind_spots"
+        ],
+        "type": "object"
+      },
+      "FusionCallAnalysisCompletedEvent": {
+        "description": "Emitted when the fusion judge completes with the structured analysis.",
+        "example": {
+          "analysis": {
+            "blind_spots": [],
+            "consensus": [],
+            "contradictions": [],
+            "partial_coverage": [],
+            "unique_insights": []
+          },
+          "item_id": "st_fusion_abc",
+          "output_index": 0,
+          "sequence_number": 40,
+          "type": "response.fusion_call.analysis.completed"
+        },
+        "properties": {
+          "analysis": {
+            "$ref": "#/components/schemas/FusionAnalysisResult"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.analysis.completed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "analysis",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallAnalysisInProgressEvent": {
+        "description": "Emitted when the fusion judge starts producing the structured analysis.",
+        "example": {
+          "item_id": "st_fusion_abc",
+          "judge_model": "openai/gpt-5",
+          "output_index": 0,
+          "sequence_number": 25,
+          "type": "response.fusion_call.analysis.in_progress"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "judge_model": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.analysis.in_progress"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "judge_model",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallCompletedEvent": {
+        "description": "Emitted when the openrouter:fusion tool call finishes.",
+        "example": {
+          "item_id": "st_fusion_abc",
+          "output_index": 0,
+          "sequence_number": 41,
+          "type": "response.fusion_call.completed"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.completed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallInProgressEvent": {
+        "description": "Emitted when an openrouter:fusion tool call begins executing.",
+        "example": {
+          "item_id": "st_fusion_abc",
+          "output_index": 0,
+          "sequence_number": 3,
+          "type": "response.fusion_call.in_progress"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.in_progress"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallPanelAddedEvent": {
+        "description": "Emitted when a fusion analysis-panel model starts.",
+        "example": {
+          "item_id": "st_fusion_abc",
+          "model": "openai/gpt-5",
+          "output_index": 0,
+          "sequence_number": 4,
+          "type": "response.fusion_call.panel.added"
+        },
+        "properties": {
+          "item_id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.panel.added"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallPanelCompletedEvent": {
+        "description": "Emitted when a fusion panel model finishes with its full content.",
+        "example": {
+          "content": "Full panel response text...",
+          "item_id": "st_fusion_abc",
+          "model": "openai/gpt-5",
+          "output_index": 0,
+          "sequence_number": 20,
+          "type": "response.fusion_call.panel.completed"
+        },
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.panel.completed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "content",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallPanelDeltaEvent": {
+        "description": "Incremental content token from a fusion panel model.",
+        "example": {
+          "delta": "Carbon taxes",
+          "item_id": "st_fusion_abc",
+          "model": "openai/gpt-5",
+          "output_index": 0,
+          "sequence_number": 5,
+          "type": "response.fusion_call.panel.delta"
+        },
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.panel.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "delta",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallPanelFailedEvent": {
+        "description": "Emitted when a fusion panel model fails.",
+        "example": {
+          "error": "Upstream provider error",
+          "item_id": "st_fusion_abc",
+          "model": "openai/gpt-5",
+          "output_index": 0,
+          "sequence_number": 18,
+          "status_code": 502,
+          "type": "response.fusion_call.panel.failed"
+        },
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "status_code": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.panel.failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "error",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
+      "FusionCallPanelReasoningDeltaEvent": {
+        "description": "Incremental reasoning token from a fusion panel model.",
+        "example": {
+          "delta": "Considering both sides",
+          "item_id": "st_fusion_abc",
+          "model": "openai/gpt-5",
+          "output_index": 0,
+          "sequence_number": 6,
+          "type": "response.fusion_call.panel.reasoning.delta"
+        },
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_index": {
+            "type": "integer"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.fusion_call.panel.reasoning.delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "delta",
+          "output_index",
+          "item_id",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
       "FusionPlugin": {
         "example": {
           "analysis_models": [
@@ -10070,6 +11709,116 @@
             "description": "Slug of the model that performs both the judge step (with web_search + web_fetch) and the final synthesis. When omitted, defaults to the first model in the Quality preset.",
             "example": "~anthropic/claude-opus-latest",
             "type": "string"
+          },
+          "preset": {
+            "description": "A curated OpenRouter fusion preset (slugs follow `<task>-<tier>`, e.g. `general-high`). Expands server-side into the preset's analysis_models panel and judge model, so callers never name individual models. Explicitly provided `analysis_models` / `model` take precedence.",
+            "enum": [
+              "general-high",
+              "general-budget"
+            ],
+            "example": "general-high",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "tools": {
+            "description": "Server tools available to panelist and judge inner calls. Each entry uses the same `{ type, parameters? }` shorthand as the outer Chat Completions request. When omitted, defaults to `[{ type: \"openrouter:web_search\" }, { type: \"openrouter:web_fetch\" }]`. Pass an empty array to disable tools entirely (panelists answer from parametric knowledge only).",
+            "example": [
+              {
+                "parameters": {
+                  "excluded_domains": [
+                    "example.com"
+                  ]
+                },
+                "type": "openrouter:web_search"
+              },
+              {
+                "type": "openrouter:web_fetch"
+              }
+            ],
+            "items": {
+              "properties": {
+                "parameters": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "nullable": true
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "nullable": true
+                            },
+                            {
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "nullable": true
+                            },
+                            {
+                              "nullable": true
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "description": "Optional configuration forwarded as the tool's `parameters` object.",
+                  "type": "object"
+                },
+                "type": {
+                  "description": "Server tool type identifier (e.g. \"openrouter:web_search\", \"openrouter:web_fetch\").",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "maxItems": 8,
+            "type": "array"
           }
         },
         "required": [
@@ -10146,6 +11895,43 @@
             "example": 0.7,
             "format": "double",
             "type": "number"
+          },
+          "tools": {
+            "description": "Server tools available to panelist and judge inner calls. Each entry uses the same `{ type, parameters? }` shorthand as the outer Chat Completions request. When omitted, defaults to `[{ type: \"openrouter:web_search\" }, { type: \"openrouter:web_fetch\" }]`. Pass an empty array to disable tools entirely (panelists answer from parametric knowledge only).",
+            "example": [
+              {
+                "parameters": {
+                  "excluded_domains": [
+                    "example.com"
+                  ]
+                },
+                "type": "openrouter:web_search"
+              },
+              {
+                "type": "openrouter:web_fetch"
+              }
+            ],
+            "items": {
+              "properties": {
+                "parameters": {
+                  "additionalProperties": {
+                    "nullable": true
+                  },
+                  "description": "Optional configuration forwarded as the tool's `parameters` object.",
+                  "type": "object"
+                },
+                "type": {
+                  "description": "Server tool type identifier (e.g. \"openrouter:web_search\", \"openrouter:web_fetch\").",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "maxItems": 8,
+            "type": "array"
           }
         },
         "type": "object"
@@ -10376,6 +12162,16 @@
                 "description": "ISO 8601 timestamp of when the generation was created",
                 "example": "2024-07-15T23:33:19.433273+00:00",
                 "type": "string"
+              },
+              "data_region": {
+                "description": "The data region this generation was routed through. 'europe' for EU-routed requests, 'global' otherwise.",
+                "enum": [
+                  "global",
+                  "europe"
+                ],
+                "example": "global",
+                "type": "string",
+                "x-speakeasy-unknown-values": "allow"
               },
               "external_user": {
                 "description": "External user identifier",
@@ -10644,7 +12440,8 @@
               "router",
               "provider_responses",
               "user_agent",
-              "http_referer"
+              "http_referer",
+              "data_region"
             ],
             "type": "object"
           }
@@ -10770,6 +12567,73 @@
                 "description": "The observability destination."
               }
             ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetPresetResponse": {
+        "description": "A preset with its currently designated version.",
+        "example": {
+          "data": {
+            "created_at": "2026-04-20T10:00:00Z",
+            "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+            "description": null,
+            "designated_version": {
+              "config": {
+                "model": "openai/gpt-4o",
+                "temperature": 0.7
+              },
+              "created_at": "2026-04-20T10:00:00Z",
+              "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+              "system_prompt": "You are a helpful assistant.",
+              "updated_at": "2026-04-20T10:00:00Z",
+              "version": 1
+            },
+            "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+            "id": "650e8400-e29b-41d4-a716-446655440001",
+            "name": "my-preset",
+            "slug": "my-preset",
+            "status": "active",
+            "status_updated_at": null,
+            "updated_at": "2026-04-20T10:00:00Z",
+            "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PresetWithDesignatedVersion"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetPresetVersionResponse": {
+        "description": "A single version of a preset.",
+        "example": {
+          "data": {
+            "config": {
+              "model": "openai/gpt-4o",
+              "temperature": 0.7
+            },
+            "created_at": "2026-04-20T10:00:00Z",
+            "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+            "system_prompt": "You are a helpful assistant.",
+            "updated_at": "2026-04-20T10:00:00Z",
+            "version": 1
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PresetDesignatedVersion"
           }
         },
         "required": [
@@ -11663,6 +13527,34 @@
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
       },
+      "InputReference": {
+        "description": "A reference asset used to guide video generation. Image references are supported by all providers; audio and video references are only honored by providers that support them (currently BytePlus Seedance 2.0).",
+        "discriminator": {
+          "mapping": {
+            "audio_url": "#/components/schemas/ContentPartAudio",
+            "image_url": "#/components/schemas/ContentPartImage",
+            "video_url": "#/components/schemas/ContentPartVideo"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "image_url": {
+            "url": "https://example.com/image.png"
+          },
+          "type": "image_url"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ContentPartImage"
+          },
+          {
+            "$ref": "#/components/schemas/ContentPartAudio"
+          },
+          {
+            "$ref": "#/components/schemas/ContentPartVideo"
+          }
+        ]
+      },
       "InputText": {
         "description": "Text input content item",
         "example": {
@@ -11889,6 +13781,15 @@
                 },
                 {
                   "$ref": "#/components/schemas/OutputSearchModelsServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputFusionServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputAdvisorServerToolItem"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputSubagentServerToolItem"
                 },
                 {
                   "$ref": "#/components/schemas/LocalShellCallItem"
@@ -12156,7 +14057,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -12535,6 +14436,80 @@
           "total_count": {
             "description": "Total number of destinations matching the filters.",
             "example": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
+      "ListPresetVersionsResponse": {
+        "description": "A paginated list of preset versions.",
+        "example": {
+          "data": [
+            {
+              "config": {
+                "model": "openai/gpt-4o",
+                "temperature": 0.7
+              },
+              "created_at": "2026-04-20T10:00:00Z",
+              "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+              "system_prompt": "You are a helpful assistant.",
+              "updated_at": "2026-04-20T10:00:00Z",
+              "version": 1
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PresetDesignatedVersion"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
+      "ListPresetsResponse": {
+        "description": "A paginated list of presets.",
+        "example": {
+          "data": [
+            {
+              "created_at": "2026-04-20T10:00:00Z",
+              "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+              "description": null,
+              "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+              "id": "650e8400-e29b-41d4-a716-446655440001",
+              "name": "my-preset",
+              "slug": "my-preset",
+              "status": "active",
+              "status_updated_at": null,
+              "updated_at": "2026-04-20T10:00:00Z",
+              "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Preset"
+            },
+            "type": "array"
+          },
+          "total_count": {
             "type": "integer"
           }
         },
@@ -13593,6 +15568,24 @@
         ],
         "type": "object"
       },
+      "MessagesFallbackParam": {
+        "additionalProperties": {
+          "nullable": true
+        },
+        "description": "Fallback model to try when the primary model fails or refuses. Only the `model` field is supported; per-attempt overrides are rejected.",
+        "example": {
+          "model": "claude-opus-4-8"
+        },
+        "properties": {
+          "model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
       "MessagesMessageParam": {
         "description": "Anthropic message with OpenRouter extensions",
         "example": {
@@ -14152,6 +16145,19 @@
             },
             "type": "object"
           },
+          "fallbacks": {
+            "description": "Fallback models to try if the primary model fails or refuses, in order. Handled by OpenRouter multi-model routing rather than Anthropic server-side fallbacks; cannot be combined with `models`. Each entry accepts only `model`. Maximum of 3 entries.",
+            "example": [
+              {
+                "model": "claude-opus-4-8"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MessagesFallbackParam"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "max_tokens": {
             "type": "integer"
           },
@@ -14653,6 +16659,9 @@
                   "type": "object"
                 },
                 {
+                  "$ref": "#/components/schemas/BashServerTool"
+                },
+                {
                   "$ref": "#/components/schemas/DatetimeServerTool"
                 },
                 {
@@ -14789,7 +16798,7 @@
                   "input_tokens": 100,
                   "output_tokens": 50,
                   "server_tool_use": null,
-                  "service_tier": "default"
+                  "service_tier": "standard"
                 }
               }
             },
@@ -14821,7 +16830,7 @@
             "input_tokens": 12,
             "output_tokens": 15,
             "server_tool_use": null,
-            "service_tier": "default"
+            "service_tier": "standard"
           }
         }
       },
@@ -14918,6 +16927,7 @@
                   "Crucible",
                   "Crusoe",
                   "Darkbloom",
+                  "Decart",
                   "DeepInfra",
                   "DeepSeek",
                   "DekaLLM",
@@ -14972,6 +16982,7 @@
                   "Together",
                   "Upstage",
                   "Venice",
+                  "Wafer",
                   "WandB",
                   "Xiaomi",
                   "xAI",
@@ -15030,7 +17041,7 @@
                   "input_tokens": 100,
                   "output_tokens": 50,
                   "server_tool_use": null,
-                  "service_tier": "default"
+                  "service_tier": "standard"
                 }
               }
             },
@@ -15217,6 +17228,9 @@
           "architecture": {
             "$ref": "#/components/schemas/ModelArchitecture"
           },
+          "benchmarks": {
+            "$ref": "#/components/schemas/ModelBenchmarks"
+          },
           "canonical_slug": {
             "description": "Canonical slug for the model",
             "example": "openai/gpt-4",
@@ -15392,6 +17406,50 @@
         ],
         "type": "object"
       },
+      "ModelBenchmarks": {
+        "description": "Third-party benchmark rankings for this model. Omitted when no benchmark data is available.",
+        "example": {
+          "artificial_analysis": {
+            "agentic_index": 55.8,
+            "coding_index": 63.2,
+            "intelligence_index": 71.4
+          },
+          "design_arena": [
+            {
+              "arena": "models",
+              "category": "website",
+              "elo": 1385.2,
+              "rank": 5,
+              "win_rate": 62.5
+            }
+          ]
+        },
+        "properties": {
+          "artificial_analysis": {
+            "$ref": "#/components/schemas/AABenchmarkEntry"
+          },
+          "design_arena": {
+            "description": "Design Arena ELO rankings across arena+category pairs.",
+            "example": [
+              {
+                "arena": "models",
+                "category": "website",
+                "elo": 1385.2,
+                "rank": 5,
+                "win_rate": 62.5
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/DABenchmarkEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "design_arena"
+        ],
+        "type": "object"
+      },
       "ModelGroup": {
         "description": "Tokenizer type used by the model",
         "enum": [
@@ -15441,6 +17499,55 @@
         "description": "Model to use for completion",
         "example": "openai/gpt-4",
         "type": "string"
+      },
+      "ModelResponse": {
+        "description": "Single model response",
+        "example": {
+          "data": {
+            "architecture": {
+              "input_modalities": [
+                "text"
+              ],
+              "instruct_type": "chatml",
+              "modality": "text->text",
+              "output_modalities": [
+                "text"
+              ],
+              "tokenizer": "GPT"
+            },
+            "context_length": 8192,
+            "created": 1692901234,
+            "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+            "id": "openai/gpt-4",
+            "name": "GPT-4",
+            "per_request_limits": null,
+            "pricing": {
+              "completion": "0.00006",
+              "image": "0",
+              "prompt": "0.00003",
+              "request": "0"
+            },
+            "supported_parameters": [
+              "temperature",
+              "top_p",
+              "max_tokens"
+            ],
+            "top_provider": {
+              "context_length": 8192,
+              "is_moderated": true,
+              "max_completion_tokens": 4096
+            }
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Model"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
       },
       "ModelsCountResponse": {
         "description": "Model count data",
@@ -19249,6 +21356,54 @@
         ],
         "type": "object"
       },
+      "OutputAdvisorServerToolItem": {
+        "description": "An openrouter:advisor server tool output item",
+        "example": {
+          "id": "st_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:advisor"
+        },
+        "properties": {
+          "advice": {
+            "description": "The advisor model's response (the advice text returned to the executor).",
+            "type": "string"
+          },
+          "error": {
+            "description": "Error message when the advisor call did not produce advice.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "instance_name": {
+            "description": "Provider-safe function name of the specific advisor instance that produced this item (e.g. `openrouter_advisor__1`). Present only when more than one advisor tool is configured; omitted for the default single advisor. Echo this field back unchanged so the advisor's cross-request memory stays namespaced to the correct instance. This identity is positional: it is derived from the index of the advisor entry in the request `tools` array, so clients must keep the order of advisor tool entries stable across requests in a conversation. Reordering or inserting advisor entries shifts these names and causes each advisor's cross-request memory to be attributed to the wrong instance.",
+            "example": "openrouter_advisor__1",
+            "type": "string"
+          },
+          "model": {
+            "description": "Slug of the advisor model that was consulted.",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "The prompt the executor sent to the advisor.",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:advisor"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
       "OutputApplyPatchCallItem": {
         "description": "A native `apply_patch_call` output item matching OpenAI's Responses API shape. Emitted when the client requested the `apply_patch` shorthand.",
         "example": {
@@ -19707,101 +21862,7 @@
         },
         "properties": {
           "analysis": {
-            "description": "Structured analysis produced by the fusion judge model.",
-            "properties": {
-              "blind_spots": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "consensus": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "contradictions": {
-                "items": {
-                  "properties": {
-                    "stances": {
-                      "items": {
-                        "properties": {
-                          "model": {
-                            "type": "string"
-                          },
-                          "stance": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "model",
-                          "stance"
-                        ],
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "topic": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "topic",
-                    "stances"
-                  ],
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              "partial_coverage": {
-                "items": {
-                  "properties": {
-                    "models": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "point": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "models",
-                    "point"
-                  ],
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              "unique_insights": {
-                "items": {
-                  "properties": {
-                    "insight": {
-                      "type": "string"
-                    },
-                    "model": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "model",
-                    "insight"
-                  ],
-                  "type": "object"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "consensus",
-              "contradictions",
-              "partial_coverage",
-              "unique_insights",
-              "blind_spots"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/FusionAnalysisResult"
           },
           "error": {
             "description": "Error message when the fusion run did not produce an analysis result.",
@@ -19840,9 +21901,12 @@
             "type": "string"
           },
           "responses": {
-            "description": "Slugs of the analysis models that produced a response in this fusion run.",
+            "description": "Analysis models that produced a response in this fusion run, with each model's full panel content.",
             "items": {
               "properties": {
+                "content": {
+                  "type": "string"
+                },
                 "model": {
                   "type": "string"
                 }
@@ -20498,7 +22562,6 @@
         "required": [
           "type",
           "id",
-          "action",
           "status"
         ],
         "type": "object"
@@ -20515,6 +22578,7 @@
             "function_call": "#/components/schemas/OutputFunctionCallItem",
             "image_generation_call": "#/components/schemas/OutputImageGenerationCallItem",
             "message": "#/components/schemas/OutputMessageItem",
+            "openrouter:advisor": "#/components/schemas/OutputAdvisorServerToolItem",
             "openrouter:apply_patch": "#/components/schemas/OutputApplyPatchServerToolItem",
             "openrouter:bash": "#/components/schemas/OutputBashServerToolItem",
             "openrouter:browser_use": "#/components/schemas/OutputBrowserUseServerToolItem",
@@ -20526,11 +22590,14 @@
             "openrouter:image_generation": "#/components/schemas/OutputImageGenerationServerToolItem",
             "openrouter:mcp": "#/components/schemas/OutputMcpServerToolItem",
             "openrouter:memory": "#/components/schemas/OutputMemoryServerToolItem",
+            "openrouter:subagent": "#/components/schemas/OutputSubagentServerToolItem",
             "openrouter:text_editor": "#/components/schemas/OutputTextEditorServerToolItem",
             "openrouter:tool_search": "#/components/schemas/OutputToolSearchServerToolItem",
             "openrouter:web_fetch": "#/components/schemas/OutputWebFetchServerToolItem",
             "openrouter:web_search": "#/components/schemas/OutputWebSearchServerToolItem",
             "reasoning": "#/components/schemas/OutputReasoningItem",
+            "shell_call": "#/components/schemas/OutputShellCallItem",
+            "shell_call_output": "#/components/schemas/OutputShellCallOutputItem",
             "web_search_call": "#/components/schemas/OutputWebSearchCallItem"
           },
           "propertyName": "type"
@@ -20603,6 +22670,12 @@
             "$ref": "#/components/schemas/OutputApplyPatchCallItem"
           },
           {
+            "$ref": "#/components/schemas/OutputShellCallItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputShellCallOutputItem"
+          },
+          {
             "$ref": "#/components/schemas/OutputWebFetchServerToolItem"
           },
           {
@@ -20619,6 +22692,12 @@
           },
           {
             "$ref": "#/components/schemas/OutputFusionServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputAdvisorServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputSubagentServerToolItem"
           },
           {
             "$ref": "#/components/schemas/OutputCustomToolCallItem"
@@ -20920,6 +22999,220 @@
           "type": {
             "enum": [
               "openrouter:experimental__search_models"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OutputShellCallItem": {
+        "description": "A native `shell_call` output item matching OpenAI's Responses API shape. Emitted for the sandbox-backed `shell` tool.",
+        "example": {
+          "action": {
+            "commands": [
+              "echo hello"
+            ],
+            "max_output_length": null,
+            "timeout_ms": null
+          },
+          "call_id": "call_abc123",
+          "id": "shc_abc123",
+          "status": "completed",
+          "type": "shell_call"
+        },
+        "properties": {
+          "action": {
+            "properties": {
+              "commands": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "max_output_length": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "timeout_ms": {
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "commands",
+              "max_output_length",
+              "timeout_ms"
+            ],
+            "type": "object"
+          },
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ShellCallStatus"
+          },
+          "type": {
+            "enum": [
+              "shell_call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "status"
+        ],
+        "type": "object"
+      },
+      "OutputShellCallOutputItem": {
+        "description": "A native `shell_call_output` item matching OpenAI's Responses API shape. Carries per-command stdout, stderr, and the exit/timeout outcome.",
+        "example": {
+          "call_id": "call_abc123",
+          "id": "sho_abc123",
+          "output": [
+            {
+              "outcome": {
+                "exit_code": 0,
+                "type": "exit"
+              },
+              "stderr": "",
+              "stdout": "hello\n"
+            }
+          ],
+          "status": "completed",
+          "type": "shell_call_output"
+        },
+        "properties": {
+          "call_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "max_output_length": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "output": {
+            "items": {
+              "properties": {
+                "outcome": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "exit_code": {
+                          "type": "integer"
+                        },
+                        "type": {
+                          "enum": [
+                            "exit"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "exit_code"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "timeout"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "stderr": {
+                  "type": "string"
+                },
+                "stdout": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "stdout",
+                "stderr",
+                "outcome"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ShellCallStatus"
+          },
+          "type": {
+            "enum": [
+              "shell_call_output"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "status",
+          "output"
+        ],
+        "type": "object"
+      },
+      "OutputSubagentServerToolItem": {
+        "description": "An openrouter:subagent server tool output item",
+        "example": {
+          "id": "st_tmp_abc123",
+          "status": "completed",
+          "type": "openrouter:subagent"
+        },
+        "properties": {
+          "error": {
+            "description": "Error message when the subagent task did not produce an outcome.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "description": "Slug of the worker model that executed the task.",
+            "type": "string"
+          },
+          "outcome": {
+            "description": "The worker model's result (the outcome text returned to the delegating model).",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "task_description": {
+            "description": "The task description the delegating model sent to the worker.",
+            "type": "string"
+          },
+          "task_name": {
+            "description": "The short task identifier the delegating model supplied.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openrouter:subagent"
             ],
             "type": "string"
           }
@@ -21577,6 +23870,76 @@
         "description": "Preferred minimum throughput (in tokens per second). Can be a number (applies to p50) or an object with percentile-specific cutoffs. Endpoints below the threshold(s) may still be used, but are deprioritized in routing. When using fallback models, this may cause a fallback model to be used instead of the primary model if it meets the threshold.",
         "example": 100
       },
+      "Preset": {
+        "description": "A preset without version details.",
+        "example": {
+          "created_at": "2026-04-20T10:00:00Z",
+          "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+          "description": null,
+          "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+          "id": "650e8400-e29b-41d4-a716-446655440001",
+          "name": "my-preset",
+          "slug": "my-preset",
+          "status": "active",
+          "status_updated_at": null,
+          "updated_at": "2026-04-20T10:00:00Z",
+          "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+        },
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "creator_user_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "designated_version_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PresetStatus"
+          },
+          "status_updated_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "creator_user_id",
+          "workspace_id",
+          "name",
+          "slug",
+          "description",
+          "status",
+          "designated_version_id",
+          "created_at",
+          "updated_at",
+          "status_updated_at"
+        ],
+        "type": "object"
+      },
       "PresetDesignatedVersion": {
         "description": "A specific version of a preset, containing config and optional system prompt.",
         "example": {
@@ -21635,7 +23998,34 @@
         ],
         "type": "object"
       },
+      "PresetStatus": {
+        "description": "The status of a preset.",
+        "enum": [
+          "active",
+          "disabled",
+          "archived"
+        ],
+        "example": "active",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "PresetWithDesignatedVersion": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Preset"
+          },
+          {
+            "properties": {
+              "designated_version": {
+                "$ref": "#/components/schemas/PresetDesignatedVersion"
+              }
+            },
+            "required": [
+              "designated_version"
+            ],
+            "type": "object"
+          }
+        ],
         "description": "A preset with its currently designated version.",
         "example": {
           "created_at": "2026-04-20T10:00:00Z",
@@ -21662,71 +24052,7 @@
           "status_updated_at": null,
           "updated_at": "2026-04-20T10:00:00Z",
           "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
-        },
-        "properties": {
-          "created_at": {
-            "type": "string"
-          },
-          "creator_user_id": {
-            "nullable": true,
-            "type": "string"
-          },
-          "description": {
-            "nullable": true,
-            "type": "string"
-          },
-          "designated_version": {
-            "$ref": "#/components/schemas/PresetDesignatedVersion"
-          },
-          "designated_version_id": {
-            "nullable": true,
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "status": {
-            "enum": [
-              "active",
-              "disabled",
-              "archived"
-            ],
-            "type": "string",
-            "x-speakeasy-unknown-values": "allow"
-          },
-          "status_updated_at": {
-            "nullable": true,
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "workspace_id": {
-            "nullable": true,
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "creator_user_id",
-          "workspace_id",
-          "name",
-          "slug",
-          "description",
-          "status",
-          "designated_version_id",
-          "created_at",
-          "updated_at",
-          "status_updated_at",
-          "designated_version"
-        ],
-        "type": "object"
+        }
       },
       "Preview_20250311_WebSearchServerTool": {
         "description": "Web search preview tool configuration (2025-03-11 version)",
@@ -21741,7 +24067,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -21776,7 +24102,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -21873,6 +24199,7 @@
           "Crucible",
           "Crusoe",
           "Darkbloom",
+          "Decart",
           "DeepInfra",
           "DeepSeek",
           "DekaLLM",
@@ -21927,6 +24254,7 @@
           "Together",
           "Upstage",
           "Venice",
+          "Wafer",
           "WandB",
           "Xiaomi",
           "xAI",
@@ -21938,7 +24266,7 @@
         "x-speakeasy-unknown-values": "allow"
       },
       "ProviderOptions": {
-        "description": "Provider-specific options keyed by provider slug. The options for the matched provider are spread into the upstream request body.",
+        "description": "Provider-specific options keyed by provider slug. Only options for the matched provider are forwarded; the rest are ignored. Unrecognized keys are silently dropped.",
         "example": {
           "openai": {
             "max_tokens": 1000
@@ -22120,6 +24448,12 @@
             "type": "object"
           },
           "darkbloom": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "decart": {
             "additionalProperties": {
               "nullable": true
             },
@@ -22599,6 +24933,12 @@
             },
             "type": "object"
           },
+          "wafer": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
           "wandb": {
             "additionalProperties": {
               "nullable": true
@@ -22892,6 +25232,7 @@
           "latency": {
             "description": "Response latency in milliseconds",
             "example": 1200,
+            "format": "double",
             "type": "number"
           },
           "model_permaslug": {
@@ -22956,6 +25297,7 @@
               "Crucible",
               "Crusoe",
               "Darkbloom",
+              "Decart",
               "DeepInfra",
               "DeepSeek",
               "DekaLLM",
@@ -23010,6 +25352,7 @@
               "Together",
               "Upstage",
               "Venice",
+              "Wafer",
               "WandB",
               "Xiaomi",
               "xAI",
@@ -23024,7 +25367,7 @@
             "description": "HTTP status code from the provider",
             "example": 200,
             "nullable": true,
-            "type": "number"
+            "type": "integer"
           }
         },
         "required": [
@@ -23180,6 +25523,7 @@
                 ]
               },
               "discount": {
+                "format": "double",
                 "type": "number"
               },
               "image": {
@@ -23406,6 +25750,7 @@
             ]
           },
           "discount": {
+            "format": "double",
             "type": "number"
           },
           "image": {
@@ -24613,6 +26958,12 @@
                   "$ref": "#/components/schemas/CustomTool"
                 },
                 {
+                  "$ref": "#/components/schemas/AdvisorServerTool_OpenRouter"
+                },
+                {
+                  "$ref": "#/components/schemas/SubagentServerTool_OpenRouter"
+                },
+                {
                   "$ref": "#/components/schemas/DatetimeServerTool"
                 },
                 {
@@ -24632,6 +26983,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/ApplyPatchServerTool_OpenRouter"
+                },
+                {
+                  "$ref": "#/components/schemas/BashServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/ShellServerTool_OpenRouter"
                 }
               ]
             },
@@ -24877,6 +27234,11 @@
         },
         "type": "object"
       },
+      "SandboxSleepAfterSeconds": {
+        "description": "How long (in seconds) the container stays warm after its last command before sleeping, freeing its capacity slot. Idle-based: each command renews the timer. Defaults to 900 (15 minutes); capped at 2592000 (30 days).",
+        "example": 900,
+        "type": "integer"
+      },
       "SearchContextSizeEnum": {
         "description": "Size of the search context for web search tools",
         "enum": [
@@ -24903,7 +27265,7 @@
         "type": "object"
       },
       "SearchQualityLevel": {
-        "description": "How much context to retrieve per result. Applies to Exa and Parallel engines; ignored with native provider search and Firecrawl. For Exa, pins a fixed per-result character cap (low=5,000, medium=15,000, high=30,000); when omitted, Exa picks an adaptive size per query and document (typically ~2,000\u20134,000 characters per result). For Parallel, controls the total characters across all results; when omitted, Parallel uses its own default size.",
+        "description": "How much context to retrieve per result. Applies to Exa, Parallel, and Perplexity engines; ignored with native provider search and Firecrawl. For Exa, pins a fixed per-result character cap (low=5,000, medium=15,000, high=30,000); when omitted, Exa picks an adaptive size per query and document (typically ~2,000\u20134,000 characters per result). For Parallel, controls the total characters across all results; when omitted, Parallel uses its own default size. For Perplexity, maps directly to the Search API's native search_context_size parameter. Overridden by `max_characters` when both are set.",
         "enum": [
           "low",
           "medium",
@@ -25128,6 +27490,17 @@
         ],
         "type": "object"
       },
+      "ShellCallStatus": {
+        "description": "Status of a shell call or its output.",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
+        "example": "completed",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "ShellServerTool": {
         "description": "Shell tool configuration",
         "example": {
@@ -25137,6 +27510,85 @@
           "type": {
             "enum": [
               "shell"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ShellServerToolConfig": {
+        "description": "Configuration for the openrouter:shell server tool",
+        "example": {
+          "engine": "openrouter",
+          "environment": {
+            "type": "container_auto"
+          }
+        },
+        "properties": {
+          "engine": {
+            "$ref": "#/components/schemas/ShellServerToolEngine"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/ShellServerToolEnvironment"
+          },
+          "sleep_after_seconds": {
+            "$ref": "#/components/schemas/SandboxSleepAfterSeconds"
+          }
+        },
+        "type": "object"
+      },
+      "ShellServerToolEngine": {
+        "description": "Which shell engine to use. \"openrouter\" runs commands server-side in the OpenRouter sandbox. \"auto\" (default) keeps the provider's native hosted shell when available (OpenAI); on other providers the call is routed to the OpenRouter sandbox.",
+        "enum": [
+          "auto",
+          "openrouter"
+        ],
+        "example": "openrouter",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ShellServerToolEnvironment": {
+        "description": "Server-side execution environment for the shell tool. Only container-backed environments are supported; \"local\" shells are not.",
+        "discriminator": {
+          "mapping": {
+            "container_auto": "#/components/schemas/ContainerAutoEnvironment",
+            "container_reference": "#/components/schemas/ContainerReferenceEnvironment"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "type": "container_auto"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ContainerAutoEnvironment"
+          },
+          {
+            "$ref": "#/components/schemas/ContainerReferenceEnvironment"
+          }
+        ]
+      },
+      "ShellServerTool_OpenRouter": {
+        "description": "OpenRouter built-in server tool: runs shell commands server-side in a sandboxed container (a sandbox-backed clone of OpenAI's hosted shell tool)",
+        "example": {
+          "parameters": {
+            "engine": "openrouter",
+            "environment": {
+              "type": "container_auto"
+            }
+          },
+          "type": "openrouter:shell"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/ShellServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:shell"
             ],
             "type": "string"
           }
@@ -25429,6 +27881,15 @@
             "response.failed": "#/components/schemas/StreamEventsResponseFailed",
             "response.function_call_arguments.delta": "#/components/schemas/FunctionCallArgsDeltaEvent",
             "response.function_call_arguments.done": "#/components/schemas/FunctionCallArgsDoneEvent",
+            "response.fusion_call.analysis.completed": "#/components/schemas/FusionCallAnalysisCompletedEvent",
+            "response.fusion_call.analysis.in_progress": "#/components/schemas/FusionCallAnalysisInProgressEvent",
+            "response.fusion_call.completed": "#/components/schemas/FusionCallCompletedEvent",
+            "response.fusion_call.in_progress": "#/components/schemas/FusionCallInProgressEvent",
+            "response.fusion_call.panel.added": "#/components/schemas/FusionCallPanelAddedEvent",
+            "response.fusion_call.panel.completed": "#/components/schemas/FusionCallPanelCompletedEvent",
+            "response.fusion_call.panel.delta": "#/components/schemas/FusionCallPanelDeltaEvent",
+            "response.fusion_call.panel.failed": "#/components/schemas/FusionCallPanelFailedEvent",
+            "response.fusion_call.panel.reasoning.delta": "#/components/schemas/FusionCallPanelReasoningDeltaEvent",
             "response.image_generation_call.completed": "#/components/schemas/ImageGenCallCompletedEvent",
             "response.image_generation_call.generating": "#/components/schemas/ImageGenCallGeneratingEvent",
             "response.image_generation_call.in_progress": "#/components/schemas/ImageGenCallInProgressEvent",
@@ -25578,6 +28039,33 @@
           },
           {
             "$ref": "#/components/schemas/ApplyPatchCallOperationDiffDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallInProgressEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallPanelAddedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallPanelDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallPanelReasoningDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallPanelCompletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallPanelFailedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallAnalysisInProgressEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallAnalysisCompletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/FusionCallCompletedEvent"
           }
         ]
       },
@@ -25810,6 +28298,127 @@
           "logprob": -0.5,
           "token": "Hello"
         }
+      },
+      "SubagentNestedTool": {
+        "additionalProperties": {
+          "nullable": true
+        },
+        "description": "A tool made available to the subagent. Only OpenRouter server tools (e.g. openrouter:web_search) are supported; function tools are rejected because the worker has no way to execute them. The subagent tool may not list itself.",
+        "example": {
+          "type": "openrouter:web_search"
+        },
+        "properties": {
+          "parameters": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "SubagentReasoning": {
+        "description": "Reasoning configuration forwarded to the subagent call. Use this to control reasoning effort and token budget for models that support extended thinking.",
+        "example": {
+          "effort": "low"
+        },
+        "properties": {
+          "effort": {
+            "description": "Reasoning effort level for the subagent call.",
+            "enum": [
+              "xhigh",
+              "high",
+              "medium",
+              "low",
+              "minimal",
+              "none"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "max_tokens": {
+            "description": "Maximum number of reasoning tokens the subagent may use. Accepted and validated but not yet forwarded to the subagent call.",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SubagentServerToolConfig": {
+        "description": "Configuration for the openrouter:subagent server tool.",
+        "example": {
+          "model": "~anthropic/claude-haiku-latest"
+        },
+        "properties": {
+          "instructions": {
+            "description": "System instructions for the subagent. When omitted, the subagent responds with no system prompt of its own.",
+            "example": "You are a fast, focused worker. Complete the task exactly as described.",
+            "type": "string"
+          },
+          "max_completion_tokens": {
+            "description": "Maximum number of output tokens (including reasoning) the subagent may produce. When omitted, the provider's default applies.",
+            "example": 2048,
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "description": "Maximum number of tool-calling steps the subagent may take during its agentic loop. Capped at 25. Only relevant when the subagent is given tools. Accepted and validated but not yet enforced on the subagent call.",
+            "example": 5,
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "model": {
+            "description": "Slug of the model that executes delegated tasks (any OpenRouter model). Typically a smaller, cheaper, faster model than the one delegating. When omitted, the model from the outer API request is used. The subagent tool itself cannot be the subagent model.",
+            "example": "~anthropic/claude-haiku-latest",
+            "type": "string"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/SubagentReasoning"
+          },
+          "temperature": {
+            "description": "Sampling temperature forwarded to the subagent call. When omitted, the provider's default applies.",
+            "example": 0.7,
+            "format": "double",
+            "type": "number"
+          },
+          "tools": {
+            "description": "Tools the subagent may use while executing a delegated task. The subagent runs as an agentic sub-agent over these tools, then returns its outcome. Only OpenRouter server tools are supported \u2014 function tools are rejected \u2014 and the list must not include the subagent tool itself.",
+            "items": {
+              "$ref": "#/components/schemas/SubagentNestedTool"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SubagentServerTool_OpenRouter": {
+        "description": "OpenRouter built-in server tool: delegates self-contained tasks to a smaller, cheaper, faster worker model (any OpenRouter model) mid-generation and returns its outcome. The worker may run as a sub-agent with its own tools.",
+        "example": {
+          "parameters": {
+            "model": "~anthropic/claude-haiku-latest"
+          },
+          "type": "openrouter:subagent"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/SubagentServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:subagent"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
       },
       "TextConfig": {
         "description": "Text output configuration including format and verbosity",
@@ -26114,6 +28723,7 @@
       },
       "URLCitation": {
         "example": {
+          "content": "OpenRouter provides a unified API for accessing LLMs from multiple providers.",
           "end_index": 42,
           "start_index": 0,
           "title": "OpenRouter Documentation",
@@ -26121,6 +28731,9 @@
           "url": "https://openrouter.ai/docs"
         },
         "properties": {
+          "content": {
+            "type": "string"
+          },
           "end_index": {
             "type": "integer"
           },
@@ -26865,9 +29478,9 @@
             "type": "boolean"
           },
           "input_references": {
-            "description": "Reference images to guide video generation",
+            "description": "Reference assets to guide video generation. Accepts image, audio, and video references. Audio and video references are only honored by providers that support them (currently BytePlus Seedance 2.0); other providers use image references and ignore the rest.",
             "items": {
-              "$ref": "#/components/schemas/ContentPartImage"
+              "$ref": "#/components/schemas/InputReference"
             },
             "type": "array"
           },
@@ -27429,7 +30042,7 @@
         },
         "properties": {
           "allowed_domains": {
-            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Perplexity. Cannot be used with excluded_domains.",
+            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, and most native providers (Anthropic, OpenAI, xAI). Cannot be used with excluded_domains.",
             "items": {
               "type": "string"
             },
@@ -27439,14 +30052,19 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Anthropic, and xAI. Not supported with OpenAI (silently ignored) or Perplexity. Cannot be used with allowed_domains.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, and xAI. Not supported with OpenAI (silently ignored). Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
+          "max_characters": {
+            "description": "Exact maximum number of characters of content per search result. Applies to the Exa, Parallel, and Perplexity engines; ignored with native provider search and Firecrawl. For Exa, caps highlight content per result. For Parallel, caps excerpt content per result (default 1,500 when omitted). For Perplexity, maps to the native `max_tokens_per_page` parameter (converted from characters to tokens) and trims the response to the exact character cap. When both `max_characters` and `search_context_size` are set, `max_characters` takes precedence. When omitted, falls back to `search_context_size` mapping (Exa) or engine defaults (Parallel, Perplexity).",
+            "example": 2000,
+            "type": "integer"
+          },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -27498,20 +30116,22 @@
           "native",
           "exa",
           "firecrawl",
-          "parallel"
+          "parallel",
+          "perplexity"
         ],
         "example": "exa",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
       },
       "WebSearchEngineEnum": {
-        "description": "Which search engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in search. \"exa\" forces the Exa search API. \"firecrawl\" uses Firecrawl (requires BYOK). \"parallel\" uses the Parallel search API.",
+        "description": "Which search engine to use. \"auto\" (default) uses native if the provider supports it, otherwise Exa. \"native\" forces the provider's built-in search. \"exa\" forces the Exa search API. \"firecrawl\" uses Firecrawl (requires BYOK). \"parallel\" uses the Parallel search API. \"perplexity\" uses the Perplexity Search API (raw ranked results).",
         "enum": [
-          "auto",
           "native",
           "exa",
           "parallel",
-          "firecrawl"
+          "firecrawl",
+          "perplexity",
+          "auto"
         ],
         "example": "auto",
         "type": "string",
@@ -27616,7 +30236,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -27646,7 +30266,7 @@
         },
         "properties": {
           "allowed_domains": {
-            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, and most native providers (Anthropic, OpenAI, xAI). Not supported with Perplexity. Cannot be used with excluded_domains.",
+            "description": "Limit search results to these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, and most native providers (Anthropic, OpenAI, xAI). Cannot be used with excluded_domains.",
             "items": {
               "type": "string"
             },
@@ -27656,14 +30276,19 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Anthropic, and xAI. Not supported with OpenAI (silently ignored) or Perplexity. Cannot be used with allowed_domains.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, and xAI. Not supported with OpenAI (silently ignored). Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
+          "max_characters": {
+            "description": "Exact maximum number of characters of content per search result. Applies to the Exa, Parallel, and Perplexity engines; ignored with native provider search and Firecrawl. For Exa, caps highlight content per result. For Parallel, caps excerpt content per result (default 1,500 when omitted). For Perplexity, maps to the native `max_tokens_per_page` parameter (converted from characters to tokens) and trims the response to the exact character cap. When both `max_characters` and `search_context_size` are set, `max_characters` takes precedence. When omitted, falls back to `search_context_size` mapping (Exa) or engine defaults (Parallel, Perplexity).",
+            "example": 2000,
+            "type": "integer"
+          },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and Parallel engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
             "example": 5,
             "type": "integer"
           },
@@ -28168,9 +30793,611 @@
         "tags": [
           "Analytics"
         ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/analytics/meta": {
+      "get": {
+        "description": "Returns the available metrics, dimensions, filter operators, and granularities for the analytics query endpoint. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getAnalyticsMeta",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "dimensions": [
+                      {
+                        "display_label": "Model",
+                        "name": "model"
+                      }
+                    ],
+                    "granularities": [
+                      {
+                        "display_label": "Day",
+                        "name": "day"
+                      }
+                    ],
+                    "metrics": [
+                      {
+                        "display_format": "number",
+                        "display_label": "Request Count",
+                        "is_rate": false,
+                        "name": "request_count"
+                      }
+                    ],
+                    "operators": [
+                      {
+                        "name": "eq",
+                        "value_type": "scalar"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "dimensions": {
+                          "items": {
+                            "properties": {
+                              "display_label": {
+                                "description": "Human-readable label",
+                                "example": "Model",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Dimension identifier used in query requests",
+                                "example": "model",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "display_label"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "granularities": {
+                          "items": {
+                            "properties": {
+                              "display_label": {
+                                "description": "Human-readable label",
+                                "example": "Day",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Granularity identifier",
+                                "enum": [
+                                  "minute",
+                                  "hour",
+                                  "day",
+                                  "week",
+                                  "month"
+                                ],
+                                "example": "day",
+                                "type": "string",
+                                "x-speakeasy-unknown-values": "allow"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "display_label"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "metrics": {
+                          "items": {
+                            "properties": {
+                              "display_format": {
+                                "description": "How this metric value should be formatted for display (e.g. percent \u2192 multiply by 100 and append %, currency \u2192 prefix with $)",
+                                "enum": [
+                                  "number",
+                                  "currency",
+                                  "percent",
+                                  "latency",
+                                  "throughput"
+                                ],
+                                "example": "number",
+                                "type": "string",
+                                "x-speakeasy-unknown-values": "allow"
+                              },
+                              "display_label": {
+                                "description": "Human-readable label",
+                                "example": "Request Count",
+                                "type": "string"
+                              },
+                              "is_rate": {
+                                "description": "Whether this metric is a rate/ratio (averaged, not summed)",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "description": "Metric identifier used in query requests",
+                                "example": "request_count",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "display_label",
+                              "is_rate",
+                              "display_format"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "operators": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "Operator identifier used in filter definitions",
+                                "enum": [
+                                  "eq",
+                                  "neq",
+                                  "in",
+                                  "not_in",
+                                  "gt",
+                                  "gte",
+                                  "lt",
+                                  "lte"
+                                ],
+                                "example": "eq",
+                                "type": "string",
+                                "x-speakeasy-unknown-values": "allow"
+                              },
+                              "value_type": {
+                                "description": "Whether the operator expects a single value or an array",
+                                "enum": [
+                                  "scalar",
+                                  "array"
+                                ],
+                                "type": "string",
+                                "x-speakeasy-unknown-values": "allow"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value_type"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "metrics",
+                        "dimensions",
+                        "operators",
+                        "granularities"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Returns analytics query metadata"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get available analytics metrics and dimensions",
+        "tags": [
+          "beta.Analytics"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/analytics/query": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
+      "post": {
+        "description": "Execute an analytics query with specified metrics, dimensions, filters, and time range. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "queryAnalytics",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "dimensions": [
+                  "model"
+                ],
+                "granularity": "day",
+                "limit": 100,
+                "metrics": [
+                  "request_count"
+                ],
+                "time_range": {
+                  "end": "2025-01-08T00:00:00Z",
+                  "start": "2025-01-01T00:00:00Z"
+                }
+              },
+              "schema": {
+                "properties": {
+                  "dimensions": {
+                    "items": {
+                      "description": "Dimension name",
+                      "example": "model",
+                      "type": "string"
+                    },
+                    "maxItems": 2,
+                    "type": "array"
+                  },
+                  "filters": {
+                    "items": {
+                      "properties": {
+                        "field": {
+                          "description": "Dimension to filter on",
+                          "example": "model",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "Filter operator",
+                          "example": "eq",
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "format": "double",
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Filter value (scalar or array depending on operator)"
+                        }
+                      },
+                      "required": [
+                        "field",
+                        "operator",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 20,
+                    "type": "array"
+                  },
+                  "granularity": {
+                    "description": "Time granularity",
+                    "example": "day",
+                    "type": "string"
+                  },
+                  "group_limit": {
+                    "description": "Maximum rows per distinct combination of dimensions. When omitted on time-series queries (granularity + dimensions), auto-computed to avoid truncating time windows. Explicit values override the default and may truncate time buckets if set lower than the number of buckets in the range. Ignored when no dimensions are specified.",
+                    "example": 100,
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "description": "Maximum total rows returned. Defaults to 1000. On time-series queries with dimensions and no explicit group_limit, the server may raise this to accommodate the expected number of unique time-bucket/dimension combinations.",
+                    "type": "integer"
+                  },
+                  "metrics": {
+                    "items": {
+                      "description": "Metric name",
+                      "example": "request_count",
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "order_by": {
+                    "properties": {
+                      "direction": {
+                        "enum": [
+                          "asc",
+                          "desc"
+                        ],
+                        "type": "string",
+                        "x-speakeasy-unknown-values": "allow"
+                      },
+                      "field": {
+                        "description": "Field to order by",
+                        "example": "request_count",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "direction"
+                    ],
+                    "type": "object"
+                  },
+                  "time_range": {
+                    "properties": {
+                      "end": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "start": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "start",
+                      "end"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "metrics"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "data": [
+                      {
+                        "date__day": "2025-01-01T00:00:00.000Z",
+                        "request_count": 1500
+                      }
+                    ],
+                    "metadata": {
+                      "query_time_ms": 42,
+                      "row_count": 1,
+                      "truncated": false
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "cachedAt": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "data": {
+                          "items": {
+                            "description": "A row of analytics data with metric/dimension values",
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "metadata": {
+                          "properties": {
+                            "query_time_ms": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "row_count": {
+                              "type": "integer"
+                            },
+                            "truncated": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "query_time_ms",
+                            "row_count",
+                            "truncated"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "data",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Analytics query results"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 408,
+                    "message": "Operation timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RequestTimeoutResponse"
+                }
+              }
+            },
+            "description": "Request Timeout - Operation exceeded time limit"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Query analytics data",
+        "tags": [
+          "beta.Analytics"
+        ]
       }
     },
     "/audio/speech": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Synthesizes audio from the input text. Returns a raw audio bytestream in the requested format (e.g. mp3, pcm, wav).",
         "operationId": "createAudioSpeech",
@@ -28375,6 +31602,17 @@
       }
     },
     "/audio/transcriptions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Transcribes audio into text. Accepts base64-encoded audio input and returns the transcribed text.",
         "operationId": "createAudioTranscriptions",
@@ -28587,6 +31825,17 @@
       }
     },
     "/auth/keys": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -28729,6 +31978,17 @@
       }
     },
     "/auth/keys/code": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -28750,7 +32010,7 @@
                 },
                 "properties": {
                   "callback_url": {
-                    "description": "The callback URL to redirect to after authorization. Note, only https URLs on ports 443 and 3000 are allowed.",
+                    "description": "The callback URL to redirect to after authorization. Supports https URLs and localhost/127.0.0.1 URLs on any port for local CLI tools.",
                     "example": "https://myapp.com/auth/callback",
                     "format": "uri",
                     "type": "string"
@@ -28813,6 +32073,11 @@
                     "example": "monthly",
                     "type": "string",
                     "x-speakeasy-unknown-values": "allow"
+                  },
+                  "workspace_id": {
+                    "description": "Optional workspace ID to associate the API key with",
+                    "format": "uuid",
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -28916,6 +32181,22 @@
               }
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
           },
           "409": {
             "content": {
@@ -29032,6 +32313,7 @@
                 "cohere",
                 "crusoe",
                 "darkbloom",
+                "decart",
                 "deepinfra",
                 "deepseek",
                 "dekallm",
@@ -29085,6 +32367,7 @@
                 "together",
                 "upstage",
                 "venice",
+                "wafer",
                 "wandb",
                 "xai",
                 "xiaomi",
@@ -29183,6 +32466,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new bring-your-own-key (BYOK) provider credential. The raw key is encrypted at rest and never returned in API responses. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createBYOKKey",
@@ -29486,6 +32780,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing bring-your-own-key (BYOK) provider credential by its `id`. Include the `key` field to rotate the raw provider API key in-place (the previous key material is overwritten). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateBYOKKey",
@@ -29617,15 +32922,26 @@
       }
     },
     "/chat/completions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
         "parameters": [
           {
-            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`.",
+            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`. The legacy header `X-OpenRouter-Experimental-Metadata` is also accepted for backward compatibility.",
             "example": "enabled",
             "in": "header",
-            "name": "X-OpenRouter-Experimental-Metadata",
+            "name": "X-OpenRouter-Metadata",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/MetadataLevel"
@@ -29831,7 +33147,7 @@
                 }
               }
             },
-            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Experimental-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
+            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
           },
           "404": {
             "content": {
@@ -30115,9 +33431,31 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/credits/coinbase": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -30152,6 +33490,580 @@
         "x-speakeasy-ignore": true,
         "x-speakeasy-name-override": "createCoinbaseCharge"
       }
+    },
+    "/datasets/app-rankings": {
+      "get": {
+        "description": "Returns the top public apps on OpenRouter ranked by token usage inside the requested\ndate window, matching the public apps marketplace on openrouter.ai/apps. Token totals\nare `prompt_tokens + completion_tokens`; hidden and private apps are excluded and\ntraffic from related app aliases is merged into the canonical visible app.\n\n`sort=popular` (default) ranks by total token volume inside the window.\n`sort=trending` ranks by absolute excess token growth: window volume minus the average\nvolume of the three equal-length periods immediately preceding the window. Apps with\nno excess growth are omitted, so `trending` may return fewer than `limit` rows.\n\nFilter with `category` (marketplace category group, e.g. `coding`) or `subcategory`\n(e.g. `cli-agent`). Ranks are re-numbered 1..N after filtering. Page with `offset` \u2014\n`rank` stays absolute, so the first row of `offset=50` is `rank: 51`.\n\nAuthenticate with any valid OpenRouter API key (same key used for inference).\nRate-limited to 30 requests/minute per key and 500 requests/day per account.\n\nWhen republishing or quoting this dataset, OpenRouter must be cited as:\n\"Source: OpenRouter (openrouter.ai/apps), as of {as_of}.\"\n\nToken counts come from each upstream provider's own tokenizer, so a token attributed\nto one app is not directly comparable to a token attributed to another app whose\ntraffic flows through a different provider.",
+        "operationId": "getAppRankings",
+        "parameters": [
+          {
+            "description": "Marketplace category group to filter by (e.g. `coding`). Only apps tagged with a subcategory inside this group are returned. Mutually combinable with `subcategory` \u2014 when both are supplied the `subcategory` must belong to the `category` group.",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "description": "Marketplace category group to filter by (e.g. `coding`). Only apps tagged with a subcategory inside this group are returned. Mutually combinable with `subcategory` \u2014 when both are supplied the `subcategory` must belong to the `category` group.",
+              "enum": [
+                "coding",
+                "creative",
+                "productivity",
+                "entertainment"
+              ],
+              "example": "coding",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Marketplace subcategory to filter by (e.g. `cli-agent`). Takes precedence over `category` for the actual filter; when `category` is also supplied the pair must be consistent.",
+            "in": "query",
+            "name": "subcategory",
+            "required": false,
+            "schema": {
+              "description": "Marketplace subcategory to filter by (e.g. `cli-agent`). Takes precedence over `category` for the actual filter; when `category` is also supplied the pair must be consistent.",
+              "enum": [
+                "cli-agent",
+                "ide-extension",
+                "cloud-agent",
+                "programming-app",
+                "native-app-builder",
+                "creative-writing",
+                "video-gen",
+                "image-gen",
+                "audio-gen",
+                "roleplay",
+                "game",
+                "writing-assistant",
+                "general-chat",
+                "personal-agent",
+                "legal"
+              ],
+              "example": "cli-agent",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "`popular` ranks apps by total token volume inside the date window. `trending` ranks apps by absolute excess token growth: window volume minus the average volume of the three equal-length periods immediately preceding the window. Apps with no excess growth are omitted from `trending` results.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "popular",
+              "description": "`popular` ranks apps by total token volume inside the date window. `trending` ranks apps by absolute excess token growth: window volume minus the average volume of the three equal-length periods immediately preceding the window. Apps with no excess growth are omitted from `trending` results.",
+              "enum": [
+                "popular",
+                "trending"
+              ],
+              "example": "popular",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Start of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to 30 days before `end_date`. The dataset begins at 2025-01-01; earlier values are clamped forward to that floor and the resolved value is echoed in `meta.start_date`.",
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "description": "Start of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to 30 days before `end_date`. The dataset begins at 2025-01-01; earlier values are clamped forward to that floor and the resolved value is echoed in `meta.start_date`.",
+              "example": "2026-04-12",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "End of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to the most recent completed UTC day. Must be on or after 2025-01-01; earlier values are rejected with a 400.",
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "description": "End of the date window in YYYY-MM-DD (UTC), inclusive. Defaults to the most recent completed UTC day. Must be on or after 2025-01-01; earlier values are rejected with a 400.",
+              "example": "2026-05-11",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of apps to return (1-100). Defaults to 50.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of apps to return (1-100). Defaults to 50.",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of ranked apps to skip before the first returned row (0-100). Defaults to 0. `rank` stays absolute, so the first row of `offset=50` is `rank: 51`.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of ranked apps to skip before the first returned row (0-100). Defaults to 0. `rank` stays absolute, so the first row of `offset=50` is `rank: 51`.",
+              "example": 0,
+              "maximum": 100,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "app_id": 12345,
+                      "app_name": "Cline",
+                      "rank": 1,
+                      "total_requests": 4321,
+                      "total_tokens": "12345678"
+                    },
+                    {
+                      "app_id": 67890,
+                      "app_name": "Roo Code",
+                      "rank": 2,
+                      "total_requests": 2109,
+                      "total_tokens": "9876543"
+                    }
+                  ],
+                  "meta": {
+                    "as_of": "2026-05-12T02:00:00Z",
+                    "end_date": "2026-05-11",
+                    "start_date": "2026-04-12",
+                    "version": "v1"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AppRankingsResponse"
+                }
+              }
+            },
+            "description": "Apps ranked per the requested `sort`, re-numbered 1..N. `popular` sorts by `total_tokens` descending; `trending` sorts by absolute excess token growth descending and may return fewer than `limit` rows."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Top apps by token usage",
+        "tags": [
+          "Datasets"
+        ],
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/datasets/benchmarks/artificial-analysis": {
+      "get": {
+        "description": "Returns composite index scores (Intelligence, Coding, Agentic) from Artificial Analysis for LLM models. Includes OpenRouter pricing per model. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
+        "operationId": "getBenchmarksArtificialAnalysis",
+        "parameters": [
+          {
+            "description": "Max results to return (1\u2013100, default 50).",
+            "in": "query",
+            "name": "max_results",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max results to return (1\u2013100, default 50).",
+              "example": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "aa_name": "GPT-4o",
+                      "agentic_index": 58.3,
+                      "coding_index": 65.8,
+                      "intelligence_index": 71.2,
+                      "model_permaslug": "openai/gpt-4o",
+                      "pricing": {
+                        "completion": "0.00001",
+                        "prompt": "0.0000025"
+                      }
+                    }
+                  ],
+                  "meta": {
+                    "as_of": "2026-06-03T12:00:00Z",
+                    "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+                    "model_count": 1,
+                    "source": "artificial-analysis",
+                    "source_url": "https://artificialanalysis.ai",
+                    "version": "v1"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BenchmarksAAResponse"
+                }
+              }
+            },
+            "description": "Artificial Analysis composite index scores with pricing and attribution metadata."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Artificial Analysis Benchmark Indices",
+        "tags": [
+          "Datasets"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/datasets/benchmarks/design-arena": {
+      "get": {
+        "description": "Returns ELO ratings from head-to-head arena battles on Design Arena. Filterable by arena (models/builders/agents) and category. Includes OpenRouter pricing per model. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
+        "operationId": "getBenchmarksDesignArena",
+        "parameters": [
+          {
+            "description": "Arena to query. Defaults to `models`.",
+            "in": "query",
+            "name": "arena",
+            "required": false,
+            "schema": {
+              "default": "models",
+              "description": "Arena to query. Defaults to `models`.",
+              "enum": [
+                "models",
+                "builders",
+                "agents"
+              ],
+              "example": "models",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Category within the arena (e.g. `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`). When omitted, returns all categories.",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "description": "Category within the arena (e.g. `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`). When omitted, returns all categories.",
+              "example": "codecategories",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max results to return: per category when no category filter is applied (1\u2013100, default 50).",
+            "in": "query",
+            "name": "max_results",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max results to return: per category when no category filter is applied (1\u2013100, default 50).",
+              "example": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "arena": "models",
+                      "avg_generation_time_ms": 3200,
+                      "category": "codecategories",
+                      "display_name": "Claude Sonnet 4",
+                      "elo": 1423,
+                      "model_permaslug": "anthropic/claude-sonnet-4",
+                      "pricing": {
+                        "completion": "0.000015",
+                        "prompt": "0.000003"
+                      },
+                      "tournament_stats": {
+                        "first_place": 12,
+                        "fourth_place": 2,
+                        "second_place": 8,
+                        "third_place": 5,
+                        "total": 27
+                      },
+                      "win_rate": 72
+                    }
+                  ],
+                  "meta": {
+                    "arena": "models",
+                    "as_of": "2026-06-03T12:00:00Z",
+                    "category": null,
+                    "citation": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
+                    "elo_bounds": {
+                      "max": 1600,
+                      "min": 900
+                    },
+                    "model_count": 1,
+                    "source": "design-arena",
+                    "source_url": "https://www.designarena.ai",
+                    "version": "v1"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BenchmarksDAResponse"
+                }
+              }
+            },
+            "description": "Design Arena ELO rankings with pricing and attribution metadata."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Design Arena Benchmark Rankings",
+        "tags": [
+          "Datasets"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/datasets/rankings-daily": {
       "get": {
@@ -30288,9 +34200,31 @@
         "tags": [
           "Datasets"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/embeddings": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -30906,7 +34840,18 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/endpoints/zdr": {
       "get": {
@@ -31041,7 +34986,728 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/files": {
+      "get": {
+        "description": "Lists files belonging to the workspace of the authenticating API key.",
+        "operationId": "listFiles",
+        "parameters": [
+          {
+            "description": "Maximum number of files to return (1\u20131000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of files to return (1\u20131000).",
+              "example": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque pagination cursor from a previous response.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque pagination cursor from a previous response.",
+              "example": "eyJjdXJzb3IiOiJmaWxlXzAxMUNOaGE4aUNKY1Uxd1hOUjZxNFY4dyJ9",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+              "example": "a103d8b6-42f0-4e50-9a3c-bf41e2c3c1a7",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "cursor": null,
+                  "data": [
+                    {
+                      "created_at": "2025-01-01T00:00:00Z",
+                      "downloadable": false,
+                      "filename": "document.pdf",
+                      "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                      "mime_type": "application/pdf",
+                      "size_bytes": 1024000,
+                      "type": "file"
+                    }
+                  ],
+                  "first_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "has_more": false,
+                  "last_id": "file_011CNha8iCJcU1wXNR6q4V8w"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/FileListResponse"
+                }
+              }
+            },
+            "description": "A page of files."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List files",
+        "tags": [
+          "Files"
+        ],
+        "x-speakeasy-name-override": "list",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "cursor",
+              "type": "cursor"
+            }
+          ],
+          "outputs": {
+            "nextCursor": "$.cursor",
+            "results": "$.data"
+          },
+          "type": "cursor"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
+      "post": {
+        "description": "Uploads a file to be referenced in future API calls. The file is stored under the workspace of the authenticating API key. Maximum file size: 100 MB.",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+              "example": "a103d8b6-42f0-4e50-9a3c-bf41e2c3c1a7",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "example": {
+                "file": "document.pdf"
+              },
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "created_at": "2025-01-01T00:00:00Z",
+                  "downloadable": false,
+                  "filename": "document.pdf",
+                  "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "mime_type": "application/pdf",
+                  "size_bytes": 1024000,
+                  "type": "file"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/FileMetadata"
+                }
+              }
+            },
+            "description": "The uploaded file metadata."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 413,
+                    "message": "Request payload too large"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PayloadTooLargeResponse"
+                }
+              }
+            },
+            "description": "Payload Too Large - Request payload exceeds size limits"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Upload a file",
+        "tags": [
+          "Files"
+        ],
+        "x-speakeasy-name-override": "upload"
       }
+    },
+    "/files/{file_id}": {
+      "delete": {
+        "description": "Deletes a file owned by the requesting workspace. Deletion is irreversible.",
+        "operationId": "deleteFile",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "example": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+              "example": "a103d8b6-42f0-4e50-9a3c-bf41e2c3c1a7",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "type": "file_deleted"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/FileDeleteResponse"
+                }
+              }
+            },
+            "description": "The file was deleted."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Delete a file",
+        "tags": [
+          "Files"
+        ],
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "description": "Retrieves metadata for a single file owned by the requesting workspace.",
+        "operationId": "getFileMetadata",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "example": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+              "example": "a103d8b6-42f0-4e50-9a3c-bf41e2c3c1a7",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "created_at": "2025-01-01T00:00:00Z",
+                  "downloadable": false,
+                  "filename": "document.pdf",
+                  "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "mime_type": "application/pdf",
+                  "size_bytes": 1024000,
+                  "type": "file"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/FileMetadata"
+                }
+              }
+            },
+            "description": "The file metadata."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get file metadata",
+        "tags": [
+          "Files"
+        ],
+        "x-speakeasy-name-override": "retrieve"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/files/{file_id}/content": {
+      "get": {
+        "description": "Downloads the raw bytes of a file. Only files created server-side are downloadable; uploaded files return 400.",
+        "operationId": "downloadFileContent",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "example": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "description": "Workspace to scope the request to. Defaults to the caller\u2019s default workspace.",
+              "example": "a103d8b6-42f0-4e50-9a3c-bf41e2c3c1a7",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "example": "binary file contents",
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The raw file content."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Download file content",
+        "tags": [
+          "Files"
+        ],
+        "x-speakeasy-name-override": "download"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation": {
       "get": {
@@ -31246,7 +35912,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation/content": {
       "get": {
@@ -31425,7 +36102,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails": {
       "get": {
@@ -31563,6 +36251,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -31815,7 +36514,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -31929,7 +36639,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/{id}": {
       "delete": {
@@ -32122,6 +36843,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
@@ -32403,6 +37135,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
@@ -32522,6 +37265,17 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -32781,6 +37535,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -32901,6 +37666,17 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -33322,7 +38098,18 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/keys": {
       "get": {
@@ -33668,6 +38455,17 @@
         ],
         "x-speakeasy-name-override": "list"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
@@ -34528,6 +39326,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -34933,15 +39742,26 @@
       }
     },
     "/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
         "parameters": [
           {
-            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`.",
+            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`. The legacy header `X-OpenRouter-Experimental-Metadata` is also accepted for backward compatibility.",
             "example": "enabled",
             "in": "header",
-            "name": "X-OpenRouter-Experimental-Metadata",
+            "name": "X-OpenRouter-Metadata",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/MetadataLevel"
@@ -35117,7 +39937,7 @@
                 }
               }
             },
-            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Experimental-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
+            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
           },
           "404": {
             "content": {
@@ -35214,6 +40034,133 @@
         "x-speakeasy-stream-request-field": "stream"
       }
     },
+    "/model/{author}/{slug}": {
+      "get": {
+        "description": "Returns full details for a single model identified by its author and slug (e.g. openai/gpt-4). Supports variant suffixes (e.g. openai/gpt-4:free) and resolves known slug aliases.",
+        "operationId": "getModel",
+        "parameters": [
+          {
+            "description": "The author/organization of the model",
+            "in": "path",
+            "name": "author",
+            "required": true,
+            "schema": {
+              "description": "The author/organization of the model",
+              "example": "openai",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The model slug, optionally including a variant suffix (e.g. gpt-4 or gpt-4:free)",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "The model slug, optionally including a variant suffix (e.g. gpt-4 or gpt-4:free)",
+              "example": "gpt-4",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "architecture": {
+                      "input_modalities": [
+                        "text"
+                      ],
+                      "instruct_type": "chatml",
+                      "modality": "text->text",
+                      "output_modalities": [
+                        "text"
+                      ],
+                      "tokenizer": "GPT"
+                    },
+                    "context_length": 8192,
+                    "created": 1692901234,
+                    "description": "GPT-4 is a large multimodal model that can solve difficult problems with greater accuracy.",
+                    "id": "openai/gpt-4",
+                    "name": "GPT-4",
+                    "per_request_limits": null,
+                    "pricing": {
+                      "completion": "0.00006",
+                      "image": "0",
+                      "prompt": "0.00003",
+                      "request": "0"
+                    },
+                    "supported_parameters": [
+                      "temperature",
+                      "top_p",
+                      "max_tokens"
+                    ],
+                    "top_provider": {
+                      "context_length": 8192,
+                      "is_moderated": true,
+                      "max_completion_tokens": 4096
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ModelResponse"
+                }
+              }
+            },
+            "description": "Returns the model details"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get a model by its slug",
+        "tags": [
+          "Models"
+        ],
+        "x-speakeasy-name-override": "get"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
     "/models": {
       "get": {
         "operationId": "getModels",
@@ -35263,6 +40210,166 @@
             "schema": {
               "description": "Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio, embeddings) or \"all\" to include all models. Defaults to \"text\".",
               "example": "text",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort the returned models server-side. Prefer this over fetching the full list and sorting client-side. Options: pricing-low-to-high, pricing-high-to-low (average prompt/completion price), context-high-to-low (context length), throughput-high-to-low, latency-low-to-high (recent median performance), most-popular, top-weekly (tokens processed in the last week), newest (creation date). When omitted, the existing default ordering is preserved.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "description": "Sort the returned models server-side. Prefer this over fetching the full list and sorting client-side. Options: pricing-low-to-high, pricing-high-to-low (average prompt/completion price), context-high-to-low (context length), throughput-high-to-low, latency-low-to-high (recent median performance), most-popular, top-weekly (tokens processed in the last week), newest (creation date). When omitted, the existing default ordering is preserved.",
+              "enum": [
+                "most-popular",
+                "newest",
+                "top-weekly",
+                "pricing-low-to-high",
+                "pricing-high-to-low",
+                "context-high-to-low",
+                "throughput-high-to-low",
+                "latency-low-to-high"
+              ],
+              "example": "newest",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Free-text search by model name or slug.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "description": "Free-text search by model name or slug.",
+              "example": "gpt-4",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter models by input modality. Comma-separated list of: text, image, audio, file.",
+            "in": "query",
+            "name": "input_modalities",
+            "required": false,
+            "schema": {
+              "description": "Filter models by input modality. Comma-separated list of: text, image, audio, file.",
+              "example": "text,image",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Minimum context length (tokens). Models with smaller context are excluded.",
+            "in": "query",
+            "name": "context",
+            "required": false,
+            "schema": {
+              "description": "Minimum context length (tokens). Models with smaller context are excluded.",
+              "example": 128000,
+              "exclusiveMinimum": true,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Minimum prompt price in $/M tokens.",
+            "in": "query",
+            "name": "min_price",
+            "required": false,
+            "schema": {
+              "description": "Minimum prompt price in $/M tokens.",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Maximum prompt price in $/M tokens.",
+            "in": "query",
+            "name": "max_price",
+            "required": false,
+            "schema": {
+              "description": "Maximum prompt price in $/M tokens.",
+              "example": 10,
+              "minimum": 0,
+              "nullable": true,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Filter models by architecture/model family (e.g. GPT, Claude, Gemini, Llama).",
+            "in": "query",
+            "name": "arch",
+            "required": false,
+            "schema": {
+              "description": "Filter models by architecture/model family (e.g. GPT, Claude, Gemini, Llama).",
+              "example": "GPT",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter models by the organization that created the model. Comma-separated list of author slugs.",
+            "in": "query",
+            "name": "model_authors",
+            "required": false,
+            "schema": {
+              "description": "Filter models by the organization that created the model. Comma-separated list of author slugs.",
+              "example": "openai,anthropic",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter models by hosting provider. Comma-separated list of provider names.",
+            "in": "query",
+            "name": "providers",
+            "required": false,
+            "schema": {
+              "description": "Filter models by hosting provider. Comma-separated list of provider names.",
+              "example": "OpenAI,Anthropic",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by distillation capability. \"true\" returns only distillable models, \"false\" excludes them.",
+            "in": "query",
+            "name": "distillable",
+            "required": false,
+            "schema": {
+              "description": "Filter by distillation capability. \"true\" returns only distillable models, \"false\" excludes them.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "example": "true",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "When set to \"true\", return only models with zero data retention endpoints.",
+            "in": "query",
+            "name": "zdr",
+            "required": false,
+            "schema": {
+              "description": "When set to \"true\", return only models with zero data retention endpoints.",
+              "enum": [
+                "true"
+              ],
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter to models with endpoints in the given data region. Currently only \"eu\" is supported.",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "description": "Filter to models with endpoints in the given data region. Currently only \"eu\" is supported.",
+              "enum": [
+                "eu"
+              ],
+              "example": "eu",
               "type": "string"
             }
           }
@@ -35363,7 +40470,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/count": {
       "get": {
@@ -35435,7 +40553,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/user": {
       "get": {
@@ -35558,7 +40687,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -35724,7 +40864,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/observability/destinations": {
       "get": {
@@ -35861,6 +41012,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new observability destination. A maximum of 5 destinations per type is allowed. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createObservabilityDestination",
@@ -36192,6 +41354,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing observability destination. Only the fields provided in the request body are updated. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateObservabilityDestination",
@@ -36528,9 +41701,327 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/presets": {
+      "get": {
+        "description": "Lists all presets for the authenticated user, ordered by most recently updated first.",
+        "operationId": "listPresets",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "created_at": "2026-04-20T10:00:00Z",
+                      "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "description": null,
+                      "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+                      "id": "650e8400-e29b-41d4-a716-446655440001",
+                      "name": "my-preset",
+                      "slug": "my-preset",
+                      "status": "active",
+                      "status_updated_at": null,
+                      "updated_at": "2026-04-20T10:00:00Z",
+                      "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListPresetsResponse"
+                }
+              }
+            },
+            "description": "Paginated list of presets."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "List presets",
+        "tags": [
+          "Presets"
+        ],
+        "x-speakeasy-name-override": "list",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/presets/{slug}": {
+      "get": {
+        "description": "Retrieves a preset by its slug with its currently designated version inline.",
+        "operationId": "getPreset",
+        "parameters": [
+          {
+            "description": "URL-safe slug identifying the preset.",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "URL-safe slug identifying the preset.",
+              "example": "my-preset",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2026-04-20T10:00:00Z",
+                    "creator_user_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "description": null,
+                    "designated_version": {
+                      "config": {
+                        "model": "openai/gpt-4o",
+                        "temperature": 0.7
+                      },
+                      "created_at": "2026-04-20T10:00:00Z",
+                      "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+                      "system_prompt": "You are a helpful assistant.",
+                      "updated_at": "2026-04-20T10:00:00Z",
+                      "version": 1
+                    },
+                    "designated_version_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "id": "650e8400-e29b-41d4-a716-446655440001",
+                    "name": "my-preset",
+                    "slug": "my-preset",
+                    "status": "active",
+                    "status_updated_at": null,
+                    "updated_at": "2026-04-20T10:00:00Z",
+                    "workspace_id": "750e8400-e29b-41d4-a716-446655440002"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GetPresetResponse"
+                }
+              }
+            },
+            "description": "Preset with its designated version."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "Get a preset",
+        "tags": [
+          "Presets"
+        ],
+        "x-speakeasy-name-override": "get"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/presets/{slug}/chat/completions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsChatCompletions",
@@ -36720,6 +42211,17 @@
       }
     },
     "/presets/{slug}/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsMessages",
@@ -36906,6 +42408,17 @@
       }
     },
     "/presets/{slug}/responses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsResponses",
@@ -37083,6 +42596,329 @@
           "Presets"
         ]
       }
+    },
+    "/presets/{slug}/versions": {
+      "get": {
+        "description": "Lists all versions of a preset, ordered by version number ascending (oldest first).",
+        "operationId": "listPresetVersions",
+        "parameters": [
+          {
+            "description": "URL-safe slug identifying the preset.",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "URL-safe slug identifying the preset.",
+              "example": "my-preset",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "config": {
+                        "model": "openai/gpt-4o",
+                        "temperature": 0.7
+                      },
+                      "created_at": "2026-04-20T10:00:00Z",
+                      "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                      "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+                      "system_prompt": "You are a helpful assistant.",
+                      "updated_at": "2026-04-20T10:00:00Z",
+                      "version": 1
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListPresetVersionsResponse"
+                }
+              }
+            },
+            "description": "Paginated list of preset versions."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "List versions of a preset",
+        "tags": [
+          "Presets"
+        ],
+        "x-speakeasy-name-override": "listVersions",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/presets/{slug}/versions/{version}": {
+      "get": {
+        "description": "Retrieves a specific version of a preset by its slug and version number.",
+        "operationId": "getPresetVersion",
+        "parameters": [
+          {
+            "description": "URL-safe slug identifying the preset.",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "URL-safe slug identifying the preset.",
+              "example": "my-preset",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number of the preset.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "description": "Version number of the preset.",
+              "example": "1",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "config": {
+                      "model": "openai/gpt-4o",
+                      "temperature": 0.7
+                    },
+                    "created_at": "2026-04-20T10:00:00Z",
+                    "creator_id": "user_2dHFtVWx2n56w6HkM0000000000",
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "preset_id": "650e8400-e29b-41d4-a716-446655440001",
+                    "system_prompt": "You are a helpful assistant.",
+                    "updated_at": "2026-04-20T10:00:00Z",
+                    "version": 1
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GetPresetVersionResponse"
+                }
+              }
+            },
+            "description": "The requested preset version."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "summary": "Get a specific version of a preset",
+        "tags": [
+          "Presets"
+        ],
+        "x-speakeasy-name-override": "getVersion"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/providers": {
       "get": {
@@ -37733,9 +43569,31 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/rerank": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -37755,14 +43613,36 @@
                 },
                 "properties": {
                   "documents": {
-                    "description": "The list of documents to rerank",
+                    "description": "The list of documents to rerank. Documents may be plain strings, or structured objects with `text` and/or `image` for multimodal models.",
                     "example": [
                       "Paris is the capital of France.",
                       "Berlin is the capital of Germany."
                     ],
                     "items": {
-                      "type": "string"
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "description": "A structured document with optional text and/or image content. At least one of `text` or `image` must be provided.",
+                          "properties": {
+                            "image": {
+                              "description": "An image associated with the document, as a remote URL (http/https) or a base64-encoded data URI (data:image/...).",
+                              "example": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Phytogenic.png",
+                              "type": "string"
+                            },
+                            "text": {
+                              "description": "The document text",
+                              "example": "AI enables robots to perceive, plan, and act autonomously.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      ],
+                      "description": "A document to rerank. Either a plain string, or a structured object with optional `text` and/or `image`."
                     },
+                    "minItems": 1,
                     "type": "array"
                   },
                   "model": {
@@ -37864,17 +43744,19 @@
                         },
                         "properties": {
                           "document": {
-                            "description": "The document object containing the original text",
+                            "description": "The document object echoing the original input (text and/or image)",
                             "properties": {
+                              "image": {
+                                "description": "The image (URL or data URI) from the original document",
+                                "example": "https://example.com/image.png",
+                                "type": "string"
+                              },
                               "text": {
                                 "description": "The document text",
                                 "example": "Paris is the capital of France.",
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "text"
-                            ],
                             "type": "object"
                           },
                           "index": {
@@ -38112,15 +43994,26 @@
       }
     },
     "/responses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
         "parameters": [
           {
-            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`.",
+            "description": "Opt-in to surface routing metadata on the response under `openrouter_metadata`. Defaults to `disabled`. The legacy header `X-OpenRouter-Experimental-Metadata` is also accepted for backward compatibility.",
             "example": "enabled",
             "in": "header",
-            "name": "X-OpenRouter-Experimental-Metadata",
+            "name": "X-OpenRouter-Metadata",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/MetadataLevel"
@@ -38306,7 +44199,7 @@
                 }
               }
             },
-            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Experimental-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
+            "description": "Forbidden - Authentication successful but insufficient permissions, or a guardrail blocked the request. When guardrails block and the `X-OpenRouter-Metadata: enabled` header is present, the response includes `openrouter_metadata` with full routing context and a `pipeline` array containing guardrail stage details."
           },
           "404": {
             "content": {
@@ -38478,6 +44371,17 @@
       }
     },
     "/videos": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -38703,7 +44607,18 @@
         "tags": [
           "Video Generation"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}": {
       "get": {
@@ -38798,7 +44713,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -38927,7 +44853,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/workspaces": {
       "get": {
@@ -39051,6 +44988,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new workspace for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createWorkspace",
@@ -39395,6 +45343,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateWorkspace",
@@ -39545,6 +45504,17 @@
       }
     },
     "/workspaces/{id}/members/add": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Add multiple organization members to a workspace. Members are assigned the same role they hold in the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAddWorkspaceMembers",
@@ -39690,6 +45660,17 @@
       }
     },
     "/workspaces/{id}/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkRemoveWorkspaceMembers",
@@ -39876,6 +45857,10 @@
       "name": "Endpoints"
     },
     {
+      "description": "Files endpoints",
+      "name": "Files"
+    },
+    {
       "description": "Generation history endpoints",
       "name": "Generations"
     },
@@ -39928,6 +45913,10 @@
     {
       "description": "Workspaces endpoints",
       "name": "Workspaces"
+    },
+    {
+      "description": "beta.Analytics endpoints",
+      "name": "beta.Analytics"
     },
     {
       "description": "beta.responses endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-06-05T06:33:03+00:00",
+  "captured_at": "2026-06-17T02:31:05+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,11 +14,11 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 66,
+  "operation_count": 81,
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "54fa253a00ac5c42",
+      "fingerprint": "6f91deb041a1b1fa",
       "id": "DELETE /byok/{id}",
       "method": "DELETE",
       "operation_id": "deleteBYOKKey",
@@ -29,7 +29,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2fb8480286edd199",
+      "fingerprint": "4ca18f79ffb216d8",
+      "id": "DELETE /files/{file_id}",
+      "method": "DELETE",
+      "operation_id": "deleteFile",
+      "path": "/files/{file_id}",
+      "tags": [
+        "Files"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "8004f3e140aff889",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -40,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1745c85b0992ea6e",
+      "fingerprint": "733cf850bfa8a450",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -51,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7af9e020afb4c928",
+      "fingerprint": "8291a7a0a00636a7",
       "id": "DELETE /observability/destinations/{id}",
       "method": "DELETE",
       "operation_id": "deleteObservabilityDestination",
@@ -62,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4cc4b797882b36d3",
+      "fingerprint": "2e01d56dde1346eb",
       "id": "DELETE /workspaces/{id}",
       "method": "DELETE",
       "operation_id": "deleteWorkspace",
@@ -73,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d9c39756fe253cfc",
+      "fingerprint": "ae78503d01b50758",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -84,7 +95,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b5a2e4bad2c286d2",
+      "fingerprint": "b69b2e0455fcf869",
+      "id": "GET /analytics/meta",
+      "method": "GET",
+      "operation_id": "getAnalyticsMeta",
+      "path": "/analytics/meta",
+      "tags": [
+        "beta.Analytics"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "7bc33c69e1541f31",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -95,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c3ad5385094e5317",
+      "fingerprint": "5c642e0bbe88b2b0",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -106,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3c98257b3b15ba09",
+      "fingerprint": "a8de6e34f937d228",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -117,7 +139,40 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "32a5aa933d91ab37",
+      "fingerprint": "536e2f01051821eb",
+      "id": "GET /datasets/app-rankings",
+      "method": "GET",
+      "operation_id": "getAppRankings",
+      "path": "/datasets/app-rankings",
+      "tags": [
+        "Datasets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "f34604bdd9969376",
+      "id": "GET /datasets/benchmarks/artificial-analysis",
+      "method": "GET",
+      "operation_id": "getBenchmarksArtificialAnalysis",
+      "path": "/datasets/benchmarks/artificial-analysis",
+      "tags": [
+        "Datasets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "77e54da40f262c74",
+      "id": "GET /datasets/benchmarks/design-arena",
+      "method": "GET",
+      "operation_id": "getBenchmarksDesignArena",
+      "path": "/datasets/benchmarks/design-arena",
+      "tags": [
+        "Datasets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "83504c0454c4196d",
       "id": "GET /datasets/rankings-daily",
       "method": "GET",
       "operation_id": "getRankingsDaily",
@@ -128,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c83853c4260db3c5",
+      "fingerprint": "98678d41300bf2ac",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -139,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f159f2f6d6b1ad93",
+      "fingerprint": "973c39a6f4957df4",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -150,7 +205,40 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "de4301db9bed6040",
+      "fingerprint": "52e3f38ade280a25",
+      "id": "GET /files",
+      "method": "GET",
+      "operation_id": "listFiles",
+      "path": "/files",
+      "tags": [
+        "Files"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "21192490b76d7137",
+      "id": "GET /files/{file_id}",
+      "method": "GET",
+      "operation_id": "getFileMetadata",
+      "path": "/files/{file_id}",
+      "tags": [
+        "Files"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "75e30dae37e11592",
+      "id": "GET /files/{file_id}/content",
+      "method": "GET",
+      "operation_id": "downloadFileContent",
+      "path": "/files/{file_id}/content",
+      "tags": [
+        "Files"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "c95fd1f97e3baaa6",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -161,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1deaadf338b00e36",
+      "fingerprint": "51f1c957e6966d83",
       "id": "GET /generation/content",
       "method": "GET",
       "operation_id": "listGenerationContent",
@@ -172,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c971fe86ab8e6f1e",
+      "fingerprint": "ef509670a9999d44",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -183,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "35e6f73bb468cb70",
+      "fingerprint": "4bfed3ae865133d0",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -194,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "03bb4f3b9c8e6c2e",
+      "fingerprint": "f593364bb80429da",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -205,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7e90108dc4db6649",
+      "fingerprint": "d504d0be2f9c3b1a",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -216,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a9e5751ca222eb49",
+      "fingerprint": "df9126ac57b2e8a6",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -227,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bdcbd251388c2a9f",
+      "fingerprint": "3f4a4fd0be15d281",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -238,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "98111f144a36687a",
+      "fingerprint": "5e74c6f64f3895ab",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -249,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "de272d5aefee14f8",
+      "fingerprint": "9fda652a77216fb3",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -260,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4c7015c8e6d592b1",
+      "fingerprint": "d47719cebfea6fce",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -271,7 +359,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c6a3e2527d06fa7e",
+      "fingerprint": "6481d488d719de61",
+      "id": "GET /model/{author}/{slug}",
+      "method": "GET",
+      "operation_id": "getModel",
+      "path": "/model/{author}/{slug}",
+      "tags": [
+        "Models"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "7c12e55fa2ed959c",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -282,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "da4869e1fabb1f97",
+      "fingerprint": "62cf82894c93d8a5",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -293,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "424f3a218e16b0c8",
+      "fingerprint": "993f9ab6be27f052",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -304,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ebbf719d1b1de4f9",
+      "fingerprint": "8d587ed916bfa2ac",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -315,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4684d46d3e9ed4ba",
+      "fingerprint": "e6b60e663bdeb4b5",
       "id": "GET /observability/destinations",
       "method": "GET",
       "operation_id": "listObservabilityDestinations",
@@ -326,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f6a02d96a127d2fb",
+      "fingerprint": "510a50aa20bc478d",
       "id": "GET /observability/destinations/{id}",
       "method": "GET",
       "operation_id": "getObservabilityDestination",
@@ -337,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9312fc5514215fa6",
+      "fingerprint": "1688e70dc78a6d2e",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -348,7 +447,51 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0190e638a75a742c",
+      "fingerprint": "64b8b887344334a0",
+      "id": "GET /presets",
+      "method": "GET",
+      "operation_id": "listPresets",
+      "path": "/presets",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "2f401e04bbdce18c",
+      "id": "GET /presets/{slug}",
+      "method": "GET",
+      "operation_id": "getPreset",
+      "path": "/presets/{slug}",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "0e2ac7a69da8f49b",
+      "id": "GET /presets/{slug}/versions",
+      "method": "GET",
+      "operation_id": "listPresetVersions",
+      "path": "/presets/{slug}/versions",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "b40dbfe8a12b0060",
+      "id": "GET /presets/{slug}/versions/{version}",
+      "method": "GET",
+      "operation_id": "getPresetVersion",
+      "path": "/presets/{slug}/versions/{version}",
+      "tags": [
+        "Presets"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "8ff8eb8b38fdeadd",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -359,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b0430f4a6ffa4c65",
+      "fingerprint": "280fb5424a4592c1",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -370,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb1755e343f1ad00",
+      "fingerprint": "d362ff6551959875",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -381,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "800226a4045deb52",
+      "fingerprint": "f32cade2ff8a4051",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -392,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f620e15efc87f708",
+      "fingerprint": "634565e76efca746",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -403,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5e91b64f55580e2e",
+      "fingerprint": "04c5ff4b21a5f2d8",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -414,7 +557,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7d6f5c7e477dc7e0",
+      "fingerprint": "a9afaca77f1d96b2",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -425,7 +568,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4f57a8b8f08fbbee",
+      "fingerprint": "4eef56f24cf213b9",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -436,7 +579,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ebfe6f0d6437a64d",
+      "fingerprint": "0fbc8d8c7c39be05",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -447,7 +590,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f131c45a71b39858",
+      "fingerprint": "43f31fd2d1723823",
       "id": "PATCH /observability/destinations/{id}",
       "method": "PATCH",
       "operation_id": "updateObservabilityDestination",
@@ -458,7 +601,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "649393331ddf22fa",
+      "fingerprint": "63b7e147e7befdae",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -469,7 +612,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e866e241015fc95b",
+      "fingerprint": "d66f5f405b714b43",
+      "id": "POST /analytics/query",
+      "method": "POST",
+      "operation_id": "queryAnalytics",
+      "path": "/analytics/query",
+      "tags": [
+        "beta.Analytics"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "e08a32f59a79d92d",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -480,7 +634,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cec87f5a232cd68d",
+      "fingerprint": "804f6d6fffd86bc3",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -491,7 +645,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c424a5da1b3397d0",
+      "fingerprint": "d493aa172fcebce7",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -502,7 +656,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "61976fd06ab1a0db",
+      "fingerprint": "ceb109a1b4b0ff2c",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -513,7 +667,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a3fe8792a450affe",
+      "fingerprint": "d986df71a15038aa",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -524,7 +678,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "78840a08479a8674",
+      "fingerprint": "242ef7374f80f5b8",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -535,7 +689,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "460f78d19065c975",
+      "fingerprint": "b01e3928aa482584",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -546,7 +700,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cb013d3338781561",
+      "fingerprint": "2c3bf36d941e5e40",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -557,7 +711,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1fce35e980af57e9",
+      "fingerprint": "6bc0405724ba1da1",
+      "id": "POST /files",
+      "method": "POST",
+      "operation_id": "uploadFile",
+      "path": "/files",
+      "tags": [
+        "Files"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "fa02a19eae7e5167",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -568,7 +733,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1e173c303b2ff6ba",
+      "fingerprint": "d3bf39f02a393587",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -579,7 +744,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7b9cda7b1e3ce55f",
+      "fingerprint": "3a6c0c7a7694c7eb",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -590,7 +755,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "64055d638a961139",
+      "fingerprint": "2f024097c594b765",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -601,7 +766,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "642759fa50e0f210",
+      "fingerprint": "c13b770c0e4a29da",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -612,7 +777,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dc02bce8d250dcc5",
+      "fingerprint": "56e0a2b04ddc58dd",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -623,7 +788,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9aa4cf34ec7c5ecf",
+      "fingerprint": "7c1b6348992c9c42",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -634,7 +799,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5086e3ca90802aa9",
+      "fingerprint": "aabc5a92b0ef0a7f",
       "id": "POST /observability/destinations",
       "method": "POST",
       "operation_id": "createObservabilityDestination",
@@ -645,7 +810,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c0bc5853e1ed88e7",
+      "fingerprint": "0f65e8f433079357",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -656,7 +821,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2b036bf52bcd2b20",
+      "fingerprint": "72c70404cdff22b3",
       "id": "POST /presets/{slug}/messages",
       "method": "POST",
       "operation_id": "createPresetsMessages",
@@ -667,7 +832,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "89e8fdd07288bffc",
+      "fingerprint": "7494e4885f2cd5c8",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -678,7 +843,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f993967db2d45188",
+      "fingerprint": "ef5d825e75e81780",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -689,7 +854,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a6984cef3488a0af",
+      "fingerprint": "2e102463943fe255",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -700,7 +865,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fbc874edb0776005",
+      "fingerprint": "09ecbcc519124a17",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -711,7 +876,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "397a8a2e22c940f0",
+      "fingerprint": "bd9843e05ec237fb",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -722,7 +887,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bcd57c55024b39f7",
+      "fingerprint": "2556147014e762fc",
       "id": "POST /workspaces/{id}/members/add",
       "method": "POST",
       "operation_id": "bulkAddWorkspaceMembers",
@@ -733,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d3a2a804cb7e2d88",
+      "fingerprint": "921b0ff6f318c0df",
       "id": "POST /workspaces/{id}/members/remove",
       "method": "POST",
       "operation_id": "bulkRemoveWorkspaceMembers",

--- a/src/api/analytics.rs
+++ b/src/api/analytics.rs
@@ -1,0 +1,266 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    error::OpenRouterError,
+    strip_option_vec_setter,
+    transport::{request as transport_request, response as transport_response},
+    types::ApiResponse,
+};
+
+/// One analytics metric definition returned by `GET /analytics/meta`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsMetric {
+    pub name: String,
+    pub display_label: String,
+    pub is_rate: bool,
+    pub display_format: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// One analytics dimension definition returned by `GET /analytics/meta`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsDimension {
+    pub name: String,
+    pub display_label: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// One analytics filter operator definition returned by `GET /analytics/meta`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsOperator {
+    pub name: String,
+    pub value_type: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// One analytics granularity definition returned by `GET /analytics/meta`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsGranularity {
+    pub name: String,
+    pub display_label: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Analytics query metadata.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsMeta {
+    pub metrics: Vec<AnalyticsMetric>,
+    pub dimensions: Vec<AnalyticsDimension>,
+    pub operators: Vec<AnalyticsOperator>,
+    pub granularities: Vec<AnalyticsGranularity>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Scalar value used inside analytics filters.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum AnalyticsFilterScalar {
+    String(String),
+    Number(f64),
+}
+
+impl From<&str> for AnalyticsFilterScalar {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<String> for AnalyticsFilterScalar {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<f64> for AnalyticsFilterScalar {
+    fn from(value: f64) -> Self {
+        Self::Number(value)
+    }
+}
+
+/// Filter value accepted by analytics query requests.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum AnalyticsFilterValue {
+    String(String),
+    Number(f64),
+    Array(Vec<AnalyticsFilterScalar>),
+}
+
+/// One analytics filter.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnalyticsFilter {
+    pub field: String,
+    pub operator: String,
+    pub value: AnalyticsFilterValue,
+}
+
+/// Analytics time range.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnalyticsTimeRange {
+    pub start: String,
+    pub end: String,
+}
+
+/// Analytics ordering clause.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AnalyticsOrderBy {
+    pub field: String,
+    pub direction: String,
+}
+
+/// Request payload for `POST /analytics/query`.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct AnalyticsQueryRequest {
+    #[builder(setter(custom))]
+    pub metrics: Vec<String>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<Vec<String>>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<Vec<AnalyticsFilter>>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub granularity: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_limit: Option<u32>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_by: Option<AnalyticsOrderBy>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_range: Option<AnalyticsTimeRange>,
+}
+
+impl AnalyticsQueryRequest {
+    pub fn builder() -> AnalyticsQueryRequestBuilder {
+        AnalyticsQueryRequestBuilder::default()
+    }
+}
+
+impl AnalyticsQueryRequestBuilder {
+    pub fn metrics<T, S>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.metrics = Some(items.into_iter().map(Into::into).collect());
+        self
+    }
+
+    strip_option_vec_setter!(dimensions, String);
+    strip_option_vec_setter!(filters, AnalyticsFilter);
+}
+
+/// Metadata returned with analytics query rows.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsQueryMetadata {
+    pub query_time_ms: f64,
+    pub row_count: u64,
+    pub truncated: bool,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Analytics query result payload.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnalyticsQueryResponse {
+    #[serde(default, rename = "cachedAt")]
+    pub cached_at: Option<f64>,
+    pub data: Vec<HashMap<String, Value>>,
+    pub metadata: AnalyticsQueryMetadata,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Get analytics query metadata (`GET /analytics/meta`).
+pub async fn get_analytics_meta(
+    base_url: &str,
+    management_key: &str,
+) -> Result<AnalyticsMeta, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_analytics_meta_with_client(&http_client, base_url, management_key).await
+}
+
+pub(crate) async fn get_analytics_meta_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+) -> Result<AnalyticsMeta, OpenRouterError> {
+    let url = format!("{base_url}/analytics/meta");
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<AnalyticsMeta> =
+            transport_response::parse_json_response(response, "analytics meta").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Query analytics (`POST /analytics/query`).
+pub async fn query_analytics(
+    base_url: &str,
+    management_key: &str,
+    request: &AnalyticsQueryRequest,
+) -> Result<AnalyticsQueryResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    query_analytics_with_client(&http_client, base_url, management_key, request).await
+}
+
+pub(crate) async fn query_analytics_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    request: &AnalyticsQueryRequest,
+) -> Result<AnalyticsQueryResponse, OpenRouterError> {
+    let url = format!("{base_url}/analytics/query");
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<AnalyticsQueryResponse> =
+            transport_response::parse_json_response(response, "analytics query").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -72,6 +72,9 @@ pub struct CreateAuthCodeRequest {
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     spawn_cloud: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
 }
 
 impl CreateAuthCodeRequest {

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use derive_builder::Builder;
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use urlencoding::encode;
@@ -231,6 +232,182 @@ pub struct RankingsDailyResponse {
     pub meta: RankingsDailyMeta,
 }
 
+/// Query parameters for `GET /datasets/app-rankings`.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct AppRankingsParams {
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subcategory: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+impl AppRankingsParams {
+    pub fn builder() -> AppRankingsParamsBuilder {
+        AppRankingsParamsBuilder::default()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.category.is_none()
+            && self.subcategory.is_none()
+            && self.sort.is_none()
+            && self.start_date.is_none()
+            && self.end_date.is_none()
+            && self.limit.is_none()
+            && self.offset.is_none()
+    }
+}
+
+/// One application ranking row returned by `GET /datasets/app-rankings`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AppRankingsItem {
+    pub rank: u64,
+    pub app_id: u64,
+    pub app_name: String,
+    pub total_tokens: String,
+    pub total_requests: u64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// App rankings dataset response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AppRankingsResponse {
+    pub data: Vec<AppRankingsItem>,
+    pub meta: RankingsDailyMeta,
+}
+
+/// OpenRouter benchmark pricing payload.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarkPricing {
+    pub prompt: String,
+    pub completion: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// One Artificial Analysis benchmark row.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarksAAItem {
+    pub model_permaslug: String,
+    pub aa_name: String,
+    pub intelligence_index: Option<f64>,
+    pub coding_index: Option<f64>,
+    pub agentic_index: Option<f64>,
+    pub pricing: Option<BenchmarkPricing>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Metadata for Artificial Analysis benchmark rows.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarksAAMeta {
+    pub as_of: String,
+    pub version: String,
+    pub source: String,
+    pub source_url: String,
+    pub citation: String,
+    pub model_count: u64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Artificial Analysis benchmark dataset response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarksAAResponse {
+    pub data: Vec<BenchmarksAAItem>,
+    pub meta: BenchmarksAAMeta,
+}
+
+/// Placement distribution from Design Arena tournament matches.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct DesignArenaTournamentStats {
+    pub first_place: Option<u64>,
+    pub second_place: Option<u64>,
+    pub third_place: Option<u64>,
+    pub fourth_place: Option<u64>,
+    pub total: Option<u64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// One Design Arena benchmark row.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarksDAItem {
+    pub model_permaslug: String,
+    pub display_name: String,
+    pub arena: String,
+    pub category: String,
+    pub elo: f64,
+    pub win_rate: f64,
+    pub avg_generation_time_ms: Option<f64>,
+    pub tournament_stats: DesignArenaTournamentStats,
+    pub pricing: Option<BenchmarkPricing>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// ELO bounds for a Design Arena response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct DesignArenaEloBounds {
+    pub min: f64,
+    pub max: f64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Metadata for Design Arena benchmark rows.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarksDAMeta {
+    pub as_of: String,
+    pub version: String,
+    pub source: String,
+    pub source_url: String,
+    pub citation: String,
+    pub model_count: u64,
+    pub arena: String,
+    pub category: Option<String>,
+    pub elo_bounds: DesignArenaEloBounds,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Design Arena benchmark dataset response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct BenchmarksDAResponse {
+    pub data: Vec<BenchmarksDAItem>,
+    pub meta: BenchmarksDAMeta,
+}
+
 /// List all providers (`GET /providers`).
 pub async fn list_providers(
     base_url: &str,
@@ -362,6 +539,140 @@ pub(crate) async fn get_rankings_daily_with_client(
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "rankings daily").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Return app rankings over a date window (`GET /datasets/app-rankings`).
+pub async fn get_app_rankings(
+    base_url: &str,
+    api_key: &str,
+    params: Option<&AppRankingsParams>,
+) -> Result<AppRankingsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_app_rankings_with_client(&http_client, base_url, api_key, params).await
+}
+
+pub(crate) async fn get_app_rankings_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    params: Option<&AppRankingsParams>,
+) -> Result<AppRankingsResponse, OpenRouterError> {
+    let url = format!("{base_url}/datasets/app-rankings");
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response = match params {
+        Some(params) if !params.is_empty() => req.query(params).send().await?,
+        _ => req.send().await?,
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "app rankings").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+#[derive(Serialize)]
+struct BenchmarkMaxResultsQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_results: Option<u32>,
+}
+
+/// Return Artificial Analysis benchmark rows.
+pub async fn get_benchmarks_artificial_analysis(
+    base_url: &str,
+    api_key: &str,
+    max_results: Option<u32>,
+) -> Result<BenchmarksAAResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_benchmarks_artificial_analysis_with_client(&http_client, base_url, api_key, max_results)
+        .await
+}
+
+pub(crate) async fn get_benchmarks_artificial_analysis_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    max_results: Option<u32>,
+) -> Result<BenchmarksAAResponse, OpenRouterError> {
+    let url = format!("{base_url}/datasets/benchmarks/artificial-analysis");
+    let query = BenchmarkMaxResultsQuery { max_results };
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response = if query.max_results.is_none() {
+        req.send().await?
+    } else {
+        req.query(&query).send().await?
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "Artificial Analysis benchmarks").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+#[derive(Serialize)]
+struct DesignArenaQuery<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arena: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_results: Option<u32>,
+}
+
+/// Return Design Arena benchmark rows.
+pub async fn get_benchmarks_design_arena(
+    base_url: &str,
+    api_key: &str,
+    arena: Option<&str>,
+    category: Option<&str>,
+    max_results: Option<u32>,
+) -> Result<BenchmarksDAResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_benchmarks_design_arena_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        arena,
+        category,
+        max_results,
+    )
+    .await
+}
+
+pub(crate) async fn get_benchmarks_design_arena_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    arena: Option<&str>,
+    category: Option<&str>,
+    max_results: Option<u32>,
+) -> Result<BenchmarksDAResponse, OpenRouterError> {
+    let url = format!("{base_url}/datasets/benchmarks/design-arena");
+    let query = DesignArenaQuery {
+        arena,
+        category,
+        max_results,
+    };
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response =
+        if query.arena.is_none() && query.category.is_none() && query.max_results.is_none() {
+            req.send().await?
+        } else {
+            req.query(&query).send().await?
+        };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "Design Arena benchmarks").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -1,0 +1,285 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use reqwest::{Client as HttpClient, multipart};
+use serde::{Deserialize, Serialize};
+use urlencoding::encode;
+
+use crate::{
+    error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
+};
+
+#[derive(Serialize)]
+struct FileWorkspaceQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ListFilesQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
+}
+
+/// Metadata describing a stored file.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct FileMetadata {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub object_type: String,
+    pub filename: String,
+    pub mime_type: String,
+    pub size_bytes: u64,
+    pub created_at: String,
+    pub downloadable: bool,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// A paginated page of files.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct FileListResponse {
+    pub data: Vec<FileMetadata>,
+    pub has_more: bool,
+    pub first_id: Option<String>,
+    pub last_id: Option<String>,
+    pub cursor: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Confirmation that a file was deleted.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct FileDeleteResponse {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub object_type: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// File upload payload for `POST /files`.
+#[derive(Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct UploadFileRequest {
+    #[builder(setter(into))]
+    pub filename: String,
+    #[builder(setter(into))]
+    pub content: Vec<u8>,
+    #[builder(setter(into, strip_option), default)]
+    pub mime_type: Option<String>,
+}
+
+impl UploadFileRequest {
+    pub fn builder() -> UploadFileRequestBuilder {
+        UploadFileRequestBuilder::default()
+    }
+}
+
+fn workspace_query(workspace_id: Option<&str>) -> FileWorkspaceQuery {
+    FileWorkspaceQuery {
+        workspace_id: workspace_id.map(ToOwned::to_owned),
+    }
+}
+
+fn apply_workspace_query(
+    req: reqwest::RequestBuilder,
+    workspace_id: Option<&str>,
+) -> reqwest::RequestBuilder {
+    let query = workspace_query(workspace_id);
+    if query.workspace_id.is_none() {
+        req
+    } else {
+        req.query(&query)
+    }
+}
+
+/// List files in the default or selected workspace (`GET /files`).
+pub async fn list_files(
+    base_url: &str,
+    api_key: &str,
+    limit: Option<u32>,
+    cursor: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<FileListResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_files_with_client(&http_client, base_url, api_key, limit, cursor, workspace_id).await
+}
+
+pub(crate) async fn list_files_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    limit: Option<u32>,
+    cursor: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<FileListResponse, OpenRouterError> {
+    let url = format!("{base_url}/files");
+    let query = ListFilesQuery {
+        limit,
+        cursor: cursor.map(ToOwned::to_owned),
+        workspace_id: workspace_id.map(ToOwned::to_owned),
+    };
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response =
+        if query.limit.is_none() && query.cursor.is_none() && query.workspace_id.is_none() {
+            req.send().await?
+        } else {
+            req.query(&query).send().await?
+        };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "file list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Upload a file into the default or selected workspace (`POST /files`).
+pub async fn upload_file(
+    base_url: &str,
+    api_key: &str,
+    request: &UploadFileRequest,
+    workspace_id: Option<&str>,
+) -> Result<FileMetadata, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    upload_file_with_client(&http_client, base_url, api_key, request, workspace_id).await
+}
+
+pub(crate) async fn upload_file_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    request: &UploadFileRequest,
+    workspace_id: Option<&str>,
+) -> Result<FileMetadata, OpenRouterError> {
+    let url = format!("{base_url}/files");
+    let mut part =
+        multipart::Part::bytes(request.content.clone()).file_name(request.filename.clone());
+    if let Some(mime_type) = &request.mime_type {
+        part = part
+            .mime_str(mime_type)
+            .map_err(|error| OpenRouterError::ConfigError(error.to_string()))?;
+    }
+    let form = multipart::Form::new().part("file", part);
+    let req =
+        transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key);
+    let response = apply_workspace_query(req, workspace_id)
+        .multipart(form)
+        .send()
+        .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "file upload").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Get metadata for one file (`GET /files/{file_id}`).
+pub async fn get_file_metadata(
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    workspace_id: Option<&str>,
+) -> Result<FileMetadata, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_file_metadata_with_client(&http_client, base_url, api_key, file_id, workspace_id).await
+}
+
+pub(crate) async fn get_file_metadata_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    workspace_id: Option<&str>,
+) -> Result<FileMetadata, OpenRouterError> {
+    let encoded_id = encode(file_id);
+    let url = format!("{base_url}/files/{encoded_id}");
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response = apply_workspace_query(req, workspace_id).send().await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "file metadata").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Download raw file content (`GET /files/{file_id}/content`).
+pub async fn download_file_content(
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    workspace_id: Option<&str>,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    download_file_content_with_client(&http_client, base_url, api_key, file_id, workspace_id).await
+}
+
+pub(crate) async fn download_file_content_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    workspace_id: Option<&str>,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let encoded_id = encode(file_id);
+    let url = format!("{base_url}/files/{encoded_id}/content");
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response = apply_workspace_query(req, workspace_id).send().await?;
+
+    if response.status().is_success() {
+        Ok(response.bytes().await?.to_vec())
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Delete one file (`DELETE /files/{file_id}`).
+pub async fn delete_file(
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    workspace_id: Option<&str>,
+) -> Result<FileDeleteResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_file_with_client(&http_client, base_url, api_key, file_id, workspace_id).await
+}
+
+pub(crate) async fn delete_file_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    workspace_id: Option<&str>,
+) -> Result<FileDeleteResponse, OpenRouterError> {
+    let encoded_id = encode(file_id);
+    let url = format!("{base_url}/files/{encoded_id}");
+    let req =
+        transport_request::with_bearer_auth(transport_request::delete(http_client, &url), api_key);
+    let response = apply_workspace_query(req, workspace_id).send().await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "file deletion").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/generation.rs
+++ b/src/api/generation.rs
@@ -16,6 +16,8 @@ pub struct GenerationData {
     pub id: String,
     pub total_cost: f64,
     pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_region: Option<String>,
     pub model: String,
     pub origin: String,
     pub usage: f64,
@@ -26,7 +28,7 @@ pub struct GenerationData {
     pub streamed: Option<bool>,
     pub cancelled: Option<bool>,
     pub provider_name: Option<String>,
-    pub latency: Option<u32>,
+    pub latency: Option<f64>,
     pub moderation_latency: Option<u32>,
     pub generation_time: Option<u32>,
     pub finish_reason: Option<String>,
@@ -43,6 +45,8 @@ pub struct GenerationData {
     pub preset_id: Option<String>,
     pub response_cache_source_id: Option<String>,
     pub service_tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
 }
 
 /// Stored prompt/input and completion/output content returned by `GET /generation/content`.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -116,6 +116,7 @@
 //! # }
 //! ```
 
+pub mod analytics;
 pub mod api_keys;
 pub mod audio;
 pub mod auth;
@@ -125,6 +126,7 @@ pub mod credits;
 pub mod discovery;
 pub mod embeddings;
 pub mod errors;
+pub mod files;
 pub mod generation;
 pub mod guardrails;
 pub mod messages;

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,5 +1,9 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use urlencoding::encode;
 
 use crate::{
@@ -8,39 +12,70 @@ use crate::{
     types::{ApiResponse, ModelCategory, SupportedParameters},
 };
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct Model {
     pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hugging_face_id: Option<String>,
     pub name: String,
     pub created: f64,
+    #[serde(default)]
     pub description: String,
-    pub context_length: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<f64>,
     pub architecture: Architecture,
     pub top_provider: TopProvider,
     pub pricing: Pricing,
-    pub per_request_limits: Option<std::collections::HashMap<String, String>>,
+    pub per_request_limits: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub supported_parameters: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_voices: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expiration_date: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub knowledge_cutoff: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<ModelLinks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub benchmarks: Option<ModelBenchmarks>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct Architecture {
-    pub modality: String,
-    pub tokenizer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modality: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokenizer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruct_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_modalities: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_modalities: Option<Vec<String>>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct TopProvider {
     pub context_length: Option<f64>,
     pub max_completion_tokens: Option<f64>,
     pub is_moderated: bool,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct Pricing {
     pub prompt: String,
@@ -51,9 +86,52 @@ pub struct Pricing {
     pub input_cache_write: Option<String>,
     pub web_search: Option<String>,
     pub internal_reasoning: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ModelLinks {
+    pub details: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AABenchmarkEntry {
+    pub intelligence_index: Option<f64>,
+    pub coding_index: Option<f64>,
+    pub agentic_index: Option<f64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct DABenchmarkEntry {
+    pub arena: String,
+    pub category: String,
+    pub elo: f64,
+    pub win_rate: f64,
+    pub rank: u64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ModelBenchmarks {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artificial_analysis: Option<AABenchmarkEntry>,
+    #[serde(default)]
+    pub design_arena: Vec<DABenchmarkEntry>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct Endpoint {
     pub name: String,
@@ -67,7 +145,7 @@ pub struct Endpoint {
     pub status: Option<serde_json::Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct EndpointPricing {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +156,7 @@ pub struct EndpointPricing {
     pub completion: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct EndpointData {
     pub id: String,
@@ -89,12 +167,88 @@ pub struct EndpointData {
     pub endpoints: Vec<Endpoint>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct EndpointArchitecture {
     pub tokenizer: Option<String>,
     pub instruct_type: Option<String>,
     pub modality: Option<String>,
+}
+
+/// Extended query parameters for `GET /models`.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct ListModelsParams {
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<ModelCategory>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_parameters: Option<SupportedParameters>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_modalities: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub q: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_modalities: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<u32>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_price: Option<f64>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_price: Option<f64>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arch: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_authors: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub providers: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distillable: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zdr: Option<bool>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+}
+
+impl ListModelsParams {
+    pub fn builder() -> ListModelsParamsBuilder {
+        ListModelsParamsBuilder::default()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.category.is_none()
+            && self.supported_parameters.is_none()
+            && self.output_modalities.is_none()
+            && self.sort.is_none()
+            && self.q.is_none()
+            && self.input_modalities.is_none()
+            && self.context.is_none()
+            && self.min_price.is_none()
+            && self.max_price.is_none()
+            && self.arch.is_none()
+            && self.model_authors.is_none()
+            && self.providers.is_none()
+            && self.distillable.is_none()
+            && self.zdr.is_none()
+            && self.region.is_none()
+    }
 }
 
 /// Returns a list of models available through the API
@@ -116,14 +270,12 @@ pub async fn list_models(
     supported_parameters: Option<SupportedParameters>,
 ) -> Result<Vec<Model>, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
-    list_models_with_client(
-        &http_client,
-        base_url,
-        api_key,
+    let params = ListModelsParams {
         category,
         supported_parameters,
-    )
-    .await
+        ..Default::default()
+    };
+    list_models_with_params_and_client(&http_client, base_url, api_key, Some(&params)).await
 }
 
 pub(crate) async fn list_models_with_client(
@@ -133,32 +285,79 @@ pub(crate) async fn list_models_with_client(
     category: Option<ModelCategory>,
     supported_parameters: Option<SupportedParameters>,
 ) -> Result<Vec<Model>, OpenRouterError> {
-    #[derive(Serialize)]
-    struct ListModelsQuery {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        category: Option<ModelCategory>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        supported_parameters: Option<SupportedParameters>,
-    }
-
-    let url = format!("{base_url}/models");
-    let query = ListModelsQuery {
+    let params = ListModelsParams {
         category,
         supported_parameters,
+        ..Default::default()
     };
+    list_models_with_params_and_client(http_client, base_url, api_key, Some(&params)).await
+}
 
+/// Returns a list of models using the full upstream filter surface.
+pub async fn list_models_with_params(
+    base_url: &str,
+    api_key: &str,
+    params: Option<&ListModelsParams>,
+) -> Result<Vec<Model>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_models_with_params_and_client(&http_client, base_url, api_key, params).await
+}
+
+pub(crate) async fn list_models_with_params_and_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    params: Option<&ListModelsParams>,
+) -> Result<Vec<Model>, OpenRouterError> {
+    let url = format!("{base_url}/models");
     let req =
         transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
-    let response = if query.category.is_none() && query.supported_parameters.is_none() {
-        req.send().await?
-    } else {
-        req.query(&query).send().await?
+    let response = match params {
+        Some(params) if !params.is_empty() => req.query(params).send().await?,
+        _ => req.send().await?,
     };
 
     if response.status().is_success() {
         let model_list_response: ApiResponse<_> =
             transport_response::parse_json_response(response, "model list").await?;
         Ok(model_list_response.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Returns metadata about a specific model.
+pub async fn get_model(
+    base_url: &str,
+    api_key: &str,
+    author: &str,
+    slug: &str,
+) -> Result<Model, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_model_with_client(&http_client, base_url, api_key, author, slug).await
+}
+
+pub(crate) async fn get_model_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    author: &str,
+    slug: &str,
+) -> Result<Model, OpenRouterError> {
+    let encoded_author = encode(author);
+    let encoded_slug = encode(slug);
+    let url = format!("{base_url}/model/{encoded_author}/{encoded_slug}");
+
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        let model_response: ApiResponse<_> =
+            transport_response::parse_json_response(response, "model").await?;
+        Ok(model_response.data)
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/api/presets.rs
+++ b/src/api/presets.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     error::OpenRouterError,
     transport::{request as transport_request, response as transport_response},
-    types::ApiResponse,
+    types::{ApiResponse, PaginationOptions},
 };
 
 /// A specific version of a preset, containing persisted config and optional system prompt.
@@ -28,6 +28,50 @@ pub struct PresetDesignatedVersion {
     pub config: HashMap<String, Value>,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Preset metadata without version details.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct Preset {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creator_user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    pub name: String,
+    pub slug: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub designated_version_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_updated_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Paginated preset list response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ListPresetsResponse {
+    pub data: Vec<Preset>,
+    pub total_count: u64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Paginated preset-version list response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ListPresetVersionsResponse {
+    pub data: Vec<PresetDesignatedVersion>,
+    pub total_count: u64,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
@@ -61,6 +105,167 @@ pub struct PresetWithDesignatedVersion {
 fn preset_url(base_url: &str, slug: &str, suffix: &str) -> String {
     let encoded_slug = encode(slug);
     format!("{base_url}/presets/{encoded_slug}/{suffix}")
+}
+
+fn with_pagination(url: String, pagination: Option<PaginationOptions>) -> String {
+    let Some(pagination) = pagination else {
+        return url;
+    };
+
+    let query = pagination.to_query_pairs();
+    if query.is_empty() {
+        return url;
+    }
+
+    let query = query
+        .into_iter()
+        .map(|(key, value)| format!("{key}={}", encode(&value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{url}?{query}")
+}
+
+/// List presets (`GET /presets`).
+pub async fn list_presets(
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListPresetsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_presets_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_presets_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListPresetsResponse, OpenRouterError> {
+    let url = with_pagination(format!("{base_url}/presets"), pagination);
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "preset list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Get a preset with its designated version (`GET /presets/{slug}`).
+pub async fn get_preset(
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_preset_with_client(&http_client, base_url, management_key, slug).await
+}
+
+pub(crate) async fn get_preset_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+) -> Result<PresetWithDesignatedVersion, OpenRouterError> {
+    let encoded_slug = encode(slug);
+    let url = format!("{base_url}/presets/{encoded_slug}");
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<PresetWithDesignatedVersion> =
+            transport_response::parse_json_response(response, "preset").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// List versions for a preset (`GET /presets/{slug}/versions`).
+pub async fn list_preset_versions(
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListPresetVersionsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_preset_versions_with_client(&http_client, base_url, management_key, slug, pagination).await
+}
+
+pub(crate) async fn list_preset_versions_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListPresetVersionsResponse, OpenRouterError> {
+    let encoded_slug = encode(slug);
+    let url = with_pagination(
+        format!("{base_url}/presets/{encoded_slug}/versions"),
+        pagination,
+    );
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "preset version list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Get a specific preset version (`GET /presets/{slug}/versions/{version}`).
+pub async fn get_preset_version(
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    version: &str,
+) -> Result<PresetDesignatedVersion, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_preset_version_with_client(&http_client, base_url, management_key, slug, version).await
+}
+
+pub(crate) async fn get_preset_version_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    slug: &str,
+    version: &str,
+) -> Result<PresetDesignatedVersion, OpenRouterError> {
+    let encoded_slug = encode(slug);
+    let encoded_version = encode(version);
+    let url = format!("{base_url}/presets/{encoded_slug}/versions/{encoded_version}");
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<PresetDesignatedVersion> =
+            transport_response::parse_json_response(response, "preset version").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
 }
 
 async fn create_preset_with_client<T: Serialize + ?Sized>(

--- a/src/api/rerank.rs
+++ b/src/api/rerank.rs
@@ -8,6 +8,49 @@ use crate::{
     types::ProviderPreferences,
 };
 
+/// One document input accepted by rerank requests.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum RerankDocumentInput {
+    Text(String),
+    Multimodal {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        text: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        image: Option<String>,
+    },
+}
+
+impl RerankDocumentInput {
+    pub fn text(value: impl Into<String>) -> Self {
+        Self::Text(value.into())
+    }
+
+    pub fn multimodal<T, U>(text: Option<T>, image: Option<U>) -> Self
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        Self::Multimodal {
+            text: text.map(Into::into),
+            image: image.map(Into::into),
+        }
+    }
+}
+
+impl From<String> for RerankDocumentInput {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for RerankDocumentInput {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
 /// Request payload for `POST /rerank`.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
@@ -17,7 +60,8 @@ pub struct RerankRequest {
     pub model: String,
     #[builder(setter(into))]
     pub query: String,
-    pub documents: Vec<String>,
+    #[builder(setter(custom))]
+    pub documents: Vec<RerankDocumentInput>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_n: Option<u32>,
@@ -29,6 +73,17 @@ pub struct RerankRequest {
 impl RerankRequest {
     pub fn builder() -> RerankRequestBuilder {
         RerankRequestBuilder::default()
+    }
+}
+
+impl RerankRequestBuilder {
+    pub fn documents<T, S>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<RerankDocumentInput>,
+    {
+        self.documents = Some(items.into_iter().map(Into::into).collect());
+        self
     }
 }
 

--- a/src/api/rerank.rs
+++ b/src/api/rerank.rs
@@ -91,7 +91,10 @@ impl RerankRequestBuilder {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct RerankDocument {
-    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
 }
 
 /// One scored rerank result.

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -23,20 +23,49 @@ impl VideoImageUrl {
     }
 }
 
-/// Reference image used to guide video generation.
+/// Reference media used to guide video generation.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub struct VideoInputReference {
     #[serde(rename = "type")]
     pub content_type: String,
-    pub image_url: VideoImageUrl,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<VideoImageUrl>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_url: Option<VideoImageUrl>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video_url: Option<VideoImageUrl>,
 }
 
 impl VideoInputReference {
     pub fn new(url: impl Into<String>) -> Self {
+        Self::image(url)
+    }
+
+    pub fn image(url: impl Into<String>) -> Self {
         Self {
             content_type: "image_url".to_string(),
-            image_url: VideoImageUrl::new(url),
+            image_url: Some(VideoImageUrl::new(url)),
+            audio_url: None,
+            video_url: None,
+        }
+    }
+
+    pub fn audio(url: impl Into<String>) -> Self {
+        Self {
+            content_type: "audio_url".to_string(),
+            image_url: None,
+            audio_url: Some(VideoImageUrl::new(url)),
+            video_url: None,
+        }
+    }
+
+    pub fn video(url: impl Into<String>) -> Self {
+        Self {
+            content_type: "video_url".to_string(),
+            image_url: None,
+            audio_url: None,
+            video_url: Some(VideoImageUrl::new(url)),
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,9 +5,9 @@ use futures_util::stream::BoxStream;
 use crate::api::legacy::completion;
 use crate::{
     api::{
-        api_keys, audio, auth, byok, chat, credits, discovery, embeddings, generation, guardrails,
-        messages, models, observability, organization, presets, rerank, responses, videos,
-        workspaces,
+        analytics, api_keys, audio, auth, byok, chat, credits, discovery, embeddings, files,
+        generation, guardrails, messages, models, observability, organization, presets, rerank,
+        responses, videos, workspaces,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -150,6 +150,11 @@ impl OpenRouterClient {
     /// Domain client for video generation operations.
     pub fn videos(&self) -> VideosClient<'_> {
         VideosClient { client: self }
+    }
+
+    /// Domain client for file upload, metadata, content, and deletion operations.
+    pub fn files(&self) -> FilesClient<'_> {
+        FilesClient { client: self }
     }
 
     /// Domain client for model/discovery/embedding operations.
@@ -1130,6 +1135,82 @@ impl OpenRouterClient {
         }
     }
 
+    /// List presets for the configured management key.
+    pub async fn list_presets(
+        &self,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<presets::ListPresetsResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::list_presets_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                pagination,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Get one preset with its designated version.
+    pub async fn get_preset(
+        &self,
+        slug: &str,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::get_preset_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                slug,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List versions for one preset.
+    pub async fn list_preset_versions(
+        &self,
+        slug: &str,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<presets::ListPresetVersionsResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::list_preset_versions_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                slug,
+                pagination,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Get a specific preset version.
+    pub async fn get_preset_version(
+        &self,
+        slug: &str,
+        version: &str,
+    ) -> Result<presets::PresetDesignatedVersion, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            presets::get_preset_version_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                slug,
+                version,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Submit an embeddings request.
     ///
     /// # Arguments
@@ -1292,6 +1373,108 @@ impl OpenRouterClient {
                 api_key,
                 job_id,
                 index,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List files in the default or selected workspace.
+    pub async fn list_files(
+        &self,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileListResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            files::list_files_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                limit,
+                cursor,
+                workspace_id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Upload a file into the default or selected workspace.
+    pub async fn upload_file(
+        &self,
+        request: &files::UploadFileRequest,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileMetadata, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            files::upload_file_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                request,
+                workspace_id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Get metadata for one file.
+    pub async fn get_file_metadata(
+        &self,
+        file_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileMetadata, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            files::get_file_metadata_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                file_id,
+                workspace_id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Download raw content for one file.
+    pub async fn download_file_content(
+        &self,
+        file_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<u8>, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            files::download_file_content_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                file_id,
+                workspace_id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Delete one file.
+    pub async fn delete_file(
+        &self,
+        file_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileDeleteResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            files::delete_file_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                file_id,
+                workspace_id,
             )
             .await
         } else {
@@ -1474,6 +1657,38 @@ impl OpenRouterClient {
         }
     }
 
+    /// Returns a list of models using the extended OpenAPI filter surface.
+    pub async fn list_models_filtered(
+        &self,
+        params: Option<&models::ListModelsParams>,
+    ) -> Result<Vec<models::Model>, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            models::list_models_with_params_and_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                params,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Returns metadata about one model.
+    pub async fn get_model(
+        &self,
+        author: &str,
+        slug: &str,
+    ) -> Result<models::Model, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            models::get_model_with_client(self.http_client(), &self.base_url, api_key, author, slug)
+                .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Returns a list of models available through the API by category.
     ///
     /// # Arguments
@@ -1650,6 +1865,64 @@ impl OpenRouterClient {
         }
     }
 
+    /// Return ranked applications over a date window.
+    pub async fn get_app_rankings(
+        &self,
+        params: Option<&discovery::AppRankingsParams>,
+    ) -> Result<discovery::AppRankingsResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            discovery::get_app_rankings_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                params,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Return Artificial Analysis benchmark rows.
+    pub async fn get_benchmarks_artificial_analysis(
+        &self,
+        max_results: Option<u32>,
+    ) -> Result<discovery::BenchmarksAAResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            discovery::get_benchmarks_artificial_analysis_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                max_results,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Return Design Arena benchmark rows.
+    pub async fn get_benchmarks_design_arena(
+        &self,
+        arena: Option<&str>,
+        category: Option<&str>,
+        max_results: Option<u32>,
+    ) -> Result<discovery::BenchmarksDAResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            discovery::get_benchmarks_design_arena_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                arena,
+                category,
+                max_results,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Preview ZDR-compatible endpoints.
     ///
     /// Equivalent to `GET /endpoints/zdr`.
@@ -1682,6 +1955,38 @@ impl OpenRouterClient {
                 &self.base_url,
                 management_key,
                 date,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Get analytics metadata (`GET /analytics/meta`).
+    pub async fn get_analytics_meta(&self) -> Result<analytics::AnalyticsMeta, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            analytics::get_analytics_meta_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Query analytics (`POST /analytics/query`).
+    pub async fn query_analytics(
+        &self,
+        request: &analytics::AnalyticsQueryRequest,
+    ) -> Result<analytics::AnalyticsQueryResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            analytics::query_analytics_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                request,
             )
             .await
         } else {
@@ -2252,6 +2557,62 @@ impl<'a> VideosClient<'a> {
     }
 }
 
+/// Domain client for file endpoints.
+#[derive(Debug, Clone, Copy)]
+pub struct FilesClient<'a> {
+    client: &'a OpenRouterClient,
+}
+
+impl<'a> FilesClient<'a> {
+    /// List files (`GET /files`).
+    pub async fn list(
+        &self,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileListResponse, OpenRouterError> {
+        self.client.list_files(limit, cursor, workspace_id).await
+    }
+
+    /// Upload a file (`POST /files`).
+    pub async fn upload(
+        &self,
+        request: &files::UploadFileRequest,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileMetadata, OpenRouterError> {
+        self.client.upload_file(request, workspace_id).await
+    }
+
+    /// Get file metadata (`GET /files/{file_id}`).
+    pub async fn get_metadata(
+        &self,
+        file_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileMetadata, OpenRouterError> {
+        self.client.get_file_metadata(file_id, workspace_id).await
+    }
+
+    /// Download file content (`GET /files/{file_id}/content`).
+    pub async fn download_content(
+        &self,
+        file_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<u8>, OpenRouterError> {
+        self.client
+            .download_file_content(file_id, workspace_id)
+            .await
+    }
+
+    /// Delete a file (`DELETE /files/{file_id}`).
+    pub async fn delete(
+        &self,
+        file_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<files::FileDeleteResponse, OpenRouterError> {
+        self.client.delete_file(file_id, workspace_id).await
+    }
+}
+
 /// Domain client for model/discovery/embedding endpoints.
 #[derive(Debug, Clone, Copy)]
 pub struct ModelsClient<'a> {
@@ -2262,6 +2623,14 @@ impl<'a> ModelsClient<'a> {
     /// List all models (`GET /models`).
     pub async fn list(&self) -> Result<Vec<models::Model>, OpenRouterError> {
         self.client.list_models().await
+    }
+
+    /// List models with the extended filter surface (`GET /models?...`).
+    pub async fn list_filtered(
+        &self,
+        params: Option<&models::ListModelsParams>,
+    ) -> Result<Vec<models::Model>, OpenRouterError> {
+        self.client.list_models_filtered(params).await
     }
 
     /// List models by category (`GET /models?category=...`).
@@ -2291,6 +2660,11 @@ impl<'a> ModelsClient<'a> {
         self.client.list_model_endpoints(author, slug).await
     }
 
+    /// Get metadata about one model (`GET /model/{author}/{slug}`).
+    pub async fn get(&self, author: &str, slug: &str) -> Result<models::Model, OpenRouterError> {
+        self.client.get_model(author, slug).await
+    }
+
     /// List providers (`GET /providers`).
     pub async fn list_providers(&self) -> Result<Vec<discovery::Provider>, OpenRouterError> {
         self.client.list_providers().await
@@ -2313,6 +2687,36 @@ impl<'a> ModelsClient<'a> {
         end_date: Option<&str>,
     ) -> Result<discovery::RankingsDailyResponse, OpenRouterError> {
         self.client.get_rankings_daily(start_date, end_date).await
+    }
+
+    /// Return ranked applications (`GET /datasets/app-rankings`).
+    pub async fn get_app_rankings(
+        &self,
+        params: Option<&discovery::AppRankingsParams>,
+    ) -> Result<discovery::AppRankingsResponse, OpenRouterError> {
+        self.client.get_app_rankings(params).await
+    }
+
+    /// Return Artificial Analysis benchmark rows.
+    pub async fn get_benchmarks_artificial_analysis(
+        &self,
+        max_results: Option<u32>,
+    ) -> Result<discovery::BenchmarksAAResponse, OpenRouterError> {
+        self.client
+            .get_benchmarks_artificial_analysis(max_results)
+            .await
+    }
+
+    /// Return Design Arena benchmark rows.
+    pub async fn get_benchmarks_design_arena(
+        &self,
+        arena: Option<&str>,
+        category: Option<&str>,
+        max_results: Option<u32>,
+    ) -> Result<discovery::BenchmarksDAResponse, OpenRouterError> {
+        self.client
+            .get_benchmarks_design_arena(arena, category, max_results)
+            .await
     }
 
     /// List ZDR-compatible endpoints (`GET /endpoints/zdr`).
@@ -2398,6 +2802,40 @@ impl<'a> ManagementClient<'a> {
         request: &messages::AnthropicMessagesRequest,
     ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
         self.client.create_message_preset(slug, request).await
+    }
+
+    /// List presets (`GET /presets`).
+    pub async fn list_presets(
+        &self,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<presets::ListPresetsResponse, OpenRouterError> {
+        self.client.list_presets(pagination).await
+    }
+
+    /// Get one preset (`GET /presets/{slug}`).
+    pub async fn get_preset(
+        &self,
+        slug: &str,
+    ) -> Result<presets::PresetWithDesignatedVersion, OpenRouterError> {
+        self.client.get_preset(slug).await
+    }
+
+    /// List preset versions (`GET /presets/{slug}/versions`).
+    pub async fn list_preset_versions(
+        &self,
+        slug: &str,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<presets::ListPresetVersionsResponse, OpenRouterError> {
+        self.client.list_preset_versions(slug, pagination).await
+    }
+
+    /// Get a preset version (`GET /presets/{slug}/versions/{version}`).
+    pub async fn get_preset_version(
+        &self,
+        slug: &str,
+        version: &str,
+    ) -> Result<presets::PresetDesignatedVersion, OpenRouterError> {
+        self.client.get_preset_version(slug, version).await
     }
 
     /// Delete an API key (`DELETE /keys/{hash}`).
@@ -2501,6 +2939,19 @@ impl<'a> ManagementClient<'a> {
         date: Option<&str>,
     ) -> Result<Vec<discovery::ActivityItem>, OpenRouterError> {
         self.client.get_activity(date).await
+    }
+
+    /// Get analytics metadata (`GET /analytics/meta`).
+    pub async fn get_analytics_meta(&self) -> Result<analytics::AnalyticsMeta, OpenRouterError> {
+        self.client.get_analytics_meta().await
+    }
+
+    /// Query analytics (`POST /analytics/query`).
+    pub async fn query_analytics(
+        &self,
+        request: &analytics::AnalyticsQueryRequest,
+    ) -> Result<analytics::AnalyticsQueryResponse, OpenRouterError> {
+        self.client.query_analytics(request).await
     }
 
     /// List BYOK provider credentials (`GET /byok`).

--- a/src/transport/request.rs
+++ b/src/transport/request.rs
@@ -69,10 +69,7 @@ pub(crate) fn with_experimental_metadata_header(
     experimental_metadata: &Option<OpenRouterExperimentalMetadata>,
 ) -> RequestBuilder {
     if let Some(level) = experimental_metadata {
-        req.header(
-            "X-OpenRouter-Experimental-Metadata",
-            level.as_header_value(),
-        )
+        req.header("X-OpenRouter-Metadata", level.as_header_value())
     } else {
         req
     }
@@ -209,7 +206,7 @@ mod tests {
         assert_eq!(
             request
                 .headers()
-                .get("X-OpenRouter-Experimental-Metadata")
+                .get("X-OpenRouter-Metadata")
                 .expect("experimental metadata header should exist"),
             "enabled"
         );

--- a/tests/unit/analytics.rs
+++ b/tests/unit/analytics.rs
@@ -1,0 +1,237 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::api::analytics::{
+    self, AnalyticsFilter, AnalyticsFilterValue, AnalyticsMeta, AnalyticsOrderBy,
+    AnalyticsQueryRequest, AnalyticsQueryResponse, AnalyticsTimeRange,
+};
+use serde_json::json;
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+#[test]
+fn test_analytics_meta_response_deserializes() {
+    let raw = r#"{
+        "data": {
+            "metrics": [{
+                "name": "request_count",
+                "display_label": "Request Count",
+                "is_rate": false,
+                "display_format": "number"
+            }],
+            "dimensions": [{
+                "name": "model",
+                "display_label": "Model"
+            }],
+            "operators": [{
+                "name": "eq",
+                "value_type": "scalar"
+            }],
+            "granularities": [{
+                "name": "day",
+                "display_label": "Day"
+            }]
+        }
+    }"#;
+
+    let parsed: openrouter_rs::types::ApiResponse<AnalyticsMeta> =
+        serde_json::from_str(raw).expect("analytics meta should deserialize");
+    assert_eq!(parsed.data.metrics[0].name, "request_count");
+    assert_eq!(parsed.data.granularities[0].name, "day");
+}
+
+#[test]
+fn test_analytics_query_response_deserializes() {
+    let raw = r#"{
+        "data": {
+            "cachedAt": 1780000000.0,
+            "data": [{
+                "date__day": "2026-06-15T00:00:00.000Z",
+                "request_count": 1500
+            }],
+            "metadata": {
+                "query_time_ms": 42,
+                "row_count": 1,
+                "truncated": false
+            }
+        }
+    }"#;
+
+    let parsed: openrouter_rs::types::ApiResponse<AnalyticsQueryResponse> =
+        serde_json::from_str(raw).expect("analytics query response should deserialize");
+    assert_eq!(parsed.data.metadata.row_count, 1);
+    assert_eq!(parsed.data.data[0]["request_count"], json!(1500));
+}
+
+#[tokio::test]
+async fn test_get_analytics_meta_path_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"metrics":[],"dimensions":[],"operators":[],"granularities":[]}}"#,
+    );
+
+    let meta = analytics::get_analytics_meta(&base_url, "management-key")
+        .await
+        .expect("analytics meta request should succeed");
+    assert!(meta.metrics.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "GET /api/v1/analytics/meta HTTP/1.1");
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer management-key")
+            || request_lower.contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_query_analytics_path_body_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"data":[],"metadata":{"query_time_ms":5,"row_count":0,"truncated":false}}}"#,
+    );
+    let request = AnalyticsQueryRequest::builder()
+        .metrics(vec!["request_count".to_string()])
+        .dimensions(vec!["model".to_string()])
+        .filters(vec![AnalyticsFilter {
+            field: "model".to_string(),
+            operator: "eq".to_string(),
+            value: AnalyticsFilterValue::String("openai/gpt-5".to_string()),
+        }])
+        .granularity("day")
+        .time_range(AnalyticsTimeRange {
+            start: "2026-06-01T00:00:00Z".to_string(),
+            end: "2026-06-15T00:00:00Z".to_string(),
+        })
+        .order_by(AnalyticsOrderBy {
+            field: "request_count".to_string(),
+            direction: "desc".to_string(),
+        })
+        .limit(100)
+        .group_limit(10)
+        .build()
+        .expect("analytics query request should build");
+
+    let response = analytics::query_analytics(&base_url, "management-key", &request)
+        .await
+        .expect("analytics query request should succeed");
+    assert_eq!(response.metadata.row_count, 0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/analytics/query HTTP/1.1"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be json");
+    assert_eq!(body["metrics"][0], "request_count");
+    assert_eq!(body["dimensions"][0], "model");
+    assert_eq!(body["filters"][0]["value"], "openai/gpt-5");
+    assert_eq!(body["time_range"]["start"], "2026-06-01T00:00:00Z");
+
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer management-key")
+            || request_lower.contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/auth.rs
+++ b/tests/unit/auth.rs
@@ -21,6 +21,7 @@ fn test_create_auth_code_request_serialization() {
         .usage_limit_type(UsageLimitType::Monthly)
         .spawn_agent("sdk")
         .spawn_cloud("aws")
+        .workspace_id("ws_123")
         .build()
         .expect("request should build");
 
@@ -32,6 +33,7 @@ fn test_create_auth_code_request_serialization() {
     assert_eq!(value["usage_limit_type"], "monthly");
     assert_eq!(value["spawn_agent"], "sdk");
     assert_eq!(value["spawn_cloud"], "aws");
+    assert_eq!(value["workspace_id"], "ws_123");
 }
 
 #[test]

--- a/tests/unit/chat_api.rs
+++ b/tests/unit/chat_api.rs
@@ -174,8 +174,8 @@ async fn test_send_chat_completion_sets_stream_false_and_headers() {
         captured.header_text
     );
     assert!(
-        headers_lower.contains("x-openrouter-experimental-metadata: enabled")
-            || headers_lower.contains("x-openrouter-experimental-metadata:enabled"),
+        headers_lower.contains("x-openrouter-metadata: enabled")
+            || headers_lower.contains("x-openrouter-metadata:enabled"),
         "experimental metadata header should be present, headers:\n{}",
         captured.header_text
     );

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -9,8 +9,8 @@ use std::{
 use openrouter_rs::{
     OpenRouterClient,
     api::{
-        audio, auth, byok, chat, credits, embeddings, guardrails, messages, observability, rerank,
-        responses, videos, workspaces,
+        analytics, audio, auth, byok, chat, credits, embeddings, files, guardrails, messages,
+        observability, rerank, responses, videos, workspaces,
     },
     error::OpenRouterError,
     types::{ModelCategory, PaginationOptions, Role, SupportedParameters},
@@ -314,6 +314,30 @@ async fn test_models_domain_renamed_methods_require_api_key() {
     let rankings = client.models().get_rankings_daily(None, None).await;
     assert!(matches!(rankings, Err(OpenRouterError::KeyNotConfigured)));
 
+    let filtered = client.models().list_filtered(None).await;
+    assert!(matches!(filtered, Err(OpenRouterError::KeyNotConfigured)));
+
+    let model = client.models().get("openai", "gpt-4").await;
+    assert!(matches!(model, Err(OpenRouterError::KeyNotConfigured)));
+
+    let app_rankings = client.models().get_app_rankings(None).await;
+    assert!(matches!(
+        app_rankings,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+
+    let aa = client
+        .models()
+        .get_benchmarks_artificial_analysis(Some(10))
+        .await;
+    assert!(matches!(aa, Err(OpenRouterError::KeyNotConfigured)));
+
+    let da = client
+        .models()
+        .get_benchmarks_design_arena(Some("models"), None, Some(10))
+        .await;
+    assert!(matches!(da, Err(OpenRouterError::KeyNotConfigured)));
+
     let by_category = client
         .models()
         .list_by_category(ModelCategory::Programming)
@@ -355,6 +379,39 @@ async fn test_models_domain_renamed_methods_require_api_key() {
     let embedding_models = client.models().list_embedding_models().await;
     assert!(matches!(
         embedding_models,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+}
+
+#[tokio::test]
+async fn test_files_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let upload = files::UploadFileRequest::builder()
+        .filename("note.txt")
+        .content(b"hello".to_vec())
+        .build()
+        .expect("upload request should build");
+
+    assert!(matches!(
+        client.files().list(None, None, None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().upload(&upload, None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().get_metadata("file_123", None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().download_content("file_123", None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().delete("file_123", None).await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
 }
@@ -542,6 +599,10 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         .messages(vec![messages::AnthropicMessage::user("hello")])
         .build()
         .expect("message preset request should build");
+    let analytics_request = analytics::AnalyticsQueryRequest::builder()
+        .metrics(vec!["request_count".to_string()])
+        .build()
+        .expect("analytics request should build");
 
     assert!(matches!(
         client.management().get_current_api_key_info().await,
@@ -565,6 +626,28 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         client
             .management()
             .create_message_preset("my-preset", &message_preset_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().list_presets(None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().get_preset("my-preset").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .list_preset_versions("my-preset", None)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .get_preset_version("my-preset", "1")
             .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
@@ -635,6 +718,17 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
     ));
     assert!(matches!(
         client.management().get_activity(Some("2026-03-11")).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().get_analytics_meta().await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .query_analytics(&analytics_request)
+            .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -8,7 +8,8 @@ use std::{
 
 use openrouter_rs::{
     api::discovery::{
-        self, ActivityItem, BigNumber, ModelsCountData, Provider, PublicEndpoint,
+        self, ActivityItem, AppRankingsParams, AppRankingsResponse, BenchmarksAAResponse,
+        BenchmarksDAResponse, BigNumber, ModelsCountData, Provider, PublicEndpoint,
         RankingsDailyResponse, UserModel,
     },
     types::ApiResponse,
@@ -248,6 +249,105 @@ fn test_rankings_daily_response_deserialization() {
     assert_eq!(parsed.meta.version, "v1");
 }
 
+#[test]
+fn test_app_rankings_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "rank": 1,
+            "app_id": 12345,
+            "app_name": "Cline",
+            "total_tokens": "12345678",
+            "total_requests": 4321
+        }],
+        "meta": {
+            "as_of": "2026-05-12T02:00:00Z",
+            "version": "v1",
+            "start_date": "2026-04-12",
+            "end_date": "2026-05-11"
+        }
+    }"#;
+
+    let parsed: AppRankingsResponse =
+        serde_json::from_str(raw).expect("app rankings response should deserialize");
+    assert_eq!(parsed.data[0].app_name, "Cline");
+    assert_eq!(parsed.data[0].total_tokens, "12345678");
+    assert_eq!(parsed.meta.start_date, "2026-04-12");
+}
+
+#[test]
+fn test_benchmark_dataset_responses_deserialize() {
+    let artificial_raw = r#"{
+        "data": [{
+            "model_permaslug": "openai/gpt-4o",
+            "aa_name": "GPT-4o",
+            "intelligence_index": 71.2,
+            "coding_index": 65.8,
+            "agentic_index": 58.3,
+            "pricing": {
+                "prompt": "0.0000025",
+                "completion": "0.00001"
+            }
+        }],
+        "meta": {
+            "as_of": "2026-06-03T12:00:00Z",
+            "version": "v1",
+            "source": "artificial-analysis",
+            "source_url": "https://artificialanalysis.ai",
+            "citation": "Source: Artificial Analysis via OpenRouter.",
+            "model_count": 1
+        }
+    }"#;
+    let artificial: BenchmarksAAResponse =
+        serde_json::from_str(artificial_raw).expect("AA benchmark response should deserialize");
+    assert_eq!(artificial.data[0].aa_name, "GPT-4o");
+    assert_eq!(
+        artificial.data[0]
+            .pricing
+            .as_ref()
+            .expect("pricing should be present")
+            .prompt,
+        "0.0000025"
+    );
+
+    let design_raw = r#"{
+        "data": [{
+            "model_permaslug": "anthropic/claude-sonnet-4",
+            "display_name": "Claude Sonnet 4",
+            "arena": "models",
+            "category": "codecategories",
+            "elo": 1423,
+            "win_rate": 72,
+            "avg_generation_time_ms": 3200,
+            "tournament_stats": {
+                "first_place": 12,
+                "second_place": 8,
+                "third_place": 5,
+                "fourth_place": 2,
+                "total": 27
+            },
+            "pricing": null
+        }],
+        "meta": {
+            "as_of": "2026-06-03T12:00:00Z",
+            "version": "v1",
+            "source": "design-arena",
+            "source_url": "https://www.designarena.ai",
+            "citation": "Source: Design Arena via OpenRouter.",
+            "model_count": 1,
+            "arena": "models",
+            "category": null,
+            "elo_bounds": {
+                "min": 900,
+                "max": 1600
+            }
+        }
+    }"#;
+    let design: BenchmarksDAResponse =
+        serde_json::from_str(design_raw).expect("Design Arena response should deserialize");
+    assert_eq!(design.data[0].display_name, "Claude Sonnet 4");
+    assert_eq!(design.meta.elo_bounds.max, 1600.0);
+}
+
 #[tokio::test]
 async fn test_list_models_for_user_request_path() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
@@ -478,6 +578,88 @@ async fn test_get_rankings_daily_with_date_query_and_auth_header() {
     );
 
     server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_app_rankings_path_query_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[],"meta":{"as_of":"2026-05-12T02:00:00Z","version":"v1","start_date":"2026-04-12","end_date":"2026-05-11"}}"#,
+    );
+    let params = AppRankingsParams::builder()
+        .category("coding")
+        .subcategory("cli-agent")
+        .sort("trending")
+        .start_date("2026-04-12")
+        .end_date("2026-05-11")
+        .limit(10)
+        .offset(2)
+        .build()
+        .expect("app rankings params should build");
+
+    let rankings = discovery::get_app_rankings(&base_url, "api-key", Some(&params))
+        .await
+        .expect("app rankings request should succeed");
+    assert!(rankings.data.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/datasets/app-rankings?category=coding&subcategory=cli-agent&sort=trending&start_date=2026-04-12&end_date=2026-05-11&limit=10&offset=2 HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include API key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_benchmark_dataset_paths_and_queries() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"artificial-analysis","source_url":"https://artificialanalysis.ai","citation":"Source","model_count":0}}"#,
+    );
+    let aa = discovery::get_benchmarks_artificial_analysis(&base_url, "api-key", Some(25))
+        .await
+        .expect("AA benchmark request should succeed");
+    assert!(aa.data.is_empty());
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture AA request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/datasets/benchmarks/artificial-analysis?max_results=25 HTTP/1.1"
+    );
+    server.join().expect("AA server thread should finish");
+
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"design-arena","source_url":"https://www.designarena.ai","citation":"Source","model_count":0,"arena":"models","category":"codecategories","elo_bounds":{"min":0,"max":0}}}"#,
+    );
+    let da = discovery::get_benchmarks_design_arena(
+        &base_url,
+        "api-key",
+        Some("models"),
+        Some("codecategories"),
+        Some(20),
+    )
+    .await
+    .expect("Design Arena benchmark request should succeed");
+    assert!(da.data.is_empty());
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture Design Arena request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/datasets/benchmarks/design-arena?arena=models&category=codecategories&max_results=20 HTTP/1.1"
+    );
+    server
+        .join()
+        .expect("Design Arena server thread should finish");
 }
 
 #[tokio::test]

--- a/tests/unit/files.rs
+++ b/tests/unit/files.rs
@@ -1,0 +1,265 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::api::files::{self, FileDeleteResponse, FileListResponse, FileMetadata};
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_server(
+    response_body: &[u8],
+    content_type: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_vec();
+    let content_type = content_type.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            content_type,
+            body.len()
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write header");
+        stream
+            .write_all(&body)
+            .expect("server should write response body");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+fn file_metadata_json() -> &'static str {
+    r#"{
+        "id": "file_123",
+        "type": "file",
+        "filename": "document.pdf",
+        "mime_type": "application/pdf",
+        "size_bytes": 1024,
+        "created_at": "2026-06-15T00:00:00Z",
+        "downloadable": true
+    }"#
+}
+
+#[test]
+fn test_file_payloads_deserialize() {
+    let file: FileMetadata =
+        serde_json::from_str(file_metadata_json()).expect("file metadata should deserialize");
+    assert_eq!(file.id, "file_123");
+    assert_eq!(file.filename, "document.pdf");
+    assert!(file.downloadable);
+
+    let list_raw = format!(
+        r#"{{
+            "data": [{}],
+            "has_more": false,
+            "first_id": "file_123",
+            "last_id": "file_123",
+            "cursor": null
+        }}"#,
+        file_metadata_json()
+    );
+    let list: FileListResponse =
+        serde_json::from_str(&list_raw).expect("file list should deserialize");
+    assert_eq!(list.data.len(), 1);
+    assert!(!list.has_more);
+
+    let deleted: FileDeleteResponse =
+        serde_json::from_str(r#"{"id":"file_123","type":"file_deleted"}"#)
+            .expect("file delete response should deserialize");
+    assert_eq!(deleted.id, "file_123");
+}
+
+#[tokio::test]
+async fn test_list_files_path_query_and_auth_header() {
+    let (base_url, rx, server) = spawn_server(
+        br#"{"data":[],"has_more":false,"first_id":null,"last_id":null,"cursor":null}"#,
+        "application/json",
+    );
+
+    let files = files::list_files(
+        &base_url,
+        "api-key",
+        Some(20),
+        Some("cursor_1"),
+        Some("ws_123"),
+    )
+    .await
+    .expect("list files should succeed");
+    assert!(files.data.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/files?limit=20&cursor=cursor_1&workspace_id=ws_123 HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include API key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_download_delete_file_paths() {
+    let (base_url, rx, server) = spawn_server(file_metadata_json().as_bytes(), "application/json");
+    let metadata = files::get_file_metadata(&base_url, "api-key", "file 123", Some("ws_123"))
+        .await
+        .expect("get file metadata should succeed");
+    assert_eq!(metadata.id, "file_123");
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture metadata request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/files/file%20123?workspace_id=ws_123 HTTP/1.1"
+    );
+    server.join().expect("metadata server thread should finish");
+
+    let (base_url, rx, server) = spawn_server(b"file bytes", "application/octet-stream");
+    let bytes = files::download_file_content(&base_url, "api-key", "file 123", None)
+        .await
+        .expect("download file content should succeed");
+    assert_eq!(bytes, b"file bytes");
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture download request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/files/file%20123/content HTTP/1.1"
+    );
+    server.join().expect("download server thread should finish");
+
+    let (base_url, rx, server) = spawn_server(
+        br#"{"id":"file_123","type":"file_deleted"}"#,
+        "application/json",
+    );
+    let deleted = files::delete_file(&base_url, "api-key", "file_123", Some("ws_123"))
+        .await
+        .expect("delete file should succeed");
+    assert_eq!(deleted.id, "file_123");
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture delete request");
+    assert_eq!(
+        captured.request_line,
+        "DELETE /api/v1/files/file_123?workspace_id=ws_123 HTTP/1.1"
+    );
+    server.join().expect("delete server thread should finish");
+}
+
+#[tokio::test]
+async fn test_upload_file_uses_multipart_file_part() {
+    let (base_url, rx, server) = spawn_server(file_metadata_json().as_bytes(), "application/json");
+    let request = files::UploadFileRequest::builder()
+        .filename("note.txt")
+        .mime_type("text/plain")
+        .content(b"hello from file".to_vec())
+        .build()
+        .expect("upload request should build");
+
+    let uploaded = files::upload_file(&base_url, "api-key", &request, Some("ws_123"))
+        .await
+        .expect("upload file should succeed");
+    assert_eq!(uploaded.id, "file_123");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture upload request");
+    assert_eq!(
+        captured.request_line,
+        "POST /api/v1/files?workspace_id=ws_123 HTTP/1.1"
+    );
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("content-type: multipart/form-data"),
+        "upload should use multipart/form-data, request:\n{}",
+        captured.request_text
+    );
+    assert!(captured.body_text.contains(r#"name="file""#));
+    assert!(captured.body_text.contains(r#"filename="note.txt""#));
+    assert!(captured.body_text.contains("Content-Type: text/plain"));
+    assert!(captured.body_text.contains("hello from file"));
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/generation.rs
+++ b/tests/unit/generation.rs
@@ -142,6 +142,8 @@ fn test_generation_response_deserializes_num_fetches() {
             "origin": "chat",
             "usage": 42.0,
             "is_byok": false,
+            "data_region": "global",
+            "latency": 12.5,
             "native_tokens_reasoning": 8,
             "num_fetches": 3,
             "preset_id": "preset_123",
@@ -155,6 +157,8 @@ fn test_generation_response_deserializes_num_fetches() {
 
     assert_eq!(parsed.data.id, "gen_123");
     assert_eq!(parsed.data.native_tokens_reasoning, Some(8));
+    assert_eq!(parsed.data.data_region.as_deref(), Some("global"));
+    assert_eq!(parsed.data.latency, Some(12.5));
     assert_eq!(parsed.data.num_fetches, Some(3));
     assert_eq!(parsed.data.preset_id.as_deref(), Some("preset_123"));
     assert_eq!(

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -575,8 +575,8 @@ async fn test_create_message_sets_stream_false_and_headers() {
         "x-openrouter-categories header should be present, headers:\n{header_text}"
     );
     assert!(
-        headers_lower.contains("x-openrouter-experimental-metadata: enabled")
-            || headers_lower.contains("x-openrouter-experimental-metadata:enabled"),
+        headers_lower.contains("x-openrouter-metadata: enabled")
+            || headers_lower.contains("x-openrouter-metadata:enabled"),
         "experimental metadata header should be present, headers:\n{header_text}"
     );
 

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -3,6 +3,7 @@ fn dummy_test() {
     // This is a placeholder test
 }
 
+pub mod analytics;
 pub mod api_keys;
 pub mod audio;
 pub mod auth;
@@ -20,6 +21,7 @@ pub mod default_headers;
 pub mod discovery;
 pub mod embeddings;
 pub mod error_model;
+pub mod files;
 pub mod generation;
 pub mod guardrails;
 pub mod messages;

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use openrouter_rs::{
-    api::models::{self, EndpointData},
+    api::models::{self, EndpointData, ListModelsParams},
     types::{ApiResponse, ModelCategory, SupportedParameters},
 };
 
@@ -153,6 +153,82 @@ fn test_model_response_deserializes_supported_voices() {
     );
 }
 
+#[test]
+fn test_model_response_deserializes_links_and_benchmarks() {
+    let raw = r#"{
+        "data": {
+            "id": "openai/gpt-4",
+            "canonical_slug": "openai/gpt-4",
+            "name": "GPT-4",
+            "created": 1692901234,
+            "description": "Test model data",
+            "context_length": null,
+            "architecture": {
+                "modality": "text->text",
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+                "tokenizer": "GPT",
+                "instruct_type": "chatml"
+            },
+            "top_provider": {
+                "context_length": null,
+                "max_completion_tokens": null,
+                "is_moderated": true
+            },
+            "pricing": {
+                "prompt": "0.00003",
+                "completion": "0.00006",
+                "request": "0"
+            },
+            "per_request_limits": null,
+            "supported_parameters": ["temperature", "top_p"],
+            "default_parameters": null,
+            "supported_voices": null,
+            "links": {
+                "details": "/api/v1/models/openai/gpt-4/endpoints"
+            },
+            "benchmarks": {
+                "artificial_analysis": {
+                    "intelligence_index": 71.4,
+                    "coding_index": 63.2,
+                    "agentic_index": 55.8
+                },
+                "design_arena": [{
+                    "arena": "models",
+                    "category": "website",
+                    "elo": 1385.2,
+                    "win_rate": 62.5,
+                    "rank": 5
+                }]
+            }
+        }
+    }"#;
+
+    let parsed: ApiResponse<models::Model> =
+        serde_json::from_str(raw).expect("single model response should deserialize");
+    assert_eq!(parsed.data.canonical_slug.as_deref(), Some("openai/gpt-4"));
+    assert!(parsed.data.context_length.is_none());
+    assert_eq!(
+        parsed
+            .data
+            .links
+            .as_ref()
+            .expect("links should be present")
+            .details,
+        "/api/v1/models/openai/gpt-4/endpoints"
+    );
+    assert_eq!(
+        parsed
+            .data
+            .benchmarks
+            .as_ref()
+            .expect("benchmarks should be present")
+            .design_arena[0]
+            .rank,
+        5
+    );
+}
+
 #[tokio::test]
 async fn test_list_model_endpoints_encodes_author_slug_and_auth_header() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
@@ -229,6 +305,66 @@ async fn test_list_model_endpoints_encodes_author_slug_and_auth_header() {
             || request_lower.contains("authorization:bearer api-key"),
         "authorization header should include API key, request:\n{}",
         request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_model_encodes_author_slug_and_auth_header() {
+    let response = r#"{
+        "data": {
+            "id": "team/model-alpha",
+            "canonical_slug": "team/model-alpha",
+            "name": "Model Alpha",
+            "created": 1735689600,
+            "description": "Test model data",
+            "context_length": 8192,
+            "architecture": {
+                "modality": "text->text",
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+                "tokenizer": "Other",
+                "instruct_type": null
+            },
+            "top_provider": {
+                "context_length": 8192,
+                "max_completion_tokens": 4096,
+                "is_moderated": false
+            },
+            "pricing": {
+                "prompt": "0",
+                "completion": "0"
+            },
+            "per_request_limits": null,
+            "supported_parameters": [],
+            "default_parameters": null,
+            "supported_voices": null,
+            "links": {
+                "details": "/api/v1/models/team/model-alpha/endpoints"
+            }
+        }
+    }"#;
+    let (base_url, rx, server) = spawn_json_server(response);
+
+    let model = models::get_model(&base_url, "api-key", "team/prod", "model alpha")
+        .await
+        .expect("get model should succeed");
+    assert_eq!(model.id, "team/model-alpha");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/model/team%2Fprod/model%20alpha HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include API key, request:\n{}",
+        captured.request_text
     );
 
     server.join().expect("server thread should finish");
@@ -318,6 +454,44 @@ async fn test_list_models_with_both_filters_query() {
     assert_eq!(
         captured.request_line,
         "GET /api/v1/models?category=programming&supported_parameters=top_p HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_models_with_extended_filter_params() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[]}"#);
+    let params = ListModelsParams::builder()
+        .category(ModelCategory::Programming)
+        .supported_parameters(SupportedParameters::TopP)
+        .output_modalities("text,image")
+        .sort("newest")
+        .q("gpt")
+        .input_modalities("text")
+        .context(128000)
+        .min_price(0.0)
+        .max_price(1.0)
+        .arch("transformer")
+        .model_authors("openai")
+        .providers("openai,anthropic")
+        .distillable(true)
+        .zdr(true)
+        .region("eu")
+        .build()
+        .expect("list model params should build");
+
+    let models = models::list_models_with_params(&base_url, "api-key", Some(&params))
+        .await
+        .expect("filtered model list should succeed");
+    assert!(models.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/models?category=programming&supported_parameters=top_p&output_modalities=text%2Cimage&sort=newest&q=gpt&input_modalities=text&context=128000&min_price=0.0&max_price=1.0&arch=transformer&model_authors=openai&providers=openai%2Canthropic&distillable=true&zdr=true&region=eu HTTP/1.1"
     );
 
     server.join().expect("server thread should finish");

--- a/tests/unit/presets.rs
+++ b/tests/unit/presets.rs
@@ -155,6 +155,47 @@ fn test_preset_response_deserializes() {
     );
 }
 
+#[test]
+fn test_list_presets_and_versions_deserialize() {
+    let presets_raw = r#"{
+        "data": [{
+            "id": "preset_1",
+            "creator_user_id": "user_1",
+            "workspace_id": "ws_1",
+            "name": "my preset",
+            "slug": "my-preset",
+            "description": null,
+            "status": "active",
+            "designated_version_id": "version_1",
+            "created_at": "2026-04-20T10:00:00Z",
+            "updated_at": "2026-04-20T10:00:00Z",
+            "status_updated_at": null
+        }],
+        "total_count": 1
+    }"#;
+    let presets: presets::ListPresetsResponse =
+        serde_json::from_str(presets_raw).expect("preset list should deserialize");
+    assert_eq!(presets.total_count, 1);
+    assert_eq!(presets.data[0].slug, "my-preset");
+
+    let versions_raw = r#"{
+        "data": [{
+            "id": "version_1",
+            "preset_id": "preset_1",
+            "creator_id": "user_1",
+            "version": 1,
+            "system_prompt": null,
+            "config": {"model":"openai/gpt-5"},
+            "created_at": "2026-04-20T10:00:00Z",
+            "updated_at": "2026-04-20T10:00:00Z"
+        }],
+        "total_count": 1
+    }"#;
+    let versions: presets::ListPresetVersionsResponse =
+        serde_json::from_str(versions_raw).expect("preset version list should deserialize");
+    assert_eq!(versions.data[0].version, 1);
+}
+
 #[tokio::test]
 async fn test_create_chat_completion_preset_path_body_and_auth_header() {
     let (base_url, rx, server) = spawn_json_server(preset_response_body());
@@ -281,4 +322,89 @@ async fn test_create_message_preset_path_body_and_auth_header() {
     assert_eq!(body["max_tokens"], 128);
 
     server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_and_get_presets_paths_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+    let presets = presets::list_presets(
+        &base_url,
+        "management-key",
+        Some(openrouter_rs::types::PaginationOptions::with_offset_and_limit(5, 10)),
+    )
+    .await
+    .expect("list presets should succeed");
+    assert_eq!(presets.total_count, 0);
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture list request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/presets?offset=5&limit=10 HTTP/1.1"
+    );
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("authorization: bearer management-key")
+            || captured
+                .request_text
+                .to_ascii_lowercase()
+                .contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+    server.join().expect("list server thread should finish");
+
+    let (base_url, rx, server) = spawn_json_server(preset_response_body());
+    let preset = presets::get_preset(&base_url, "management-key", "my preset")
+        .await
+        .expect("get preset should succeed");
+    assert_eq!(preset.id, "preset_1");
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture get request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/presets/my%20preset HTTP/1.1"
+    );
+    server.join().expect("get server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_and_get_preset_versions_paths() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+    let versions = presets::list_preset_versions(
+        &base_url,
+        "management-key",
+        "my preset",
+        Some(openrouter_rs::types::PaginationOptions::with_limit(25)),
+    )
+    .await
+    .expect("list preset versions should succeed");
+    assert_eq!(versions.total_count, 0);
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture versions request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/presets/my%20preset/versions?limit=25 HTTP/1.1"
+    );
+    server.join().expect("versions server thread should finish");
+
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"version_1","preset_id":"preset_1","creator_id":"user_1","version":1,"system_prompt":null,"config":{"model":"openai/gpt-5"},"created_at":"2026-04-20T10:00:00Z","updated_at":"2026-04-20T10:00:00Z"}}"#,
+    );
+    let version = presets::get_preset_version(&base_url, "management-key", "my preset", "1")
+        .await
+        .expect("get preset version should succeed");
+    assert_eq!(version.version, 1);
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture version request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/presets/my%20preset/versions/1 HTTP/1.1"
+    );
+    server.join().expect("version server thread should finish");
 }

--- a/tests/unit/rerank.rs
+++ b/tests/unit/rerank.rs
@@ -80,12 +80,34 @@ fn test_rerank_response_deserialization() {
     assert_eq!(parsed.model, "cohere/rerank-v3.5");
     assert_eq!(parsed.results.len(), 1);
     assert_eq!(
-        parsed.results[0].document.text,
-        "Paris is the capital of France."
+        parsed.results[0].document.text.as_deref(),
+        Some("Paris is the capital of France.")
     );
     assert_eq!(
         parsed.usage.expect("usage should be present").search_units,
         Some(1)
+    );
+}
+
+#[test]
+fn test_rerank_response_deserializes_image_only_document_echo() {
+    let raw = r#"{
+        "id": "gen-rerank-123",
+        "model": "cohere/rerank-v3.5",
+        "results": [{
+            "index": 0,
+            "relevance_score": 0.91,
+            "document": {"image": "https://example.com/image.png"}
+        }]
+    }"#;
+
+    let parsed: RerankResponse =
+        serde_json::from_str(raw).expect("image-only rerank response should deserialize");
+    assert_eq!(parsed.results.len(), 1);
+    assert_eq!(parsed.results[0].document.text, None);
+    assert_eq!(
+        parsed.results[0].document.image.as_deref(),
+        Some("https://example.com/image.png")
     );
 }
 

--- a/tests/unit/rerank.rs
+++ b/tests/unit/rerank.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use openrouter_rs::{
-    api::rerank::{self, RerankRequest, RerankResponse},
+    api::rerank::{self, RerankDocumentInput, RerankRequest, RerankResponse},
     types::ProviderPreferences,
 };
 
@@ -34,6 +34,27 @@ fn test_rerank_request_serialization() {
     assert_eq!(value["documents"][0], "Paris is the capital of France.");
     assert_eq!(value["top_n"], 1);
     assert_eq!(value["provider"]["allow_fallbacks"], true);
+}
+
+#[test]
+fn test_rerank_request_serializes_multimodal_documents() {
+    let request = RerankRequest::builder()
+        .model("cohere/rerank-v3.5")
+        .query("find the matching image")
+        .documents(vec![
+            RerankDocumentInput::text("plain document"),
+            RerankDocumentInput::multimodal(Some("caption"), Some("https://example.com/image.png")),
+        ])
+        .build()
+        .expect("rerank request should build");
+
+    let value = serde_json::to_value(&request).expect("rerank request should serialize");
+    assert_eq!(value["documents"][0], "plain document");
+    assert_eq!(value["documents"][1]["text"], "caption");
+    assert_eq!(
+        value["documents"][1]["image"],
+        "https://example.com/image.png"
+    );
 }
 
 #[test]

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -315,8 +315,8 @@ async fn test_create_response_sets_stream_false_and_headers() {
         captured.header_text
     );
     assert!(
-        headers_lower.contains("x-openrouter-experimental-metadata: enabled")
-            || headers_lower.contains("x-openrouter-experimental-metadata:enabled"),
+        headers_lower.contains("x-openrouter-metadata: enabled")
+            || headers_lower.contains("x-openrouter-metadata:enabled"),
         "experimental metadata header should be present, headers:\n{}",
         captured.header_text
     );

--- a/tests/unit/videos.rs
+++ b/tests/unit/videos.rs
@@ -36,9 +36,11 @@ fn test_video_generation_request_serialization() {
             "https://example.com/first.png",
             "first_frame",
         )])
-        .input_references(vec![VideoInputReference::new(
-            "https://example.com/reference.png",
-        )])
+        .input_references(vec![
+            VideoInputReference::image("https://example.com/reference.png"),
+            VideoInputReference::audio("https://example.com/reference.wav"),
+            VideoInputReference::video("https://example.com/reference.mp4"),
+        ])
         .provider(VideoProviderOptions::new(provider_options))
         .build()
         .expect("video generation request should build");
@@ -52,6 +54,14 @@ fn test_video_generation_request_serialization() {
     assert_eq!(
         value["input_references"][0]["image_url"]["url"],
         "https://example.com/reference.png"
+    );
+    assert_eq!(
+        value["input_references"][1]["audio_url"]["url"],
+        "https://example.com/reference.wav"
+    );
+    assert_eq!(
+        value["input_references"][2]["video_url"]["url"],
+        "https://example.com/reference.mp4"
     );
     assert_eq!(
         value["provider"]["options"]["google-vertex"]["output_config"]["effort"],


### PR DESCRIPTION
## Summary
- Accept the latest OpenRouter OpenAPI drift for issue #220 and refresh the tracked baseline to 81 method/path entries.
- Add typed SDK/domain coverage for files, analytics, app rankings, benchmark datasets, singular model lookup, preset list/read/versioning, and related schema refreshes.
- Update README, CHANGELOG, and the official endpoint matrix for the new 81 / 81 implementation snapshot.

## Validation
- `just openapi-drift-check`
- `just quality`

Refs #220