### PR TITLE
feat: accept issue 222 OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed SDK support for the Files API (`GET|POST /files`, `GET|DELETE /files/{file_id}`, and `GET /files/{file_id}/content`) via `api::files` and the canonical `client.files()` surface.
 - Added typed management-key SDK support for analytics metadata and query endpoints (`GET /analytics/meta`, `POST /analytics/query`) via `api::analytics` and `client.management().get_analytics_meta(...)` / `query_analytics(...)`.
 - Added typed SDK support for `GET /datasets/app-rankings`, `GET /datasets/benchmarks/artificial-analysis`, and `GET /datasets/benchmarks/design-arena` through the `models()` domain client.
+- Added typed SDK support for unified benchmark discovery via `GET /benchmarks`, `api::discovery::UnifiedBenchmarksParams`, and `client.models().get_benchmarks(...)`.
+- Added typed management-key SDK support for workspace budgets (`GET /workspaces/{id}/budgets`, `PUT|DELETE /workspaces/{id}/budgets/{interval}`) via `api::workspaces` and `client.management().*_workspace_budget(...)`.
 - Added typed SDK support for `GET /model/{author}/{slug}` and expanded `GET /models` filtering through `ListModelsParams`.
 - Added management-key SDK support for listing, reading, and versioning presets via `GET /presets`, `GET /presets/{slug}`, `GET /presets/{slug}/versions`, and `GET /presets/{slug}/versions/{version}`.
 - Added typed SDK support for `GET /datasets/rankings-daily`, including `api::discovery::RankingsDailyResponse` and the canonical `client.models().get_rankings_daily(...)` surface.
@@ -19,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed `GenerationData::preset_id` support on `GET /generation` metadata responses.
 
 ### Changed
+- Accepted the 2026-06-22 OpenAPI drift review, including unified benchmarks, workspace budget management, model reasoning metadata, analytics warnings, server-tool usage metadata, embedding cost details, and Anthropic file document helpers, restoring the repository snapshot to `83 / 83` official OpenAPI endpoint coverage.
+- Deprecated the legacy `get_benchmarks_artificial_analysis(...)` and `get_benchmarks_design_arena(...)` compatibility methods in favor of `get_benchmarks(...)`.
 - Accepted the 2026-06-16 OpenAPI drift review, including analytics, files, app rankings, benchmark datasets, singular model lookup, preset read/version endpoints, model filter/schema refreshes, rerank multimodal documents, and video input reference refreshes, restoring the repository snapshot to `81 / 81` official OpenAPI endpoint coverage.
 - Changed the opt-in OpenRouter metadata request header sent by chat, Responses, and Messages requests from `X-OpenRouter-Experimental-Metadata` to the upstream `X-OpenRouter-Metadata` spelling while preserving the existing request-builder method names.
 - Refreshed model and generation metadata deserialization for nullable model context lengths, model links/benchmarks, default parameters, generation `data_region`, floating-point latency, and integer status values.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ The canonical public surface is domain-oriented:
 | `audio().transcriptions()` | `create` | `/audio/transcriptions` | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `files()` | `list`, `upload`, `get_metadata`, `download_content`, `delete` | `/files*` | API key |
