### PR TITLE
feat: add cache_control to request builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added top-level `cache_control` support to chat completion and Responses API request builders for automatic prompt caching.
 - Added typed SDK support for the Files API (`GET|POST /files`, `GET|DELETE /files/{file_id}`, and `GET /files/{file_id}/content`) via `api::files` and the canonical `client.files()` surface.
 - Added typed management-key SDK support for analytics metadata and query endpoints (`GET /analytics/meta`, `POST /analytics/query`) via `api::analytics` and `client.management().get_analytics_meta(...)` / `query_analytics(...)`.
 - Added typed SDK support for `GET /datasets/app-rankings`, `GET /datasets/benchmarks/artificial-analysis`, and `GET /datasets/benchmarks/design-arena` through the `models()` domain client.

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -565,6 +565,10 @@ pub struct ChatCompletionRequest {
 
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     trace: Option<TraceOptions>,
 
     #[builder(setter(strip_option), default)]

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    api::chat::{Plugin, TraceOptions},
+    api::chat::{CacheControl, Plugin, TraceOptions},
     error::OpenRouterError,
     strip_option_map_setter, strip_option_vec_setter,
     transport::{
@@ -165,6 +165,10 @@ pub struct ResponsesRequest {
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
 
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -174,6 +174,7 @@ fn test_chat_request_extended_control_fields_serialize() {
         .messages(vec![Message::new(Role::User, "ping")])
         .user("user-123")
         .session_id("session-abc")
+        .cache_control(CacheControl::ephemeral_with_ttl("1h"))
         .metadata([("env", "test"), ("feature", "chat-parity")])
         .trace(trace)
         .stop(StopSequence::Multiple(vec![
@@ -187,6 +188,8 @@ fn test_chat_request_extended_control_fields_serialize() {
 
     assert_eq!(json["user"], "user-123");
     assert_eq!(json["session_id"], "session-abc");
+    assert_eq!(json["cache_control"]["type"], "ephemeral");
+    assert_eq!(json["cache_control"]["ttl"], "1h");
     assert_eq!(json["metadata"]["env"], "test");
     assert_eq!(json["metadata"]["feature"], "chat-parity");
     assert_eq!(json["trace"]["trace_id"], "trace-1");

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures_util::StreamExt;
 use openrouter_rs::api::{
-    chat::{Plugin, TraceOptions},
+    chat::{CacheControl, Plugin, TraceOptions},
     responses::{
         ResponsesRequest, ResponsesResponse, ResponsesStreamEvent, create_response, stream_response,
     },
@@ -146,6 +146,7 @@ fn test_responses_request_serialization() {
         .truncation("auto")
         .user("user-123")
         .session_id("session-abc")
+        .cache_control(CacheControl::ephemeral())
         .trace({
             let mut trace = TraceOptions::default();
             trace.trace_id = Some("trace-1".to_string());
@@ -165,6 +166,8 @@ fn test_responses_request_serialization() {
     assert_eq!(value["max_output_tokens"], 256);
     assert_eq!(value["modalities"][1], "image");
     assert_eq!(value["plugins"][0]["id"], "web");
+    assert_eq!(value["cache_control"]["type"], "ephemeral");
+    assert!(value["cache_control"].get("ttl").is_none());
     assert_eq!(value["trace"]["trace_id"], "trace-1");
     assert_eq!(value["trace"]["span_name"], "responses.unit");
 }


### PR DESCRIPTION
See `CONTRIBUTING.md`, `docs/policies/maintenance-policy.md`, and `docs/policies/compatibility-update-policy.md` for contributor workflow, release expectations, compatibility-update cadence, MSRV policy, and breaking-change guidance.

## Summary
- What problem does this PR solve? Using automatic cache control
- What is the high-level approach? Pass the cache control argument to OpenRouter

## Changes
- [x] API behavior changes
- [ ] Type/model changes
- [ ] Docs/examples updates
- [ ] CI/release changes

## Validation
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --test unit`
- [ ] `cargo test --test integration -- --nocapture` (if secrets are available)

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)