-| `models()` | `list`, `list_filtered`, `list_by_category`, `list_by_parameters`, `get`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `get_app_rankings`, `get_benchmarks_artificial_analysis`, `get_benchmarks_design_arena`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/model*`, `/models*`, `/providers`, `/datasets/*`, `/endpoints/zdr`, `/embeddings*` | API key |
-| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_presets`, `get_preset`, `list_preset_versions`, `get_preset_version`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `get_analytics_meta`, `query_analytics`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/analytics*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
+| `models()` | `list`, `list_filtered`, `list_by_category`, `list_by_parameters`, `get`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `get_app_rankings`, `get_benchmarks`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/model*`, `/models*`, `/providers`, `/datasets/*`, `/benchmarks`, `/endpoints/zdr`, `/embeddings*` | API key |
+| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_presets`, `get_preset`, `list_preset_versions`, `get_preset_version`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `get_analytics_meta`, `query_analytics`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `list_workspace_budgets`, `upsert_workspace_budget`, `delete_workspace_budget`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/analytics*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
 At runtime, the builder/client exposes the values the SDK directly consumes:
@@ -132,9 +132,9 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 - unified streaming across chat, responses, and messages
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
-- model discovery, provider discovery, app rankings, benchmark datasets, embeddings, and ZDR endpoints
+- model discovery, provider discovery, app rankings, unified benchmarks, embeddings, and ZDR endpoints
 - typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
-- management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
+- management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
 
@@ -329,8 +329,8 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ### Unreleased
 
-- Added typed SDK coverage for files, analytics, app rankings, benchmark datasets, singular model lookup, preset listing/readback/versioning, extended model filters, multimodal rerank documents, and richer video input references.
-- Accepted OpenAPI drift through the 2026-06-16 review and restored the tracked endpoint snapshot to `81 / 81`.
+- Added typed SDK coverage for files, analytics, app rankings, unified benchmarks, singular model lookup, preset listing/readback/versioning, workspace budgets, extended model filters, multimodal rerank documents, and richer video input references.
+- Accepted OpenAPI drift through the 2026-06-22 review and restored the tracked endpoint snapshot to `83 / 83`.
 
 ### Version 0.10.0 *(Latest)*
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,19 +1,21 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-06-16
+Snapshot date: 2026-06-22
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `81` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `81 / 81` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 81` endpoints currently exercised.
+- Official OpenAPI endpoints: `83` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `83 / 83` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 83` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
 
+- Upstream replaced the two per-source benchmark dataset endpoints with unified `GET /benchmarks` and added workspace budget management. The SDK now exposes `client.models().get_benchmarks(...)` and `client.management().list_workspace_budgets(...)` / `upsert_workspace_budget(...)` / `delete_workspace_budget(...)`. The old per-source benchmark methods remain deprecated compatibility wrappers.
+- Upstream added model reasoning metadata, analytics warnings, chat server-tool usage metadata, embedding cost details, and Anthropic file document sources. The SDK now exposes typed fields/helpers for these stable surfaces while preserving flexible `Value` and `HashMap` escape hatches for high-churn payloads.
 - Official audio speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.audio().speech().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
 - Upstream added `GET /generation/content`, now exposed as `client.get_generation_content(...)` / `client.management().get_generation_content(...)`.
 - Upstream added official workspace-management endpoints and workspace-aware management fields. The SDK and CLI now expose them; live management-key validation remains pending.
@@ -60,12 +62,11 @@ Legend:
 | `GET /byok/{id}` | `client.management().get_byok_key(...)` | Yes | Path | No | P1 |
 | `PATCH /byok/{id}` | `client.management().update_byok_key(...)` | Yes | Path | No | P1 |
 | `DELETE /byok/{id}` | `client.management().delete_byok_key(...)` | Yes | Path | No | P1 |
+| `GET /benchmarks` | `client.models().get_benchmarks(...)` | Yes | Path | No | P2 |
 | `POST /chat/completions` | `client.chat().create(...)` / `client.chat().stream(...)` | Yes | Contract | Yes | Keep |
 | `GET /credits` | `client.get_credits()` / `client.management().get_credits()` | Yes | Path | No | P2 |
 | `POST /credits/coinbase` | `client.create_coinbase_charge(...)` / `client.management().create_coinbase_charge(...)` | Yes | Path | No | P2 |
 | `GET /datasets/app-rankings` | `client.models().get_app_rankings(...)` | Yes | Path | No | P2 |
-| `GET /datasets/benchmarks/artificial-analysis` | `client.models().get_benchmarks_artificial_analysis(...)` | Yes | Path | No | P2 |
-| `GET /datasets/benchmarks/design-arena` | `client.models().get_benchmarks_design_arena(...)` | Yes | Path | No | P2 |
 | `GET /datasets/rankings-daily` | `client.models().get_rankings_daily(...)` | Yes | Path | No | P2 |
 | `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | Yes | Keep |
 | `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | Path | Yes | Keep |
@@ -117,6 +118,7 @@ Legend:
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
 | `GET /workspaces` | `client.management().list_workspaces(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}` | `client.management().get_workspace(...)` | Yes | Path | No | P1 |
+| `GET /workspaces/{id}/budgets` | `client.management().list_workspace_budgets(...)` | Yes | Path | No | P1 |
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |
@@ -131,22 +133,26 @@ Legend:
 | `GET /videos/{jobId}/content` | `client.videos().get_content(...)` | Yes | Path | No | P2 |
 | `PATCH /workspaces/{id}` | `client.management().update_workspace(...)` | Yes | Path | No | P1 |
 | `DELETE /workspaces/{id}` | `client.management().delete_workspace(...)` | Yes | Path | No | P1 |
+| `PUT /workspaces/{id}/budgets/{interval}` | `client.management().upsert_workspace_budget(...)` | Yes | Path | No | P1 |
+| `DELETE /workspaces/{id}/budgets/{interval}` | `client.management().delete_workspace_budget(...)` | Yes | Path | No | P1 |
 
 ## Supplemental (Legacy)
 
-The endpoint below is intentionally kept as legacy compatibility and is not part of current OpenAPI:
+The endpoints below are intentionally kept as legacy compatibility and are not part of current OpenAPI:
 
 | Endpoint | SDK surface | Notes |
 | --- | --- | --- |
 | `POST /completions` | `client.legacy().completions().create(...)` (feature `legacy-completions`) | Migration-only surface toward `chat`/`responses` |
 | `POST /tts` | `client.audio().speech().create(...)` | Compatibility fallback while upstream rolls out `POST /audio/speech` everywhere |
+| `GET /datasets/benchmarks/artificial-analysis` | `client.models().get_benchmarks_artificial_analysis(...)` | Deprecated compatibility surface; prefer `client.models().get_benchmarks(...)` |
+| `GET /datasets/benchmarks/design-arena` | `client.models().get_benchmarks_design_arena(...)` | Deprecated compatibility surface; prefer `client.models().get_benchmarks(...)` |
 
 ## Incremental Test Plan
 
 1. P1: add management-key live coverage for assignment endpoints (`/guardrails/*/assignments/*` and `/guardrails/assignments/*`).
 2. P1: add management-key live smoke coverage for `/activity` and `/analytics*`.
 3. P1: add controlled file lifecycle live coverage for `/files*` once upload/download fixtures and cleanup guarantees are defined.
-4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets*`, `/model/{author}/{slug}`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
+4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets*`, `/benchmarks`, `/model/{author}/{slug}`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
 5. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, and `/videos*` once stable fixtures and cost controls are defined.
 6. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
 7. P1: add management-key live validation for `/byok*` and `/observability/destinations*` once safe test credentials and destination fixtures are defined.

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,23 +1,13 @@
 {
   "components": {
     "parameters": {
-      "AppCategories": {
-        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
-        "in": "header",
-        "name": "X-OpenRouter-Categories",
-        "schema": {
-          "type": "string"
-        },
-        "x-speakeasy-name-override": "appCategories"
-      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-OpenRouter-Title",
+        "name": "X-Title",
         "schema": {
           "type": "string"
-        },
-        "x-speakeasy-name-override": "appTitle"
+        }
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -1542,6 +1532,9 @@
               },
               {
                 "$ref": "#/components/schemas/AnthropicUrlPdfSource"
+              },
+              {
+                "$ref": "#/components/schemas/AnthropicFileDocumentSource"
               }
             ]
           },
@@ -1599,6 +1592,28 @@
           "return_code",
           "stderr",
           "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicFileDocumentSource": {
+        "example": {
+          "file_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "type": "file"
+        },
+        "properties": {
+          "file_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file_id"
         ],
         "type": "object"
       },
@@ -4889,8 +4904,7 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField",
-            "nullable": true
+            "$ref": "#/components/schemas/ResponsesErrorField"
           },
           "frequency_penalty": {
             "format": "double",
@@ -4901,12 +4915,10 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails",
-            "nullable": true
+            "$ref": "#/components/schemas/IncompleteDetails"
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs",
-            "nullable": true
+            "$ref": "#/components/schemas/BaseInputs"
           },
           "max_output_tokens": {
             "nullable": true,
@@ -4995,8 +5007,7 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig",
-            "nullable": true
+            "$ref": "#/components/schemas/BaseReasoningConfig"
           },
           "safety_identifier": {
             "nullable": true,
@@ -5017,8 +5028,7 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig",
-            "nullable": true
+            "$ref": "#/components/schemas/TextConfig"
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -5107,7 +5117,6 @@
             "type": "array"
           },
           "top_logprobs": {
-            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -5116,8 +5125,7 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation",
-            "nullable": true
+            "$ref": "#/components/schemas/Truncation"
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -5328,447 +5336,6 @@
             "$ref": "#/components/schemas/ContainerReferenceEnvironment"
           }
         ]
-      },
-      "BenchmarkPricing": {
-        "description": "OpenRouter pricing per token for this model. Null if pricing is unavailable.",
-        "example": {
-          "completion": "0.000015",
-          "prompt": "0.000003"
-        },
-        "nullable": true,
-        "properties": {
-          "completion": {
-            "description": "Cost per output token (USD, decimal string).",
-            "example": "0.000015",
-            "type": "string"
-          },
-          "prompt": {
-            "description": "Cost per input token (USD, decimal string).",
-            "example": "0.000003",
-            "type": "string"
-          }
-        },
-        "required": [
-          "prompt",
-          "completion"
-        ],
-        "type": "object"
-      },
-      "BenchmarksAAItem": {
-        "example": {
-          "aa_name": "GPT-4o",
-          "agentic_index": 58.3,
-          "coding_index": 65.8,
-          "intelligence_index": 71.2,
-          "model_permaslug": "openai/gpt-4o",
-          "pricing": {
-            "completion": "0.00001",
-            "prompt": "0.0000025"
-          }
-        },
-        "properties": {
-          "aa_name": {
-            "description": "Model name as listed on Artificial Analysis.",
-            "example": "GPT-4o",
-            "type": "string"
-          },
-          "agentic_index": {
-            "description": "Artificial Analysis Agentic Index composite score. Higher is better.",
-            "example": 58.3,
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
-          "coding_index": {
-            "description": "Artificial Analysis Coding Index composite score. Higher is better.",
-            "example": 65.8,
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
-          "intelligence_index": {
-            "description": "Artificial Analysis Intelligence Index composite score. Higher is better.",
-            "example": 71.2,
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
-          "model_permaslug": {
-            "description": "Stable OpenRouter model identifier.",
-            "example": "openai/gpt-4o",
-            "type": "string"
-          },
-          "pricing": {
-            "$ref": "#/components/schemas/BenchmarkPricing"
-          }
-        },
-        "required": [
-          "model_permaslug",
-          "aa_name",
-          "intelligence_index",
-          "coding_index",
-          "agentic_index",
-          "pricing"
-        ],
-        "type": "object"
-      },
-      "BenchmarksAAMeta": {
-        "example": {
-          "as_of": "2026-06-03T12:00:00Z",
-          "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
-          "model_count": 50,
-          "source": "artificial-analysis",
-          "source_url": "https://artificialanalysis.ai",
-          "version": "v1"
-        },
-        "properties": {
-          "as_of": {
-            "description": "ISO-8601 timestamp of when this data was last updated.",
-            "example": "2026-06-03T12:00:00Z",
-            "type": "string"
-          },
-          "citation": {
-            "description": "Required attribution when republishing this data.",
-            "example": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
-            "type": "string"
-          },
-          "model_count": {
-            "description": "Number of unique models in the response.",
-            "type": "integer"
-          },
-          "source": {
-            "description": "Data source identifier.",
-            "enum": [
-              "artificial-analysis"
-            ],
-            "type": "string"
-          },
-          "source_url": {
-            "description": "URL of the upstream data source.",
-            "enum": [
-              "https://artificialanalysis.ai"
-            ],
-            "type": "string"
-          },
-          "version": {
-            "description": "Dataset version.",
-            "enum": [
-              "v1"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "as_of",
-          "version",
-          "source",
-          "source_url",
-          "citation",
-          "model_count"
-        ],
-        "type": "object"
-      },
-      "BenchmarksAAResponse": {
-        "example": {
-          "data": [
-            {
-              "aa_name": "GPT-4o",
-              "agentic_index": 58.3,
-              "coding_index": 65.8,
-              "intelligence_index": 71.2,
-              "model_permaslug": "openai/gpt-4o",
-              "pricing": {
-                "completion": "0.00001",
-                "prompt": "0.0000025"
-              }
-            }
-          ],
-          "meta": {
-            "as_of": "2026-06-03T12:00:00Z",
-            "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
-            "model_count": 1,
-            "source": "artificial-analysis",
-            "source_url": "https://artificialanalysis.ai",
-            "version": "v1"
-          }
-        },
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/BenchmarksAAItem"
-            },
-            "type": "array"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/BenchmarksAAMeta"
-          }
-        },
-        "required": [
-          "data",
-          "meta"
-        ],
-        "type": "object"
-      },
-      "BenchmarksDAItem": {
-        "example": {
-          "arena": "models",
-          "avg_generation_time_ms": 3200,
-          "category": "codecategories",
-          "display_name": "Claude Sonnet 4",
-          "elo": 1423,
-          "model_permaslug": "anthropic/claude-sonnet-4",
-          "pricing": {
-            "completion": "0.000015",
-            "prompt": "0.000003"
-          },
-          "tournament_stats": {
-            "first_place": 12,
-            "fourth_place": 2,
-            "second_place": 8,
-            "third_place": 5,
-            "total": 27
-          },
-          "win_rate": 72
-        },
-        "properties": {
-          "arena": {
-            "description": "Arena this ranking belongs to.",
-            "example": "models",
-            "type": "string"
-          },
-          "avg_generation_time_ms": {
-            "description": "Average generation time in milliseconds.",
-            "example": 3200,
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
-          "category": {
-            "description": "Category within the arena.",
-            "example": "codecategories",
-            "type": "string"
-          },
-          "display_name": {
-            "description": "Human-readable model name from Design Arena.",
-            "example": "Claude Sonnet 4",
-            "type": "string"
-          },
-          "elo": {
-            "description": "ELO rating from head-to-head arena battles.",
-            "example": 1423,
-            "format": "double",
-            "type": "number"
-          },
-          "model_permaslug": {
-            "description": "Stable OpenRouter model identifier when the model is on OpenRouter; otherwise the upstream Design Arena model id. Use pricing != null to detect OpenRouter-mapped models.",
-            "example": "anthropic/claude-sonnet-4",
-            "type": "string"
-          },
-          "pricing": {
-            "$ref": "#/components/schemas/BenchmarkPricing"
-          },
-          "tournament_stats": {
-            "description": "Placement distribution from tournament matches.",
-            "properties": {
-              "first_place": {
-                "nullable": true,
-                "type": "integer"
-              },
-              "fourth_place": {
-                "nullable": true,
-                "type": "integer"
-              },
-              "second_place": {
-                "nullable": true,
-                "type": "integer"
-              },
-              "third_place": {
-                "nullable": true,
-                "type": "integer"
-              },
-              "total": {
-                "nullable": true,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "first_place",
-              "second_place",
-              "third_place",
-              "fourth_place",
-              "total"
-            ],
-            "type": "object"
-          },
-          "win_rate": {
-            "description": "Win rate as a percentage (0\u2013100).",
-            "example": 72,
-            "format": "double",
-            "type": "number"
-          }
-        },
-        "required": [
-          "model_permaslug",
-          "display_name",
-          "arena",
-          "category",
-          "elo",
-          "win_rate",
-          "avg_generation_time_ms",
-          "tournament_stats",
-          "pricing"
-        ],
-        "type": "object"
-      },
-      "BenchmarksDAMeta": {
-        "example": {
-          "arena": "models",
-          "as_of": "2026-06-03T12:00:00Z",
-          "category": null,
-          "citation": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
-          "elo_bounds": {
-            "max": 1600,
-            "min": 900
-          },
-          "model_count": 50,
-          "source": "design-arena",
-          "source_url": "https://www.designarena.ai",
-          "version": "v1"
-        },
-        "properties": {
-          "arena": {
-            "description": "The arena filter applied.",
-            "type": "string"
-          },
-          "as_of": {
-            "description": "ISO-8601 timestamp of when this data was generated.",
-            "example": "2026-06-03T12:00:00Z",
-            "type": "string"
-          },
-          "category": {
-            "description": "The category filter applied, or null if showing all.",
-            "nullable": true,
-            "type": "string"
-          },
-          "citation": {
-            "description": "Required attribution when republishing this data.",
-            "example": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
-            "type": "string"
-          },
-          "elo_bounds": {
-            "description": "ELO range across all returned models for normalization.",
-            "properties": {
-              "max": {
-                "description": "Maximum ELO in the result set.",
-                "format": "double",
-                "type": "number"
-              },
-              "min": {
-                "description": "Minimum ELO in the result set.",
-                "format": "double",
-                "type": "number"
-              }
-            },
-            "required": [
-              "min",
-              "max"
-            ],
-            "type": "object"
-          },
-          "model_count": {
-            "description": "Number of unique models in the response.",
-            "type": "integer"
-          },
-          "source": {
-            "description": "Data source identifier.",
-            "enum": [
-              "design-arena"
-            ],
-            "type": "string"
-          },
-          "source_url": {
-            "description": "URL of the upstream data source.",
-            "enum": [
-              "https://www.designarena.ai"
-            ],
-            "type": "string"
-          },
-          "version": {
-            "description": "Dataset version.",
-            "enum": [
-              "v1"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "as_of",
-          "version",
-          "source",
-          "source_url",
-          "citation",
-          "model_count",
-          "arena",
-          "category",
-          "elo_bounds"
-        ],
-        "type": "object"
-      },
-      "BenchmarksDAResponse": {
-        "example": {
-          "data": [
-            {
-              "arena": "models",
-              "avg_generation_time_ms": 3200,
-              "category": "codecategories",
-              "display_name": "Claude Sonnet 4",
-              "elo": 1423,
-              "model_permaslug": "anthropic/claude-sonnet-4",
-              "pricing": {
-                "completion": "0.000015",
-                "prompt": "0.000003"
-              },
-              "tournament_stats": {
-                "first_place": 12,
-                "fourth_place": 2,
-                "second_place": 8,
-                "third_place": 5,
-                "total": 27
-              },
-              "win_rate": 72
-            }
-          ],
-          "meta": {
-            "arena": "models",
-            "as_of": "2026-06-03T12:00:00Z",
-            "category": null,
-            "citation": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
-            "elo_bounds": {
-              "max": 1600,
-              "min": 900
-            },
-            "model_count": 1,
-            "source": "design-arena",
-            "source_url": "https://www.designarena.ai",
-            "version": "v1"
-          }
-        },
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/BenchmarksDAItem"
-            },
-            "type": "array"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/BenchmarksDAMeta"
-          }
-        },
-        "required": [
-          "data",
-          "meta"
-        ],
-        "type": "object"
       },
       "BigNumberUnion": {
         "description": "Price per million prompt tokens",
@@ -8027,6 +7594,10 @@
           "prompt_tokens_details": {
             "cached_tokens": 2
           },
+          "server_tool_use_details": {
+            "tool_calls_executed": 2,
+            "tool_calls_requested": 2
+          },
           "total_tokens": 25
         },
         "properties": {
@@ -8096,6 +7667,28 @@
               },
               "video_tokens": {
                 "description": "Video input tokens",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "server_tool_use_details": {
+            "description": "Usage for server-side tool execution (e.g., web search)",
+            "nullable": true,
+            "properties": {
+              "tool_calls_executed": {
+                "description": "Number of OpenRouter server tool calls that executed and produced a result",
+                "nullable": true,
+                "type": "integer"
+              },
+              "tool_calls_requested": {
+                "description": "Total number of OpenRouter server-orchestrated tool calls the model requested, across all tool types. Provider-native tools (e.g. native web search) are not counted here.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "web_search_requests": {
+                "description": "Number of web searches performed by server-side tools. For server-orchestrated tool calls a web search is also counted in tool_calls_requested; provider-native web search may report web_search_requests only. Do not sum the two.",
+                "nullable": true,
                 "type": "integer"
               }
             },
@@ -8182,7 +7775,7 @@
             "type": "integer"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -10135,6 +9728,23 @@
           "deleted": {
             "const": true,
             "description": "Always `true` on success.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "DeleteWorkspaceBudgetResponse": {
+        "example": {
+          "deleted": true
+        },
+        "properties": {
+          "deleted": {
+            "const": true,
+            "description": "Confirmation that the budget was deleted (or did not exist)",
+            "example": true,
             "type": "boolean"
           }
         },
@@ -14057,7 +13667,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -14516,6 +14126,33 @@
         "required": [
           "data",
           "total_count"
+        ],
+        "type": "object"
+      },
+      "ListWorkspaceBudgetsResponse": {
+        "example": {
+          "data": [
+            {
+              "created_at": "2025-08-24T10:30:00Z",
+              "id": "770e8400-e29b-41d4-a716-446655440000",
+              "limit_usd": 100,
+              "reset_interval": "monthly",
+              "updated_at": "2025-08-24T15:45:00Z",
+              "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          ]
+        },
+        "properties": {
+          "data": {
+            "description": "List of budgets configured for the workspace",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceBudget"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
         ],
         "type": "object"
       },
@@ -17212,6 +16849,17 @@
             "prompt": "0.00003",
             "request": "0"
           },
+          "reasoning": {
+            "default_effort": "medium",
+            "default_enabled": true,
+            "mandatory": false,
+            "supported_efforts": [
+              "high",
+              "medium",
+              "low",
+              "minimal"
+            ]
+          },
           "supported_parameters": [
             "temperature",
             "top_p",
@@ -17291,6 +16939,9 @@
           },
           "pricing": {
             "$ref": "#/components/schemas/PublicPricing"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/ModelReasoning"
           },
           "supported_parameters": {
             "description": "List of supported parameters for this model",
@@ -17499,6 +17150,56 @@
         "description": "Model to use for completion",
         "example": "openai/gpt-4",
         "type": "string"
+      },
+      "ModelReasoning": {
+        "description": "Reasoning effort configuration. Omitted for non-reasoning models and dynamic router models.",
+        "example": {
+          "default_effort": "medium",
+          "default_enabled": true,
+          "mandatory": false,
+          "supported_efforts": [
+            "high",
+            "medium",
+            "low",
+            "minimal"
+          ]
+        },
+        "properties": {
+          "default_effort": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReasoningEffort"
+              },
+              {
+                "description": "Default reasoning effort when the client enables reasoning without specifying effort. Maps to `reasoning.effort` in chat requests. When `\"none\"`, prefer omitting effort unless the user explicitly disables reasoning."
+              }
+            ]
+          },
+          "default_enabled": {
+            "description": "Default reasoning enabled state when the client does not set `reasoning.enabled`.",
+            "type": "boolean"
+          },
+          "mandatory": {
+            "description": "When true, reasoning cannot be disabled and effort \"none\" is rejected.",
+            "type": "boolean"
+          },
+          "supported_efforts": {
+            "description": "Allowed reasoning effort values for this model, in descending effort order (highest first). Null means no allowlist \u2014 all gateway effort values are accepted.",
+            "items": {
+              "$ref": "#/components/schemas/ReasoningEffort"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "supports_max_tokens": {
+            "description": "Present and `true` when the model accepts `reasoning.max_tokens` in requests (Anthropic-style) instead of or in addition to `reasoning.effort`. Omitted otherwise.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "mandatory"
+        ],
+        "type": "object"
       },
       "ModelResponse": {
         "description": "Single model response",
@@ -24067,7 +23768,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -24102,7 +23803,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -28818,6 +28519,339 @@
         ],
         "type": "object"
       },
+      "UnifiedBenchmarkPricing": {
+        "description": "OpenRouter pricing per token for this model. Null if pricing is unavailable.",
+        "example": {
+          "completion": "0.000015",
+          "prompt": "0.000003"
+        },
+        "nullable": true,
+        "properties": {
+          "completion": {
+            "description": "Cost per output token (USD, decimal string).",
+            "example": "0.000015",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "Cost per input token (USD, decimal string).",
+            "example": "0.000003",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt",
+          "completion"
+        ],
+        "type": "object"
+      },
+      "UnifiedBenchmarksAAItem": {
+        "example": {
+          "agentic_index": 58.3,
+          "coding_index": 65.8,
+          "display_name": "GPT-4o",
+          "intelligence_index": 71.2,
+          "model_permaslug": "openai/gpt-4o",
+          "pricing": {
+            "completion": "0.00001",
+            "prompt": "0.0000025"
+          },
+          "source": "artificial-analysis"
+        },
+        "properties": {
+          "agentic_index": {
+            "description": "Artificial Analysis Agentic Index composite score. Higher is better.",
+            "example": 58.3,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "coding_index": {
+            "description": "Artificial Analysis Coding Index composite score. Higher is better.",
+            "example": 65.8,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "display_name": {
+            "description": "Model name as listed on Artificial Analysis.",
+            "example": "GPT-4o",
+            "type": "string"
+          },
+          "intelligence_index": {
+            "description": "Artificial Analysis Intelligence Index composite score. Higher is better.",
+            "example": 71.2,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "model_permaslug": {
+            "description": "Stable OpenRouter model identifier.",
+            "example": "openai/gpt-4o",
+            "type": "string"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/UnifiedBenchmarkPricing"
+          },
+          "source": {
+            "description": "Benchmark source discriminator.",
+            "enum": [
+              "artificial-analysis"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "model_permaslug",
+          "display_name",
+          "intelligence_index",
+          "coding_index",
+          "agentic_index",
+          "pricing"
+        ],
+        "type": "object"
+      },
+      "UnifiedBenchmarksDAItem": {
+        "example": {
+          "arena": "models",
+          "avg_generation_time_ms": 3200,
+          "category": "codecategories",
+          "display_name": "Claude Sonnet 4",
+          "elo": 1423,
+          "model_permaslug": "anthropic/claude-sonnet-4",
+          "pricing": {
+            "completion": "0.000015",
+            "prompt": "0.000003"
+          },
+          "source": "design-arena",
+          "tournament_stats": {
+            "first_place": 12,
+            "fourth_place": 2,
+            "second_place": 8,
+            "third_place": 5,
+            "total": 27
+          },
+          "win_rate": 72
+        },
+        "properties": {
+          "arena": {
+            "description": "Arena this ranking belongs to.",
+            "example": "models",
+            "type": "string"
+          },
+          "avg_generation_time_ms": {
+            "description": "Average generation time in milliseconds.",
+            "example": 3200,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "category": {
+            "description": "Category within the arena.",
+            "example": "codecategories",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "Human-readable model name from Design Arena.",
+            "example": "Claude Sonnet 4",
+            "type": "string"
+          },
+          "elo": {
+            "description": "ELO rating from head-to-head arena battles.",
+            "example": 1423,
+            "format": "double",
+            "type": "number"
+          },
+          "model_permaslug": {
+            "description": "Stable OpenRouter model identifier when mapped; otherwise the upstream Design Arena model id.",
+            "example": "anthropic/claude-sonnet-4",
+            "type": "string"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/UnifiedBenchmarkPricing"
+          },
+          "source": {
+            "description": "Benchmark source discriminator.",
+            "enum": [
+              "design-arena"
+            ],
+            "type": "string"
+          },
+          "tournament_stats": {
+            "description": "Placement distribution from tournament matches.",
+            "properties": {
+              "first_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "fourth_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "second_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "third_place": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "total": {
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "first_place",
+              "second_place",
+              "third_place",
+              "fourth_place",
+              "total"
+            ],
+            "type": "object"
+          },
+          "win_rate": {
+            "description": "Win rate as a percentage (0\u2013100).",
+            "example": 72,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "source",
+          "model_permaslug",
+          "display_name",
+          "arena",
+          "category",
+          "elo",
+          "win_rate",
+          "avg_generation_time_ms",
+          "tournament_stats",
+          "pricing"
+        ],
+        "type": "object"
+      },
+      "UnifiedBenchmarksMeta": {
+        "example": {
+          "as_of": "2026-06-03T12:00:00Z",
+          "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+          "model_count": 50,
+          "source": "artificial-analysis",
+          "source_url": "https://artificialanalysis.ai",
+          "task_type": null,
+          "version": "v1"
+        },
+        "properties": {
+          "as_of": {
+            "description": "ISO-8601 timestamp of when this data was last updated.",
+            "example": "2026-06-03T12:00:00Z",
+            "type": "string"
+          },
+          "citation": {
+            "description": "Required attribution when republishing this data.",
+            "example": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+            "type": "string"
+          },
+          "model_count": {
+            "description": "Number of unique models in the response.",
+            "type": "integer"
+          },
+          "source": {
+            "description": "The source filter applied.",
+            "enum": [
+              "artificial-analysis",
+              "design-arena"
+            ],
+            "example": "artificial-analysis",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "source_url": {
+            "description": "URL of the upstream data source.",
+            "example": "https://artificialanalysis.ai",
+            "type": "string"
+          },
+          "task_type": {
+            "description": "The task_type filter applied, or null if showing all.",
+            "nullable": true,
+            "type": "string"
+          },
+          "version": {
+            "description": "Dataset version.",
+            "enum": [
+              "v1"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "as_of",
+          "version",
+          "source",
+          "source_url",
+          "citation",
+          "model_count",
+          "task_type"
+        ],
+        "type": "object"
+      },
+      "UnifiedBenchmarksResponse": {
+        "example": {
+          "data": [
+            {
+              "agentic_index": 58.3,
+              "coding_index": 65.8,
+              "display_name": "GPT-4o",
+              "intelligence_index": 71.2,
+              "model_permaslug": "openai/gpt-4o",
+              "pricing": {
+                "completion": "0.00001",
+                "prompt": "0.0000025"
+              },
+              "source": "artificial-analysis"
+            }
+          ],
+          "meta": {
+            "as_of": "2026-06-03T12:00:00Z",
+            "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+            "model_count": 1,
+            "source": "artificial-analysis",
+            "source_url": "https://artificialanalysis.ai",
+            "task_type": null,
+            "version": "v1"
+          }
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "artificial-analysis": "#/components/schemas/UnifiedBenchmarksAAItem",
+                  "design-arena": "#/components/schemas/UnifiedBenchmarksDAItem"
+                },
+                "propertyName": "source"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UnifiedBenchmarksAAItem"
+                },
+                {
+                  "$ref": "#/components/schemas/UnifiedBenchmarksDAItem"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/UnifiedBenchmarksMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object"
+      },
       "UnprocessableEntityResponse": {
         "description": "Unprocessable Entity - Semantic validation failure",
         "example": {
@@ -29355,6 +29389,51 @@
               },
               {
                 "description": "The updated workspace"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "UpsertWorkspaceBudgetRequest": {
+        "example": {
+          "limit_usd": 100
+        },
+        "properties": {
+          "limit_usd": {
+            "description": "Spending limit in USD. Must be greater than 0.",
+            "example": 100,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "limit_usd"
+        ],
+        "type": "object"
+      },
+      "UpsertWorkspaceBudgetResponse": {
+        "example": {
+          "data": {
+            "created_at": "2025-08-24T10:30:00Z",
+            "id": "770e8400-e29b-41d4-a716-446655440000",
+            "limit_usd": 100,
+            "reset_interval": "monthly",
+            "updated_at": "2025-08-24T15:45:00Z",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        },
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceBudget"
+              },
+              {
+                "description": "The created or updated budget"
               }
             ]
           }
@@ -30064,7 +30143,7 @@
             "type": "integer"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -30236,7 +30315,7 @@
             "$ref": "#/components/schemas/WebSearchDomainFilter"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -30288,7 +30367,7 @@
             "type": "integer"
           },
           "max_results": {
-            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search.",
+            "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
             "type": "integer"
           },
@@ -30560,6 +30639,80 @@
         ],
         "type": "object"
       },
+      "WorkspaceBudget": {
+        "example": {
+          "created_at": "2025-08-24T10:30:00Z",
+          "id": "770e8400-e29b-41d4-a716-446655440000",
+          "limit_usd": 100,
+          "reset_interval": "monthly",
+          "updated_at": "2025-08-24T15:45:00Z",
+          "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+        },
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 timestamp of when the budget was created",
+            "example": "2025-08-24T10:30:00Z",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the budget",
+            "example": "770e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "limit_usd": {
+            "description": "Spending limit in USD for this interval",
+            "example": 100,
+            "format": "double",
+            "type": "number"
+          },
+          "reset_interval": {
+            "description": "Interval at which spend resets. Null means a lifetime (one-time) budget.",
+            "enum": [
+              "daily",
+              "weekly",
+              "monthly",
+              null
+            ],
+            "example": "monthly",
+            "nullable": true,
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "updated_at": {
+            "description": "ISO 8601 timestamp of when the budget was last updated",
+            "example": "2025-08-24T15:45:00Z",
+            "type": "string"
+          },
+          "workspace_id": {
+            "description": "ID of the workspace the budget belongs to",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "limit_usd",
+          "reset_interval",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "WorkspaceBudgetInterval": {
+        "description": "Budget reset interval. Use \"lifetime\" for a one-time budget that never resets.",
+        "enum": [
+          "daily",
+          "weekly",
+          "monthly",
+          "lifetime"
+        ],
+        "example": "monthly",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "WorkspaceMember": {
         "example": {
           "created_at": "2025-08-24T10:30:00Z",
@@ -30793,18 +30946,7 @@
         "tags": [
           "Analytics"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/analytics/meta": {
       "get": {
@@ -31050,31 +31192,9 @@
         "tags": [
           "beta.Analytics"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/analytics/query": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Execute an analytics query with specified metrics, dimensions, filters, and time range. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "queryAnalytics",
@@ -31099,7 +31219,7 @@
                 "properties": {
                   "dimensions": {
                     "items": {
-                      "description": "Dimension name",
+                      "description": "Dimension to group by (up to 2). Use the /meta endpoint for available dimensions.",
                       "example": "model",
                       "type": "string"
                     },
@@ -31110,7 +31230,7 @@
                     "items": {
                       "properties": {
                         "field": {
-                          "description": "Dimension to filter on",
+                          "description": "Dimension to filter on. Use the /meta endpoint for available dimensions.",
                           "example": "model",
                           "type": "string"
                         },
@@ -31143,7 +31263,7 @@
                               "type": "array"
                             }
                           ],
-                          "description": "Filter value (scalar or array depending on operator)"
+                          "description": "Filter value (scalar or array depending on operator). Several dimensions are enriched in responses (returned as human-readable labels), but filters must use the underlying ID: `api_key_id` \u2014 numeric ID (from generation metadata) or key hash (64-char hex from GET /api/v1/keys, resolved server-side); `user` \u2014 Clerk user ID (e.g. \"user_abc123\"), not the display name; `workspace` \u2014 workspace UUID, not the workspace name; `app` \u2014 numeric app ID, not the app title; `model` \u2014 permaslug (e.g. \"openai/gpt-4o\"), not the display name. Other dimensions (provider, origin, country, etc.) are not enriched and accept the value as returned."
                         }
                       },
                       "required": [
@@ -31281,6 +31401,13 @@
                             "truncated"
                           ],
                           "type": "object"
+                        },
+                        "warnings": {
+                          "description": "Warnings about filter resolution issues (e.g. unresolvable api_key_id hashes). The query still runs normally; these inform the caller that some filter values could not be resolved.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
                         }
                       },
                       "required": [
@@ -31387,17 +31514,6 @@
       }
     },
     "/audio/speech": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Synthesizes audio from the input text. Returns a raw audio bytestream in the requested format (e.g. mp3, pcm, wav).",
         "operationId": "createAudioSpeech",
@@ -31602,17 +31718,6 @@
       }
     },
     "/audio/transcriptions": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Transcribes audio into text. Accepts base64-encoded audio input and returns the transcribed text.",
         "operationId": "createAudioTranscriptions",
@@ -31825,17 +31930,6 @@
       }
     },
     "/auth/keys": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -31978,17 +32072,6 @@
       }
     },
     "/auth/keys/code": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -32238,6 +32321,194 @@
         "x-speakeasy-name-override": "createAuthCode"
       }
     },
+    "/benchmarks": {
+      "get": {
+        "description": "Unified benchmark endpoint that aggregates scores from multiple benchmark sources (Artificial Analysis, Design Arena). Filter by source to reproduce the exact shapes from the legacy per-source endpoints, or use task_type to find models suited for specific workloads. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
+        "operationId": "getBenchmarks",
+        "parameters": [
+          {
+            "description": "Benchmark source to query. Determines the shape of the returned items.",
+            "in": "query",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "description": "Benchmark source to query. Determines the shape of the returned items.",
+              "enum": [
+                "artificial-analysis",
+                "design-arena"
+              ],
+              "example": "artificial-analysis",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Filter results by task type. For Artificial Analysis, maps to the corresponding index. For Design Arena, maps to the matching category.",
+            "in": "query",
+            "name": "task_type",
+            "required": false,
+            "schema": {
+              "description": "Filter results by task type. For Artificial Analysis, maps to the corresponding index. For Design Arena, maps to the matching category.",
+              "enum": [
+                "coding",
+                "intelligence",
+                "agentic"
+              ],
+              "example": "coding",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Design Arena only: arena to query. Defaults to `models` when source is `design-arena`.",
+            "in": "query",
+            "name": "arena",
+            "required": false,
+            "schema": {
+              "description": "Design Arena only: arena to query. Defaults to `models` when source is `design-arena`.",
+              "enum": [
+                "models",
+                "builders",
+                "agents"
+              ],
+              "example": "models",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          {
+            "description": "Design Arena only: category within the arena (e.g. `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`). When omitted, returns all categories.",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "description": "Design Arena only: category within the arena (e.g. `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`). When omitted, returns all categories.",
+              "example": "codecategories",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max results to return (1\u2013100, default 50).",
+            "in": "query",
+            "name": "max_results",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max results to return (1\u2013100, default 50).",
+              "example": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "agentic_index": 58.3,
+                      "coding_index": 65.8,
+                      "display_name": "GPT-4o",
+                      "intelligence_index": 71.2,
+                      "model_permaslug": "openai/gpt-4o",
+                      "pricing": {
+                        "completion": "0.00001",
+                        "prompt": "0.0000025"
+                      },
+                      "source": "artificial-analysis"
+                    }
+                  ],
+                  "meta": {
+                    "as_of": "2026-06-03T12:00:00Z",
+                    "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+                    "model_count": 1,
+                    "source": "artificial-analysis",
+                    "source_url": "https://artificialanalysis.ai",
+                    "task_type": null,
+                    "version": "v1"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnifiedBenchmarksResponse"
+                }
+              }
+            },
+            "description": "Benchmark results filtered by the specified source and optional task type."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List Benchmarks",
+        "tags": [
+          "Benchmarks"
+        ]
+      }
+    },
     "/byok": {
       "get": {
         "description": "List the bring-your-own-key (BYOK) provider credentials for the authenticated entity's default workspace. Use the `workspace_id` query parameter to scope the result to a different workspace, or the `provider` query parameter to filter by upstream provider. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
@@ -32466,17 +32737,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new bring-your-own-key (BYOK) provider credential. The raw key is encrypted at rest and never returned in API responses. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createBYOKKey",
@@ -32780,17 +33040,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing bring-your-own-key (BYOK) provider credential by its `id`. Include the `key` field to rotate the raw provider API key in-place (the previous key material is overwritten). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateBYOKKey",
@@ -32922,17 +33171,6 @@
       }
     },
     "/chat/completions": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
@@ -33431,31 +33669,9 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/credits/coinbase": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -33736,334 +33952,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
-    },
-    "/datasets/benchmarks/artificial-analysis": {
-      "get": {
-        "description": "Returns composite index scores (Intelligence, Coding, Agentic) from Artificial Analysis for LLM models. Includes OpenRouter pricing per model. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
-        "operationId": "getBenchmarksArtificialAnalysis",
-        "parameters": [
-          {
-            "description": "Max results to return (1\u2013100, default 50).",
-            "in": "query",
-            "name": "max_results",
-            "required": false,
-            "schema": {
-              "default": 50,
-              "description": "Max results to return (1\u2013100, default 50).",
-              "example": 20,
-              "maximum": 100,
-              "minimum": 1,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "data": [
-                    {
-                      "aa_name": "GPT-4o",
-                      "agentic_index": 58.3,
-                      "coding_index": 65.8,
-                      "intelligence_index": 71.2,
-                      "model_permaslug": "openai/gpt-4o",
-                      "pricing": {
-                        "completion": "0.00001",
-                        "prompt": "0.0000025"
-                      }
-                    }
-                  ],
-                  "meta": {
-                    "as_of": "2026-06-03T12:00:00Z",
-                    "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
-                    "model_count": 1,
-                    "source": "artificial-analysis",
-                    "source_url": "https://artificialanalysis.ai",
-                    "version": "v1"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/BenchmarksAAResponse"
-                }
-              }
-            },
-            "description": "Artificial Analysis composite index scores with pricing and attribution metadata."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 400,
-                    "message": "Invalid request parameters"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestResponse"
-                }
-              }
-            },
-            "description": "Bad Request - Invalid request parameters or malformed input"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 401,
-                    "message": "Missing Authentication header"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedResponse"
-                }
-              }
-            },
-            "description": "Unauthorized - Authentication required or invalid credentials"
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 429,
-                    "message": "Rate limit exceeded"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/TooManyRequestsResponse"
-                }
-              }
-            },
-            "description": "Too Many Requests - Rate limit exceeded"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 500,
-                    "message": "Internal Server Error"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error - Unexpected server error"
-          }
-        },
-        "summary": "Artificial Analysis Benchmark Indices",
-        "tags": [
-          "Datasets"
-        ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
-    },
-    "/datasets/benchmarks/design-arena": {
-      "get": {
-        "description": "Returns ELO ratings from head-to-head arena battles on Design Arena. Filterable by arena (models/builders/agents) and category. Includes OpenRouter pricing per model. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
-        "operationId": "getBenchmarksDesignArena",
-        "parameters": [
-          {
-            "description": "Arena to query. Defaults to `models`.",
-            "in": "query",
-            "name": "arena",
-            "required": false,
-            "schema": {
-              "default": "models",
-              "description": "Arena to query. Defaults to `models`.",
-              "enum": [
-                "models",
-                "builders",
-                "agents"
-              ],
-              "example": "models",
-              "type": "string",
-              "x-speakeasy-unknown-values": "allow"
-            }
-          },
-          {
-            "description": "Category within the arena (e.g. `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`). When omitted, returns all categories.",
-            "in": "query",
-            "name": "category",
-            "required": false,
-            "schema": {
-              "description": "Category within the arena (e.g. `codecategories`, `uicomponent`, `gamedev`, `3d`, `dataviz`, `image`, `video`, `svg`). When omitted, returns all categories.",
-              "example": "codecategories",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max results to return: per category when no category filter is applied (1\u2013100, default 50).",
-            "in": "query",
-            "name": "max_results",
-            "required": false,
-            "schema": {
-              "default": 50,
-              "description": "Max results to return: per category when no category filter is applied (1\u2013100, default 50).",
-              "example": 20,
-              "maximum": 100,
-              "minimum": 1,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "data": [
-                    {
-                      "arena": "models",
-                      "avg_generation_time_ms": 3200,
-                      "category": "codecategories",
-                      "display_name": "Claude Sonnet 4",
-                      "elo": 1423,
-                      "model_permaslug": "anthropic/claude-sonnet-4",
-                      "pricing": {
-                        "completion": "0.000015",
-                        "prompt": "0.000003"
-                      },
-                      "tournament_stats": {
-                        "first_place": 12,
-                        "fourth_place": 2,
-                        "second_place": 8,
-                        "third_place": 5,
-                        "total": 27
-                      },
-                      "win_rate": 72
-                    }
-                  ],
-                  "meta": {
-                    "arena": "models",
-                    "as_of": "2026-06-03T12:00:00Z",
-                    "category": null,
-                    "citation": "Source: Design Arena (www.designarena.ai) via OpenRouter (openrouter.ai/rankings).",
-                    "elo_bounds": {
-                      "max": 1600,
-                      "min": 900
-                    },
-                    "model_count": 1,
-                    "source": "design-arena",
-                    "source_url": "https://www.designarena.ai",
-                    "version": "v1"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/BenchmarksDAResponse"
-                }
-              }
-            },
-            "description": "Design Arena ELO rankings with pricing and attribution metadata."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 400,
-                    "message": "Invalid request parameters"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestResponse"
-                }
-              }
-            },
-            "description": "Bad Request - Invalid request parameters or malformed input"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 401,
-                    "message": "Missing Authentication header"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedResponse"
-                }
-              }
-            },
-            "description": "Unauthorized - Authentication required or invalid credentials"
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 429,
-                    "message": "Rate limit exceeded"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/TooManyRequestsResponse"
-                }
-              }
-            },
-            "description": "Too Many Requests - Rate limit exceeded"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": 500,
-                    "message": "Internal Server Error"
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error - Unexpected server error"
-          }
-        },
-        "summary": "Design Arena Benchmark Rankings",
-        "tags": [
-          "Datasets"
-        ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/datasets/rankings-daily": {
       "get": {
@@ -34200,31 +34089,9 @@
         "tags": [
           "Datasets"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/embeddings": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -34510,6 +34377,39 @@
                           "example": 0.0001,
                           "format": "double",
                           "type": "number"
+                        },
+                        "cost_details": {
+                          "description": "Breakdown of upstream inference costs",
+                          "example": {
+                            "upstream_inference_completions_cost": 0.0004,
+                            "upstream_inference_cost": null,
+                            "upstream_inference_prompt_cost": 0.0008
+                          },
+                          "nullable": true,
+                          "properties": {
+                            "upstream_inference_completions_cost": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "upstream_inference_cost": {
+                              "format": "double",
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "upstream_inference_prompt_cost": {
+                              "format": "double",
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "upstream_inference_prompt_cost",
+                            "upstream_inference_completions_cost"
+                          ],
+                          "type": "object"
+                        },
+                        "is_byok": {
+                          "description": "Whether a request was made using a Bring Your Own Key configuration",
+                          "type": "boolean"
                         },
                         "prompt_tokens": {
                           "description": "Number of tokens in the input",
@@ -34840,18 +34740,7 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/endpoints/zdr": {
       "get": {
@@ -34986,18 +34875,7 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/files": {
       "get": {
@@ -35154,17 +35032,6 @@
           "type": "cursor"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Uploads a file to be referenced in future API calls. The file is stored under the workspace of the authenticating API key. Maximum file size: 100 MB.",
         "operationId": "uploadFile",
@@ -35557,18 +35424,7 @@
           "Files"
         ],
         "x-speakeasy-name-override": "retrieve"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/files/{file_id}/content": {
       "get": {
@@ -35696,18 +35552,7 @@
           "Files"
         ],
         "x-speakeasy-name-override": "download"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/generation": {
       "get": {
@@ -35912,18 +35757,7 @@
         "tags": [
           "Generations"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/generation/content": {
       "get": {
@@ -36102,18 +35936,7 @@
         "tags": [
           "Generations"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails": {
       "get": {
@@ -36251,17 +36074,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -36514,18 +36326,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -36639,18 +36440,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/guardrails/{id}": {
       "delete": {
@@ -36843,17 +36633,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
@@ -37135,17 +36914,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
@@ -37265,17 +37033,6 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -37535,17 +37292,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -37666,17 +37412,6 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -38098,18 +37833,7 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/keys": {
       "get": {
@@ -38455,17 +38179,6 @@
         ],
         "x-speakeasy-name-override": "list"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
@@ -39326,17 +39039,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -39742,17 +39444,6 @@
       }
     },
     "/messages": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
@@ -40148,18 +39839,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "get"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models": {
       "get": {
@@ -40401,7 +40081,7 @@
                       "id": "openai/gpt-4",
                       "knowledge_cutoff": null,
                       "links": {
-                        "details": "/api/v1/models/openai/gpt-5.4/endpoints"
+                        "details": "/api/v1/models/openai/gpt-4/endpoints"
                       },
                       "name": "GPT-4",
                       "per_request_limits": null,
@@ -40470,18 +40150,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/count": {
       "get": {
@@ -40553,18 +40222,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/user": {
       "get": {
@@ -40687,18 +40345,7 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -40864,18 +40511,7 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/observability/destinations": {
       "get": {
@@ -41012,17 +40648,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new observability destination. A maximum of 5 destinations per type is allowed. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createObservabilityDestination",
@@ -41354,17 +40979,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing observability destination. Only the fields provided in the request body are updated. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateObservabilityDestination",
@@ -41701,18 +41315,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/presets": {
       "get": {
@@ -41852,18 +41455,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/presets/{slug}": {
       "get": {
@@ -41997,31 +41589,9 @@
           "Presets"
         ],
         "x-speakeasy-name-override": "get"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/presets/{slug}/chat/completions": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsChatCompletions",
@@ -42211,17 +41781,6 @@
       }
     },
     "/presets/{slug}/messages": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsMessages",
@@ -42408,17 +41967,6 @@
       }
     },
     "/presets/{slug}/responses": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsResponses",
@@ -42763,18 +42311,7 @@
           },
           "type": "offsetLimit"
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/presets/{slug}/versions/{version}": {
       "get": {
@@ -42907,18 +42444,7 @@
           "Presets"
         ],
         "x-speakeasy-name-override": "getVersion"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/providers": {
       "get": {
@@ -43569,31 +43095,9 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/rerank": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -43994,17 +43498,6 @@
       }
     },
     "/responses": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
@@ -44371,17 +43864,6 @@
       }
     },
     "/videos": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -44607,18 +44089,7 @@
         "tags": [
           "Video Generation"
         ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/videos/{jobId}": {
       "get": {
@@ -44713,18 +44184,7 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -44853,18 +44313,7 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ]
+      }
     },
     "/workspaces": {
       "get": {
@@ -44988,17 +44437,6 @@
           "type": "offsetLimit"
         }
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Create a new workspace for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createWorkspace",
@@ -45343,17 +44781,6 @@
         ],
         "x-speakeasy-name-override": "get"
       },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "patch": {
         "description": "Update an existing workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateWorkspace",
@@ -45503,18 +44930,334 @@
         "x-speakeasy-name-override": "update"
       }
     },
+    "/workspaces/{id}/budgets": {
+      "get": {
+        "description": "List all budgets configured for a workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listWorkspaceBudgets",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "id": "770e8400-e29b-41d4-a716-446655440000",
+                      "limit_usd": 100,
+                      "reset_interval": "monthly",
+                      "updated_at": "2025-08-24T15:45:00Z",
+                      "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkspaceBudgetsResponse"
+                }
+              }
+            },
+            "description": "Budgets retrieved successfully"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List workspace budgets",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "listBudgets"
+      }
+    },
+    "/workspaces/{id}/budgets/{interval}": {
+      "delete": {
+        "description": "Remove the budget for a given interval. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "deleteWorkspaceBudget",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Budget reset interval. Use \"lifetime\" for a one-time budget that never resets.",
+            "example": "monthly",
+            "in": "path",
+            "name": "interval",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WorkspaceBudgetInterval"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "deleted": true
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteWorkspaceBudgetResponse"
+                }
+              }
+            },
+            "description": "Budget deleted successfully"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Delete a workspace budget",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "deleteBudget"
+      },
+      "put": {
+        "description": "Create or update the budget for a given interval. Budget limits must strictly decrease as the interval narrows (lifetime > monthly > weekly > daily). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "upsertWorkspaceBudget",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Budget reset interval. Use \"lifetime\" for a one-time budget that never resets.",
+            "example": "monthly",
+            "in": "path",
+            "name": "interval",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WorkspaceBudgetInterval"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "limit_usd": 100
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpsertWorkspaceBudgetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "created_at": "2025-08-24T10:30:00Z",
+                    "id": "770e8400-e29b-41d4-a716-446655440000",
+                    "limit_usd": 100,
+                    "reset_interval": "monthly",
+                    "updated_at": "2025-08-24T15:45:00Z",
+                    "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UpsertWorkspaceBudgetResponse"
+                }
+              }
+            },
+            "description": "Budget created or updated successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Create or update a workspace budget",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "setBudget"
+      }
+    },
     "/workspaces/{id}/members/add": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Add multiple organization members to a workspace. Members are assigned the same role they hold in the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAddWorkspaceMembers",
@@ -45660,17 +45403,6 @@
       }
     },
     "/workspaces/{id}/members/remove": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/AppIdentifier"
-        },
-        {
-          "$ref": "#/components/parameters/AppDisplayName"
-        },
-        {
-          "$ref": "#/components/parameters/AppCategories"
-        }
-      ],
       "post": {
         "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkRemoveWorkspaceMembers",
@@ -45835,6 +45567,10 @@
     {
       "description": "BYOK endpoints",
       "name": "BYOK"
+    },
+    {
+      "description": "Benchmarks endpoints",
+      "name": "Benchmarks"
     },
     {
       "description": "Chat completion endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-06-17T02:31:05+00:00",
+  "captured_at": "2026-06-22T14:37:38+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,11 +14,11 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 81,
+  "operation_count": 83,
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "6f91deb041a1b1fa",
+      "fingerprint": "54fa253a00ac5c42",
       "id": "DELETE /byok/{id}",
       "method": "DELETE",
       "operation_id": "deleteBYOKKey",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4ca18f79ffb216d8",
+      "fingerprint": "47da8e59e02d600d",
       "id": "DELETE /files/{file_id}",
       "method": "DELETE",
       "operation_id": "deleteFile",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8004f3e140aff889",
+      "fingerprint": "2fb8480286edd199",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "733cf850bfa8a450",
+      "fingerprint": "1745c85b0992ea6e",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8291a7a0a00636a7",
+      "fingerprint": "7af9e020afb4c928",
       "id": "DELETE /observability/destinations/{id}",
       "method": "DELETE",
       "operation_id": "deleteObservabilityDestination",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2e01d56dde1346eb",
+      "fingerprint": "4cc4b797882b36d3",
       "id": "DELETE /workspaces/{id}",
       "method": "DELETE",
       "operation_id": "deleteWorkspace",
@@ -84,7 +84,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ae78503d01b50758",
+      "fingerprint": "9372d297621cc309",
+      "id": "DELETE /workspaces/{id}/budgets/{interval}",
+      "method": "DELETE",
+      "operation_id": "deleteWorkspaceBudget",
+      "path": "/workspaces/{id}/budgets/{interval}",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "d9c39756fe253cfc",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -95,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b69b2e0455fcf869",
+      "fingerprint": "1aec2d13e09c30e0",
       "id": "GET /analytics/meta",
       "method": "GET",
       "operation_id": "getAnalyticsMeta",
@@ -106,7 +117,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7bc33c69e1541f31",
+      "fingerprint": "c3f36f83f80a7074",
+      "id": "GET /benchmarks",
+      "method": "GET",
+      "operation_id": "getBenchmarks",
+      "path": "/benchmarks",
+      "tags": [
+        "Benchmarks"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "a594718fe535598f",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -117,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5c642e0bbe88b2b0",
+      "fingerprint": "e047496712531dc0",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -128,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a8de6e34f937d228",
+      "fingerprint": "3c98257b3b15ba09",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -139,7 +161,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "536e2f01051821eb",
+      "fingerprint": "dd4808939eae0f28",
       "id": "GET /datasets/app-rankings",
       "method": "GET",
       "operation_id": "getAppRankings",
@@ -150,29 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f34604bdd9969376",
-      "id": "GET /datasets/benchmarks/artificial-analysis",
-      "method": "GET",
-      "operation_id": "getBenchmarksArtificialAnalysis",
-      "path": "/datasets/benchmarks/artificial-analysis",
-      "tags": [
-        "Datasets"
-      ]
-    },
-    {
-      "deprecated": false,
-      "fingerprint": "77e54da40f262c74",
-      "id": "GET /datasets/benchmarks/design-arena",
-      "method": "GET",
-      "operation_id": "getBenchmarksDesignArena",
-      "path": "/datasets/benchmarks/design-arena",
-      "tags": [
-        "Datasets"
-      ]
-    },
-    {
-      "deprecated": false,
-      "fingerprint": "83504c0454c4196d",
+      "fingerprint": "32a5aa933d91ab37",
       "id": "GET /datasets/rankings-daily",
       "method": "GET",
       "operation_id": "getRankingsDaily",
@@ -183,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "98678d41300bf2ac",
+      "fingerprint": "ec6055f82bb199b1",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "973c39a6f4957df4",
+      "fingerprint": "f9560f5aeb6653a5",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "52e3f38ade280a25",
+      "fingerprint": "22c98b85de29d359",
       "id": "GET /files",
       "method": "GET",
       "operation_id": "listFiles",
@@ -216,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "21192490b76d7137",
+      "fingerprint": "964fb978cb483f37",
       "id": "GET /files/{file_id}",
       "method": "GET",
       "operation_id": "getFileMetadata",
@@ -227,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "75e30dae37e11592",
+      "fingerprint": "07b67840637ef665",
       "id": "GET /files/{file_id}/content",
       "method": "GET",
       "operation_id": "downloadFileContent",
@@ -238,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c95fd1f97e3baaa6",
+      "fingerprint": "efcbb378ebef2a31",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "51f1c957e6966d83",
+      "fingerprint": "1deaadf338b00e36",
       "id": "GET /generation/content",
       "method": "GET",
       "operation_id": "listGenerationContent",
@@ -260,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ef509670a9999d44",
+      "fingerprint": "c971fe86ab8e6f1e",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4bfed3ae865133d0",
+      "fingerprint": "35e6f73bb468cb70",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -282,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f593364bb80429da",
+      "fingerprint": "03bb4f3b9c8e6c2e",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -293,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d504d0be2f9c3b1a",
+      "fingerprint": "7e90108dc4db6649",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "df9126ac57b2e8a6",
+      "fingerprint": "a9e5751ca222eb49",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -315,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3f4a4fd0be15d281",
+      "fingerprint": "bdcbd251388c2a9f",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -326,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5e74c6f64f3895ab",
+      "fingerprint": "98111f144a36687a",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -337,7 +337,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9fda652a77216fb3",
+      "fingerprint": "de272d5aefee14f8",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -348,7 +348,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d47719cebfea6fce",
+      "fingerprint": "4c7015c8e6d592b1",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -359,7 +359,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6481d488d719de61",
+      "fingerprint": "9690afbafdf4f325",
       "id": "GET /model/{author}/{slug}",
       "method": "GET",
       "operation_id": "getModel",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7c12e55fa2ed959c",
+      "fingerprint": "d061c5615ce84bb4",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -381,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "62cf82894c93d8a5",
+      "fingerprint": "da4869e1fabb1f97",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "993f9ab6be27f052",
+      "fingerprint": "cec3115b64b924c2",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8d587ed916bfa2ac",
+      "fingerprint": "2574d2e1f2d090b9",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -414,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e6b60e663bdeb4b5",
+      "fingerprint": "4684d46d3e9ed4ba",
       "id": "GET /observability/destinations",
       "method": "GET",
       "operation_id": "listObservabilityDestinations",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "510a50aa20bc478d",
+      "fingerprint": "f6a02d96a127d2fb",
       "id": "GET /observability/destinations/{id}",
       "method": "GET",
       "operation_id": "getObservabilityDestination",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1688e70dc78a6d2e",
+      "fingerprint": "9312fc5514215fa6",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -447,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "64b8b887344334a0",
+      "fingerprint": "a90b5c3dd05907d3",
       "id": "GET /presets",
       "method": "GET",
       "operation_id": "listPresets",
@@ -458,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2f401e04bbdce18c",
+      "fingerprint": "74aabffbcb745a92",
       "id": "GET /presets/{slug}",
       "method": "GET",
       "operation_id": "getPreset",
@@ -469,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0e2ac7a69da8f49b",
+      "fingerprint": "8cc0d3d675380036",
       "id": "GET /presets/{slug}/versions",
       "method": "GET",
       "operation_id": "listPresetVersions",
@@ -480,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b40dbfe8a12b0060",
+      "fingerprint": "cc40dcaf01755861",
       "id": "GET /presets/{slug}/versions/{version}",
       "method": "GET",
       "operation_id": "getPresetVersion",
@@ -491,7 +491,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8ff8eb8b38fdeadd",
+      "fingerprint": "0190e638a75a742c",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -502,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "280fb5424a4592c1",
+      "fingerprint": "b0430f4a6ffa4c65",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -513,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d362ff6551959875",
+      "fingerprint": "fb1755e343f1ad00",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -524,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f32cade2ff8a4051",
+      "fingerprint": "800226a4045deb52",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -535,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "634565e76efca746",
+      "fingerprint": "f620e15efc87f708",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -546,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "04c5ff4b21a5f2d8",
+      "fingerprint": "5e91b64f55580e2e",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -557,7 +557,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a9afaca77f1d96b2",
+      "fingerprint": "c3eb5912b9234772",
+      "id": "GET /workspaces/{id}/budgets",
+      "method": "GET",
+      "operation_id": "listWorkspaceBudgets",
+      "path": "/workspaces/{id}/budgets",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "c842a460f3c4a1be",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -568,7 +579,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4eef56f24cf213b9",
+      "fingerprint": "4f57a8b8f08fbbee",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -579,7 +590,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0fbc8d8c7c39be05",
+      "fingerprint": "ebfe6f0d6437a64d",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -590,7 +601,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "43f31fd2d1723823",
+      "fingerprint": "f131c45a71b39858",
       "id": "PATCH /observability/destinations/{id}",
       "method": "PATCH",
       "operation_id": "updateObservabilityDestination",
@@ -601,7 +612,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "63b7e147e7befdae",
+      "fingerprint": "649393331ddf22fa",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -612,7 +623,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d66f5f405b714b43",
+      "fingerprint": "01f96879b8a1e317",
       "id": "POST /analytics/query",
       "method": "POST",
       "operation_id": "queryAnalytics",
@@ -623,7 +634,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e08a32f59a79d92d",
+      "fingerprint": "d12e8b9041f8f80f",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -634,7 +645,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "804f6d6fffd86bc3",
+      "fingerprint": "9dce64a7a8c3e600",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -645,7 +656,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d493aa172fcebce7",
+      "fingerprint": "c424a5da1b3397d0",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -656,7 +667,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ceb109a1b4b0ff2c",
+      "fingerprint": "79c3df353d9a81c4",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -667,7 +678,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d986df71a15038aa",
+      "fingerprint": "7e331bbbb6def65c",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -678,7 +689,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "242ef7374f80f5b8",
+      "fingerprint": "f092096268bd0c64",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -689,7 +700,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "b01e3928aa482584",
+      "fingerprint": "460f78d19065c975",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -700,7 +711,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2c3bf36d941e5e40",
+      "fingerprint": "d8539cd4dfe48055",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -711,7 +722,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6bc0405724ba1da1",
+      "fingerprint": "21587cdf56af8364",
       "id": "POST /files",
       "method": "POST",
       "operation_id": "uploadFile",
@@ -722,7 +733,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fa02a19eae7e5167",
+      "fingerprint": "1fce35e980af57e9",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -733,7 +744,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d3bf39f02a393587",
+      "fingerprint": "1e173c303b2ff6ba",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -744,7 +755,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3a6c0c7a7694c7eb",
+      "fingerprint": "7b9cda7b1e3ce55f",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -755,7 +766,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2f024097c594b765",
+      "fingerprint": "64055d638a961139",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -766,7 +777,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c13b770c0e4a29da",
+      "fingerprint": "642759fa50e0f210",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -777,7 +788,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "56e0a2b04ddc58dd",
+      "fingerprint": "dc02bce8d250dcc5",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -788,7 +799,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7c1b6348992c9c42",
+      "fingerprint": "83c130d286f04c98",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -799,7 +810,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "aabc5a92b0ef0a7f",
+      "fingerprint": "5086e3ca90802aa9",
       "id": "POST /observability/destinations",
       "method": "POST",
       "operation_id": "createObservabilityDestination",
@@ -810,7 +821,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0f65e8f433079357",
+      "fingerprint": "02a5cadb680a8406",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -821,7 +832,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "72c70404cdff22b3",
+      "fingerprint": "8f48682816552737",
       "id": "POST /presets/{slug}/messages",
       "method": "POST",
       "operation_id": "createPresetsMessages",
@@ -832,7 +843,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7494e4885f2cd5c8",
+      "fingerprint": "699e6676994f161c",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -843,7 +854,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ef5d825e75e81780",
+      "fingerprint": "23afa870a3b5fc86",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -854,7 +865,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2e102463943fe255",
+      "fingerprint": "2f8138db981da192",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -865,7 +876,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "09ecbcc519124a17",
+      "fingerprint": "d962d3d1324b6269",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -876,7 +887,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bd9843e05ec237fb",
+      "fingerprint": "397a8a2e22c940f0",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -887,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2556147014e762fc",
+      "fingerprint": "bcd57c55024b39f7",
       "id": "POST /workspaces/{id}/members/add",
       "method": "POST",
       "operation_id": "bulkAddWorkspaceMembers",
@@ -898,11 +909,22 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "921b0ff6f318c0df",
+      "fingerprint": "d3a2a804cb7e2d88",
       "id": "POST /workspaces/{id}/members/remove",
       "method": "POST",
       "operation_id": "bulkRemoveWorkspaceMembers",
       "path": "/workspaces/{id}/members/remove",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "f51f3d510f964b63",
+      "id": "PUT /workspaces/{id}/budgets/{interval}",
+      "method": "PUT",
+      "operation_id": "upsertWorkspaceBudget",
+      "path": "/workspaces/{id}/budgets/{interval}",
       "tags": [
         "Workspaces"
       ]

--- a/src/api/analytics.rs
+++ b/src/api/analytics.rs
@@ -194,6 +194,8 @@ pub struct AnalyticsQueryResponse {
     pub cached_at: Option<f64>,
     pub data: Vec<HashMap<String, Value>>,
     pub metadata: AnalyticsQueryMetadata,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::{
+    api::models::ModelReasoning,
     error::OpenRouterError,
     transport::{request as transport_request, response as transport_response},
     types::ApiResponse,
@@ -129,6 +130,8 @@ pub struct UserModel {
     pub default_parameters: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration_date: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ModelReasoning>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
 }
@@ -408,6 +411,119 @@ pub struct BenchmarksDAResponse {
     pub meta: BenchmarksDAMeta,
 }
 
+/// Query parameters for the unified benchmarks endpoint.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct UnifiedBenchmarksParams {
+    #[builder(setter(into))]
+    pub source: String,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_type: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arena: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_results: Option<u32>,
+}
+
+impl UnifiedBenchmarksParams {
+    pub fn builder() -> UnifiedBenchmarksParamsBuilder {
+        UnifiedBenchmarksParamsBuilder::default()
+    }
+
+    pub fn artificial_analysis() -> Self {
+        Self {
+            source: "artificial-analysis".to_string(),
+            task_type: None,
+            arena: None,
+            category: None,
+            max_results: None,
+        }
+    }
+
+    pub fn design_arena() -> Self {
+        Self {
+            source: "design-arena".to_string(),
+            task_type: None,
+            arena: None,
+            category: None,
+            max_results: None,
+        }
+    }
+}
+
+/// One Artificial Analysis row returned by `GET /benchmarks`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct UnifiedBenchmarksAAItem {
+    pub source: String,
+    pub model_permaslug: String,
+    pub display_name: String,
+    pub intelligence_index: Option<f64>,
+    pub coding_index: Option<f64>,
+    pub agentic_index: Option<f64>,
+    pub pricing: Option<BenchmarkPricing>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// One Design Arena row returned by `GET /benchmarks`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct UnifiedBenchmarksDAItem {
+    pub source: String,
+    pub model_permaslug: String,
+    pub display_name: String,
+    pub arena: String,
+    pub category: String,
+    pub elo: f64,
+    pub win_rate: f64,
+    pub avg_generation_time_ms: Option<f64>,
+    pub tournament_stats: DesignArenaTournamentStats,
+    pub pricing: Option<BenchmarkPricing>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// One benchmark row returned by `GET /benchmarks`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum UnifiedBenchmarkItem {
+    DesignArena(UnifiedBenchmarksDAItem),
+    ArtificialAnalysis(UnifiedBenchmarksAAItem),
+    Other(HashMap<String, serde_json::Value>),
+}
+
+/// Metadata for the unified benchmarks endpoint.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct UnifiedBenchmarksMeta {
+    pub as_of: String,
+    pub version: String,
+    pub source: String,
+    pub source_url: String,
+    pub citation: String,
+    pub model_count: u64,
+    pub task_type: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Unified benchmark response returned by `GET /benchmarks`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct UnifiedBenchmarksResponse {
+    pub data: Vec<UnifiedBenchmarkItem>,
+    pub meta: UnifiedBenchmarksMeta,
+}
+
 /// List all providers (`GET /providers`).
 pub async fn list_providers(
     base_url: &str,
@@ -577,6 +693,37 @@ pub(crate) async fn get_app_rankings_with_client(
     }
 }
 
+/// Return benchmark rows from a selected benchmark source (`GET /benchmarks`).
+pub async fn get_benchmarks(
+    base_url: &str,
+    api_key: &str,
+    params: &UnifiedBenchmarksParams,
+) -> Result<UnifiedBenchmarksResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_benchmarks_with_client(&http_client, base_url, api_key, params).await
+}
+
+pub(crate) async fn get_benchmarks_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    params: &UnifiedBenchmarksParams,
+) -> Result<UnifiedBenchmarksResponse, OpenRouterError> {
+    let url = format!("{base_url}/benchmarks");
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .query(params)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "benchmarks").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
 #[derive(Serialize)]
 struct BenchmarkMaxResultsQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -584,6 +731,7 @@ struct BenchmarkMaxResultsQuery {
 }
 
 /// Return Artificial Analysis benchmark rows.
+#[deprecated(note = "use get_benchmarks with source `artificial-analysis`")]
 pub async fn get_benchmarks_artificial_analysis(
     base_url: &str,
     api_key: &str,
@@ -629,6 +777,7 @@ struct DesignArenaQuery<'a> {
 }
 
 /// Return Design Arena benchmark rows.
+#[deprecated(note = "use get_benchmarks with source `design-arena`")]
 pub async fn get_benchmarks_design_arena(
     base_url: &str,
     api_key: &str,

--- a/src/api/embeddings.rs
+++ b/src/api/embeddings.rs
@@ -241,6 +241,16 @@ pub struct EmbeddingPromptTokensDetails {
     pub video_tokens: Option<u32>,
 }
 
+/// Provider-level cost breakdown for embedding requests.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct EmbeddingCostDetails {
+    pub upstream_inference_completions_cost: f64,
+    pub upstream_inference_prompt_cost: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_inference_cost: Option<f64>,
+}
+
 /// Token/cost usage for embedding request.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
@@ -251,6 +261,8 @@ pub struct EmbeddingUsage {
     pub prompt_tokens_details: Option<EmbeddingPromptTokensDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_details: Option<EmbeddingCostDetails>,
 }
 
 /// Response body for `POST /embeddings`.

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -218,6 +218,19 @@ impl AnthropicContentPart {
         }
     }
 
+    pub fn document_file_id(file_id: impl Into<String>) -> Self {
+        Self::Document {
+            source: json!({
+                "type": "file",
+                "file_id": file_id.into()
+            }),
+            title: None,
+            context: None,
+            citations: None,
+            cache_control: None,
+        }
+    }
+
     pub fn tool_use(
         id: impl Into<String>,
         name: impl Into<String>,

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -9,7 +9,7 @@ use urlencoding::encode;
 use crate::{
     error::OpenRouterError,
     transport::{request as transport_request, response as transport_response},
-    types::{ApiResponse, ModelCategory, SupportedParameters},
+    types::{ApiResponse, Effort, ModelCategory, SupportedParameters},
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -44,6 +44,8 @@ pub struct Model {
     pub links: Option<ModelLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub benchmarks: Option<ModelBenchmarks>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ModelReasoning>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
@@ -127,6 +129,22 @@ pub struct ModelBenchmarks {
     pub artificial_analysis: Option<AABenchmarkEntry>,
     #[serde(default)]
     pub design_arena: Vec<DABenchmarkEntry>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ModelReasoning {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_effort: Option<Effort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_enabled: Option<bool>,
+    pub mandatory: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported_efforts: Option<Vec<Effort>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_max_tokens: Option<bool>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+
 use derive_builder::Builder;
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeMap};
+use serde_json::Value;
 use urlencoding::encode;
 
 use crate::{
@@ -233,6 +236,43 @@ pub struct WorkspaceMembersRemoveResponse {
     pub removed_count: f64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct WorkspaceBudget {
+    pub id: String,
+    pub workspace_id: String,
+    pub limit_usd: f64,
+    pub reset_interval: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ListWorkspaceBudgetsResponse {
+    pub data: Vec<WorkspaceBudget>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct UpsertWorkspaceBudgetRequest {
+    pub limit_usd: f64,
+}
+
+impl UpsertWorkspaceBudgetRequest {
+    pub fn builder() -> UpsertWorkspaceBudgetRequestBuilder {
+        UpsertWorkspaceBudgetRequestBuilder::default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct DeleteWorkspaceBudgetResponse {
+    deleted: bool,
+}
+
 pub async fn list_workspaces(
     base_url: &str,
     management_key: &str,
@@ -438,6 +478,126 @@ pub(crate) async fn delete_workspace_with_client(
     if response.status().is_success() {
         let payload: DeleteWorkspaceResponse =
             transport_response::parse_json_response(response, "workspace deletion").await?;
+        Ok(payload.deleted)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn list_workspace_budgets(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<ListWorkspaceBudgetsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_workspace_budgets_with_client(&http_client, base_url, management_key, id).await
+}
+
+pub(crate) async fn list_workspace_budgets_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<ListWorkspaceBudgetsResponse, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}/budgets", encode(id));
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "workspace budget list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn upsert_workspace_budget(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    interval: &str,
+    request: &UpsertWorkspaceBudgetRequest,
+) -> Result<WorkspaceBudget, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    upsert_workspace_budget_with_client(
+        &http_client,
+        base_url,
+        management_key,
+        id,
+        interval,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn upsert_workspace_budget_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    interval: &str,
+    request: &UpsertWorkspaceBudgetRequest,
+) -> Result<WorkspaceBudget, OpenRouterError> {
+    let url = format!(
+        "{base_url}/workspaces/{}/budgets/{}",
+        encode(id),
+        encode(interval)
+    );
+    let response = transport_request::with_bearer_auth(
+        transport_request::put(http_client, &url),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: ApiResponse<WorkspaceBudget> =
+            transport_response::parse_json_response(response, "workspace budget upsert").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn delete_workspace_budget(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    interval: &str,
+) -> Result<bool, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_workspace_budget_with_client(&http_client, base_url, management_key, id, interval).await
+}
+
+pub(crate) async fn delete_workspace_budget_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    interval: &str,
+) -> Result<bool, OpenRouterError> {
+    let url = format!(
+        "{base_url}/workspaces/{}/budgets/{}",
+        encode(id),
+        encode(interval)
+    );
+    let response = transport_request::with_bearer_auth(
+        transport_request::delete(http_client, &url),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let payload: DeleteWorkspaceBudgetResponse =
+            transport_response::parse_json_response(response, "workspace budget deletion").await?;
         Ok(payload.deleted)
     } else {
         transport_response::handle_error(response).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1883,7 +1883,29 @@ impl OpenRouterClient {
         }
     }
 
+    /// Return benchmark rows from a selected source.
+    ///
+    /// Equivalent to `GET /benchmarks`.
+    pub async fn get_benchmarks(
+        &self,
+        params: &discovery::UnifiedBenchmarksParams,
+    ) -> Result<discovery::UnifiedBenchmarksResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            discovery::get_benchmarks_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                params,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Return Artificial Analysis benchmark rows.
+    #[deprecated(note = "use get_benchmarks with source `artificial-analysis`")]
+    #[allow(deprecated)]
     pub async fn get_benchmarks_artificial_analysis(
         &self,
         max_results: Option<u32>,
@@ -1902,6 +1924,8 @@ impl OpenRouterClient {
     }
 
     /// Return Design Arena benchmark rows.
+    #[deprecated(note = "use get_benchmarks with source `design-arena`")]
+    #[allow(deprecated)]
     pub async fn get_benchmarks_design_arena(
         &self,
         arena: Option<&str>,
@@ -2290,6 +2314,66 @@ impl OpenRouterClient {
                 &self.base_url,
                 management_key,
                 id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List budgets configured for a workspace (`GET /workspaces/{id}/budgets`).
+    pub async fn list_workspace_budgets(
+        &self,
+        id: &str,
+    ) -> Result<workspaces::ListWorkspaceBudgetsResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::list_workspace_budgets_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Create or update a workspace budget (`PUT /workspaces/{id}/budgets/{interval}`).
+    pub async fn upsert_workspace_budget(
+        &self,
+        id: &str,
+        interval: &str,
+        request: &workspaces::UpsertWorkspaceBudgetRequest,
+    ) -> Result<workspaces::WorkspaceBudget, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::upsert_workspace_budget_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                interval,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Delete a workspace budget (`DELETE /workspaces/{id}/budgets/{interval}`).
+    pub async fn delete_workspace_budget(
+        &self,
+        id: &str,
+        interval: &str,
+    ) -> Result<bool, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::delete_workspace_budget_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                interval,
             )
             .await
         } else {
@@ -2697,7 +2781,17 @@ impl<'a> ModelsClient<'a> {
         self.client.get_app_rankings(params).await
     }
 
+    /// Return benchmark rows from a selected source (`GET /benchmarks`).
+    pub async fn get_benchmarks(
+        &self,
+        params: &discovery::UnifiedBenchmarksParams,
+    ) -> Result<discovery::UnifiedBenchmarksResponse, OpenRouterError> {
+        self.client.get_benchmarks(params).await
+    }
+
     /// Return Artificial Analysis benchmark rows.
+    #[deprecated(note = "use get_benchmarks with source `artificial-analysis`")]
+    #[allow(deprecated)]
     pub async fn get_benchmarks_artificial_analysis(
         &self,
         max_results: Option<u32>,
@@ -2708,6 +2802,8 @@ impl<'a> ModelsClient<'a> {
     }
 
     /// Return Design Arena benchmark rows.
+    #[deprecated(note = "use get_benchmarks with source `design-arena`")]
+    #[allow(deprecated)]
     pub async fn get_benchmarks_design_arena(
         &self,
         arena: Option<&str>,
@@ -3217,6 +3313,35 @@ impl<'a> ManagementClient<'a> {
     /// Delete a workspace (`DELETE /workspaces/{id}`).
     pub async fn delete_workspace(&self, id: &str) -> Result<bool, OpenRouterError> {
         self.client.delete_workspace(id).await
+    }
+
+    /// List budgets for a workspace (`GET /workspaces/{id}/budgets`).
+    pub async fn list_workspace_budgets(
+        &self,
+        id: &str,
+    ) -> Result<workspaces::ListWorkspaceBudgetsResponse, OpenRouterError> {
+        self.client.list_workspace_budgets(id).await
+    }
+
+    /// Create or update a workspace budget (`PUT /workspaces/{id}/budgets/{interval}`).
+    pub async fn upsert_workspace_budget(
+        &self,
+        id: &str,
+        interval: &str,
+        request: &workspaces::UpsertWorkspaceBudgetRequest,
+    ) -> Result<workspaces::WorkspaceBudget, OpenRouterError> {
+        self.client
+            .upsert_workspace_budget(id, interval, request)
+            .await
+    }
+
+    /// Delete a workspace budget (`DELETE /workspaces/{id}/budgets/{interval}`).
+    pub async fn delete_workspace_budget(
+        &self,
+        id: &str,
+        interval: &str,
+    ) -> Result<bool, OpenRouterError> {
+        self.client.delete_workspace_budget(id, interval).await
     }
 
     /// Add workspace members (`POST /workspaces/{id}/members/add`).

--- a/src/transport/request.rs
+++ b/src/transport/request.rs
@@ -14,6 +14,10 @@ pub(crate) fn post(client: &Client, url: &str) -> RequestBuilder {
     request(client, Method::POST, url)
 }
 
+pub(crate) fn put(client: &Client, url: &str) -> RequestBuilder {
+    request(client, Method::PUT, url)
+}
+
 pub(crate) fn patch(client: &Client, url: &str) -> RequestBuilder {
     request(client, Method::PATCH, url)
 }

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -53,6 +53,20 @@ pub struct ResponseCostDetails {
     pub upstream_inference_cost: Option<f64>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ServerToolUseDetails {
+    /// Number of OpenRouter server tool calls that executed and produced a result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls_executed: Option<u32>,
+    /// Number of OpenRouter server-orchestrated tool calls requested by the model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls_requested: Option<u32>,
+    /// Number of web searches performed by server-side tools.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_search_requests: Option<u32>,
+}
+
 /// Token and billing usage reported for chat completion responses.
 ///
 /// Response payloads are intentionally constructed by deserialization rather than
@@ -89,6 +103,9 @@ pub struct ResponseUsage {
     /// Whether the request was billed through BYOK provider credentials.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_byok: Option<bool>,
+    /// Server-side tool execution usage when returned by OpenRouter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_tool_use_details: Option<ServerToolUseDetails>,
 }
 
 impl ResponseUsage {
@@ -100,6 +117,7 @@ impl ResponseUsage {
             cost: None,
             cost_details: None,
             is_byok: None,
+            server_tool_use_details: None,
         }
     }
 }

--- a/tests/unit/analytics.rs
+++ b/tests/unit/analytics.rs
@@ -143,7 +143,8 @@ fn test_analytics_query_response_deserializes() {
                 "query_time_ms": 42,
                 "row_count": 1,
                 "truncated": false
-            }
+            },
+            "warnings": ["unresolved api_key_id hash"]
         }
     }"#;
 
@@ -151,6 +152,10 @@ fn test_analytics_query_response_deserializes() {
         serde_json::from_str(raw).expect("analytics query response should deserialize");
     assert_eq!(parsed.data.metadata.row_count, 1);
     assert_eq!(parsed.data.data[0]["request_count"], json!(1500));
+    assert_eq!(
+        parsed.data.warnings.as_deref(),
+        Some(["unresolved api_key_id hash".to_string()].as_slice())
+    );
 }
 
 #[tokio::test]

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -9,8 +9,8 @@ use std::{
 use openrouter_rs::{
     OpenRouterClient,
     api::{
-        analytics, audio, auth, byok, chat, credits, embeddings, files, guardrails, messages,
-        observability, rerank, responses, videos, workspaces,
+        analytics, audio, auth, byok, chat, credits, discovery, embeddings, files, guardrails,
+        messages, observability, rerank, responses, videos, workspaces,
     },
     error::OpenRouterError,
     types::{ModelCategory, PaginationOptions, Role, SupportedParameters},
@@ -326,17 +326,9 @@ async fn test_models_domain_renamed_methods_require_api_key() {
         Err(OpenRouterError::KeyNotConfigured)
     ));
 
-    let aa = client
-        .models()
-        .get_benchmarks_artificial_analysis(Some(10))
-        .await;
-    assert!(matches!(aa, Err(OpenRouterError::KeyNotConfigured)));
-
-    let da = client
-        .models()
-        .get_benchmarks_design_arena(Some("models"), None, Some(10))
-        .await;
-    assert!(matches!(da, Err(OpenRouterError::KeyNotConfigured)));
+    let benchmark_params = discovery::UnifiedBenchmarksParams::artificial_analysis();
+    let benchmarks = client.models().get_benchmarks(&benchmark_params).await;
+    assert!(matches!(benchmarks, Err(OpenRouterError::KeyNotConfigured)));
 
     let by_category = client
         .models()
@@ -558,6 +550,10 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
         .name("Updated")
         .build()
         .expect("update workspace request should build");
+    let budget_request = workspaces::UpsertWorkspaceBudgetRequest::builder()
+        .limit_usd(100.0)
+        .build()
+        .expect("budget request should build");
     let workspace_members_request = workspaces::WorkspaceMembersRequest::builder()
         .user_ids(vec!["user_1".to_string()])
         .build()
@@ -916,6 +912,24 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
     ));
     assert!(matches!(
         client.management().delete_workspace("ws_123").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().list_workspace_budgets("ws_123").await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .upsert_workspace_budget("ws_123", "monthly", &budget_request)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .delete_workspace_budget("ws_123", "monthly")
+            .await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
     assert!(matches!(

--- a/tests/unit/completion.rs
+++ b/tests/unit/completion.rs
@@ -264,7 +264,12 @@ fn test_usage_deserializes_openrouter_cost_fields() {
                 "upstream_inference_completions_cost": 0.00015,
                 "upstream_inference_cost": null
             },
-            "is_byok": false
+            "is_byok": false,
+            "server_tool_use_details": {
+                "tool_calls_requested": 2,
+                "tool_calls_executed": 1,
+                "web_search_requests": 1
+            }
         }
     }"#;
 
@@ -278,6 +283,12 @@ fn test_usage_deserializes_openrouter_cost_fields() {
     assert_eq!(cost_details.upstream_inference_prompt_cost, 0.0001);
     assert_eq!(cost_details.upstream_inference_completions_cost, 0.00015);
     assert_eq!(cost_details.upstream_inference_cost, None);
+    let server_tool_use = usage
+        .server_tool_use_details
+        .expect("server tool details should be present");
+    assert_eq!(server_tool_use.tool_calls_requested, Some(2));
+    assert_eq!(server_tool_use.tool_calls_executed, Some(1));
+    assert_eq!(server_tool_use.web_search_requests, Some(1));
 }
 
 /// Test deserialization of multimodal assistant content parts

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -10,9 +10,9 @@ use openrouter_rs::{
     api::discovery::{
         self, ActivityItem, AppRankingsParams, AppRankingsResponse, BenchmarksAAResponse,
         BenchmarksDAResponse, BigNumber, ModelsCountData, Provider, PublicEndpoint,
-        RankingsDailyResponse, UserModel,
+        RankingsDailyResponse, UnifiedBenchmarkItem, UnifiedBenchmarksParams, UserModel,
     },
-    types::ApiResponse,
+    types::{ApiResponse, Effort},
 };
 
 struct CapturedRequest {
@@ -126,7 +126,14 @@ fn test_models_for_user_response_deserialization() {
             "supported_parameters": ["temperature", "top_p"],
             "supported_voices": ["alloy", "verse"],
             "default_parameters": null,
-            "expiration_date": null
+            "expiration_date": null,
+            "reasoning": {
+                "default_effort": "medium",
+                "default_enabled": true,
+                "mandatory": false,
+                "supported_efforts": ["high", "medium", "low"],
+                "supports_max_tokens": true
+            }
         }]
     }"#;
 
@@ -147,6 +154,16 @@ fn test_models_for_user_response_deserialization() {
         parsed.data[0].pricing.completion,
         BigNumber::Number(_)
     ));
+    let reasoning = parsed.data[0]
+        .reasoning
+        .as_ref()
+        .expect("reasoning metadata should deserialize");
+    assert!(matches!(
+        reasoning.default_effort.as_ref(),
+        Some(Effort::Medium)
+    ));
+    assert!(!reasoning.mandatory);
+    assert_eq!(reasoning.supports_max_tokens, Some(true));
 }
 
 #[test]
@@ -620,42 +637,56 @@ async fn test_get_app_rankings_path_query_and_auth_header() {
 }
 
 #[tokio::test]
-async fn test_get_benchmark_dataset_paths_and_queries() {
+async fn test_get_benchmarks_path_queries_and_auth_header() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":[],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"artificial-analysis","source_url":"https://artificialanalysis.ai","citation":"Source","model_count":0}}"#,
+        r#"{"data":[{"source":"artificial-analysis","model_permaslug":"openai/gpt-4o","display_name":"GPT-4o","intelligence_index":71.2,"coding_index":65.8,"agentic_index":58.3,"pricing":{"prompt":"0.0000025","completion":"0.00001"}}],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"artificial-analysis","source_url":"https://artificialanalysis.ai","citation":"Source","model_count":1,"task_type":"coding"}}"#,
     );
-    let aa = discovery::get_benchmarks_artificial_analysis(&base_url, "api-key", Some(25))
+    let params = UnifiedBenchmarksParams::builder()
+        .source("artificial-analysis")
+        .task_type("coding")
+        .max_results(25)
+        .build()
+        .expect("benchmark params should build");
+    let aa = discovery::get_benchmarks(&base_url, "api-key", &params)
         .await
-        .expect("AA benchmark request should succeed");
-    assert!(aa.data.is_empty());
+        .expect("benchmark request should succeed");
+    assert_eq!(aa.meta.source, "artificial-analysis");
+    assert!(matches!(
+        &aa.data[0],
+        UnifiedBenchmarkItem::ArtificialAnalysis(item) if item.display_name == "GPT-4o"
+    ));
     let captured = rx
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture AA request");
     assert_eq!(
         captured.request_line,
-        "GET /api/v1/datasets/benchmarks/artificial-analysis?max_results=25 HTTP/1.1"
+        "GET /api/v1/benchmarks?source=artificial-analysis&task_type=coding&max_results=25 HTTP/1.1"
     );
     server.join().expect("AA server thread should finish");
 
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":[],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"design-arena","source_url":"https://www.designarena.ai","citation":"Source","model_count":0,"arena":"models","category":"codecategories","elo_bounds":{"min":0,"max":0}}}"#,
+        r#"{"data":[{"source":"design-arena","model_permaslug":"anthropic/claude-sonnet-4","display_name":"Claude Sonnet 4","arena":"models","category":"codecategories","elo":1423,"win_rate":72,"avg_generation_time_ms":3200,"tournament_stats":{"first_place":12,"second_place":8,"third_place":5,"fourth_place":2,"total":27},"pricing":null}],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"design-arena","source_url":"https://www.designarena.ai","citation":"Source","model_count":1,"task_type":null}}"#,
     );
-    let da = discovery::get_benchmarks_design_arena(
-        &base_url,
-        "api-key",
-        Some("models"),
-        Some("codecategories"),
-        Some(20),
-    )
-    .await
-    .expect("Design Arena benchmark request should succeed");
-    assert!(da.data.is_empty());
+    let params = UnifiedBenchmarksParams::builder()
+        .source("design-arena")
+        .arena("models")
+        .category("codecategories")
+        .max_results(20)
+        .build()
+        .expect("benchmark params should build");
+    let da = discovery::get_benchmarks(&base_url, "api-key", &params)
+        .await
+        .expect("Design Arena benchmark request should succeed");
+    assert!(matches!(
+        &da.data[0],
+        UnifiedBenchmarkItem::DesignArena(item) if item.elo == 1423.0
+    ));
     let captured = rx
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture Design Arena request");
     assert_eq!(
         captured.request_line,
-        "GET /api/v1/datasets/benchmarks/design-arena?arena=models&category=codecategories&max_results=20 HTTP/1.1"
+        "GET /api/v1/benchmarks?source=design-arena&arena=models&category=codecategories&max_results=20 HTTP/1.1"
     );
     server
         .join()

--- a/tests/unit/embeddings.rs
+++ b/tests/unit/embeddings.rs
@@ -90,13 +90,30 @@ fn test_embedding_response_float_deserialization() {
             {"object":"embedding","embedding":[0.1,0.2,0.3],"index":0}
         ],
         "model": "openai/text-embedding-3-large",
-        "usage": {"prompt_tokens": 8, "total_tokens": 8, "cost": 0.00001}
+        "usage": {
+            "prompt_tokens": 8,
+            "total_tokens": 8,
+            "cost": 0.00001,
+            "cost_details": {
+                "upstream_inference_prompt_cost": 0.000006,
+                "upstream_inference_completions_cost": 0.0,
+                "upstream_inference_cost": null
+            }
+        }
     }"#;
 
     let response: EmbeddingResponse =
         serde_json::from_str(raw).expect("embedding response should deserialize");
     assert_eq!(response.object, "list");
     assert_eq!(response.data.len(), 1);
+    let cost_details = response
+        .usage
+        .as_ref()
+        .and_then(|usage| usage.cost_details.as_ref())
+        .expect("embedding cost details should deserialize");
+    assert_eq!(cost_details.upstream_inference_prompt_cost, 0.000006);
+    assert_eq!(cost_details.upstream_inference_completions_cost, 0.0);
+    assert_eq!(cost_details.upstream_inference_cost, None);
 
     match &response.data[0].embedding {
         EmbeddingVector::Float(values) => assert_eq!(values.len(), 3),

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -138,6 +138,21 @@ fn test_anthropic_messages_response_deserialization() {
 }
 
 #[test]
+fn test_anthropic_document_file_id_part_serializes() {
+    let message = AnthropicMessage::user(vec![AnthropicContentPart::document_file_id(
+        "file_011CNha8iCJcU1wXNR6q4V8w",
+    )]);
+    let value = serde_json::to_value(&message).expect("message should serialize");
+
+    assert_eq!(value["content"][0]["type"], "document");
+    assert_eq!(value["content"][0]["source"]["type"], "file");
+    assert_eq!(
+        value["content"][0]["source"]["file_id"],
+        "file_011CNha8iCJcU1wXNR6q4V8w"
+    );
+}
+
+#[test]
 fn test_anthropic_messages_system_role_roundtrip() {
     let message = AnthropicMessage::system("Follow the policy.");
     let value = serde_json::to_value(&message).expect("system message should serialize");

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -200,6 +200,13 @@ fn test_model_response_deserializes_links_and_benchmarks() {
                     "win_rate": 62.5,
                     "rank": 5
                 }]
+            },
+            "reasoning": {
+                "default_effort": "high",
+                "default_enabled": true,
+                "mandatory": false,
+                "supported_efforts": ["high", "medium", "low", "minimal"],
+                "supports_max_tokens": true
             }
         }
     }"#;
@@ -227,6 +234,16 @@ fn test_model_response_deserializes_links_and_benchmarks() {
             .rank,
         5
     );
+    let reasoning = parsed
+        .data
+        .reasoning
+        .as_ref()
+        .expect("reasoning metadata should be present");
+    assert!(matches!(
+        reasoning.default_effort.as_ref(),
+        Some(openrouter_rs::types::Effort::High)
+    ));
+    assert_eq!(reasoning.supports_max_tokens, Some(true));
 }
 
 #[tokio::test]

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -8,8 +8,9 @@ use std::{
 
 use openrouter_rs::{
     api::workspaces::{
-        self, CreateWorkspaceRequest, UpdateWorkspaceRequest, Workspace, WorkspaceListResponse,
-        WorkspaceMembersAddResponse, WorkspaceMembersRemoveResponse, WorkspaceMembersRequest,
+        self, CreateWorkspaceRequest, UpdateWorkspaceRequest, UpsertWorkspaceBudgetRequest,
+        Workspace, WorkspaceBudget, WorkspaceListResponse, WorkspaceMembersAddResponse,
+        WorkspaceMembersRemoveResponse, WorkspaceMembersRequest,
     },
     types::{ApiResponse, PaginationOptions},
 };
@@ -299,6 +300,38 @@ fn test_workspace_list_and_member_response_deserialization() {
     assert_eq!(remove.removed_count, 2.0);
 }
 
+#[test]
+fn test_workspace_budget_response_deserialization() {
+    let raw = r#"{
+        "data": [{
+            "id": "770e8400-e29b-41d4-a716-446655440000",
+            "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
+            "limit_usd": 100,
+            "reset_interval": "monthly",
+            "created_at": "2025-08-24T10:30:00Z",
+            "updated_at": "2025-08-24T15:45:00Z"
+        }]
+    }"#;
+
+    let parsed: workspaces::ListWorkspaceBudgetsResponse =
+        serde_json::from_str(raw).expect("workspace budget list should deserialize");
+    assert_eq!(parsed.data.len(), 1);
+    assert_eq!(parsed.data[0].limit_usd, 100.0);
+    assert_eq!(parsed.data[0].reset_interval.as_deref(), Some("monthly"));
+
+    let lifetime_raw = r#"{
+        "id": "770e8400-e29b-41d4-a716-446655440000",
+        "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
+        "limit_usd": 1000,
+        "reset_interval": null,
+        "created_at": "2025-08-24T10:30:00Z",
+        "updated_at": "2025-08-24T15:45:00Z"
+    }"#;
+    let lifetime: WorkspaceBudget =
+        serde_json::from_str(lifetime_raw).expect("lifetime workspace budget should deserialize");
+    assert_eq!(lifetime.reset_interval, None);
+}
+
 #[tokio::test]
 async fn test_list_workspaces_path_pagination_and_auth_header() {
     let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
@@ -463,6 +496,82 @@ async fn test_delete_workspace_encodes_id_path() {
     assert_eq!(
         captured.request_line,
         "DELETE /api/v1/workspaces/team%2Fprod%201 HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_workspace_budgets_encodes_id_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[]}"#);
+
+    let budgets = workspaces::list_workspace_budgets(&base_url, "mgmt-key", "team/prod 1")
+        .await
+        .expect("list workspace budgets should succeed");
+    assert!(budgets.data.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces/team%2Fprod%201/budgets HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_upsert_workspace_budget_encodes_path_and_body() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"770e8400-e29b-41d4-a716-446655440000","workspace_id":"550e8400-e29b-41d4-a716-446655440000","limit_usd":100,"reset_interval":"monthly","created_at":"2025-08-24T10:30:00Z","updated_at":"2025-08-24T15:45:00Z"}}"#,
+    );
+    let request = UpsertWorkspaceBudgetRequest::builder()
+        .limit_usd(100.0)
+        .build()
+        .expect("budget request should build");
+
+    let budget = workspaces::upsert_workspace_budget(
+        &base_url,
+        "mgmt-key",
+        "team/prod 1",
+        "monthly",
+        &request,
+    )
+    .await
+    .expect("upsert workspace budget should succeed");
+    assert_eq!(budget.limit_usd, 100.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "PUT /api/v1/workspaces/team%2Fprod%201/budgets/monthly HTTP/1.1"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body["limit_usd"], 100.0);
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_delete_workspace_budget_encodes_path() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"deleted":true}"#);
+
+    let deleted =
+        workspaces::delete_workspace_budget(&base_url, "mgmt-key", "team/prod 1", "lifetime")
+            .await
+            .expect("delete workspace budget should succeed");
+    assert!(deleted);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "DELETE /api/v1/workspaces/team%2Fprod%201/budgets/lifetime HTTP/1.1"
     );
 
     server.join().expect("server thread should finish");


### PR DESCRIPTION
## Summary

- add the canonical `GET /benchmarks` SDK surface via `client.models().get_benchmarks(...)`
- add management-key workspace budget methods for listing, upserting, and deleting workspace budgets
- type stable schema additions for model reasoning metadata, analytics warnings, server-tool usage, embedding cost details, and Anthropic file document inputs
- refresh the tracked OpenAPI baseline and endpoint matrix to 83 / 83 official endpoints

## Why

Issue #222 reported actionable upstream OpenAPI drift: the benchmark endpoints moved to a unified shape, workspace budgets became official, and several stable response fields were added. The SDK now exposes the accepted surface while keeping the old per-source benchmark methods as deprecated compatibility wrappers.

Closes #222.

## Validation

- `just openapi-drift-check`
- `just test-unit`
- `just quality`
- `just quality-ci`