### PR TITLE
feat: accept issue 225 OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added typed SDK support for image generation (`POST /images`, `GET /images/models`, and `GET /images/models/{author}/{slug}/endpoints`) via `api::images` and the canonical `client.images()` surface.
+- Added typed SDK support for task classification discovery via `GET /classifications/task` and `client.models().get_task_classifications(...)`.
 - Added top-level `cache_control` support to chat completion and Responses API request builders for automatic prompt caching.
 - Added typed SDK support for the Files API (`GET|POST /files`, `GET|DELETE /files/{file_id}`, and `GET /files/{file_id}/content`) via `api::files` and the canonical `client.files()` surface.
 - Added typed management-key SDK support for analytics metadata and query endpoints (`GET /analytics/meta`, `POST /analytics/query`) via `api::analytics` and `client.management().get_analytics_meta(...)` / `query_analytics(...)`.
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed `GenerationData::preset_id` support on `GET /generation` metadata responses.
 
 ### Changed
+- Accepted the 2026-06-29 OpenAPI drift review, including image generation endpoints, task classification discovery, optional unified benchmark source filters, nullable benchmark citation metadata, and Responses debug options, restoring the repository snapshot to `87 / 87` official OpenAPI endpoint coverage.
 - Accepted the 2026-06-22 OpenAPI drift review, including unified benchmarks, workspace budget management, model reasoning metadata, analytics warnings, server-tool usage metadata, embedding cost details, and Anthropic file document helpers, restoring the repository snapshot to `83 / 83` official OpenAPI endpoint coverage.
 - Deprecated the legacy `get_benchmarks_artificial_analysis(...)` and `get_benchmarks_design_arena(...)` compatibility methods in favor of `get_benchmarks(...)`.
 - Accepted the 2026-06-16 OpenAPI drift review, including analytics, files, app rankings, benchmark datasets, singular model lookup, preset read/version endpoints, model filter/schema refreshes, rerank multimodal documents, and video input reference refreshes, restoring the repository snapshot to `81 / 81` official OpenAPI endpoint coverage.

--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 </div>
 
-`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, video generation, models, embeddings, files, presets, analytics, and management APIs, plus a companion CLI in the same repository.
+`openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, image generation, video generation, models, embeddings, files, presets, analytics, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `81 / 81` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `87 / 87` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
-- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `files()`, `models()`, `management()`, and opt-in `legacy()`
+- Domain-oriented clients: `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `images()`, `videos()`, `files()`, `models()`, `management()`, and opt-in `legacy()`
 - Typed request/response models with builder-style ergonomics
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
-- Streaming support for chat, responses, and messages, including a unified stream abstraction
+- Streaming support for chat, responses, messages, and image generation, including a unified stream abstraction
 - Typed tools, manual JSON-schema tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
 - Opt-in OpenRouter response metadata for chat, Responses API, and Anthropic-compatible Messages requests
-- Discovery, rankings and benchmark datasets, rerank, audio speech/transcription, video generation, files, embeddings, API-key management, preset creation/readback/versioning, analytics, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Discovery, rankings and benchmark datasets, task classifications, rerank, audio speech/transcription, image generation, video generation, files, embeddings, API-key management, preset creation/readback/versioning, analytics, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -105,9 +105,10 @@ The canonical public surface is domain-oriented:
 | `rerank()` | `create` | `/rerank` | API key |
 | `audio().speech()` | `create` | `/audio/speech` (legacy `/tts` fallback) | API key |
 | `audio().transcriptions()` | `create` | `/audio/transcriptions` | API key |
+| `images()` | `create`, `stream`, `list_models`, `list_model_endpoints` | `/images*` | API key |
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `files()` | `list`, `upload`, `get_metadata`, `download_content`, `delete` | `/files*` | API key |
-| `models()` | `list`, `list_filtered`, `list_by_category`, `list_by_parameters`, `get`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `get_app_rankings`, `get_benchmarks`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/model*`, `/models*`, `/providers`, `/datasets/*`, `/benchmarks`, `/endpoints/zdr`, `/embeddings*` | API key |
+| `models()` | `list`, `list_filtered`, `list_by_category`, `list_by_parameters`, `get`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `get_app_rankings`, `get_task_classifications`, `get_benchmarks`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/model*`, `/models*`, `/providers`, `/datasets/*`, `/classifications/task`, `/benchmarks`, `/endpoints/zdr`, `/embeddings*` | API key |
 | `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_presets`, `get_preset`, `list_preset_versions`, `get_preset_version`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `get_analytics_meta`, `query_analytics`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `list_workspace_budgets`, `upsert_workspace_budget`, `delete_workspace_budget`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/analytics*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
@@ -128,11 +129,11 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 `openrouter-rs` is not just a thin `/chat/completions` wrapper. The repo currently covers:
 
 - chat completions, responses, and Anthropic-compatible messages
-- rerank, audio speech generation, audio transcription, and video generation polling/content retrieval
+- rerank, audio speech generation, audio transcription, image generation, and video generation polling/content retrieval
 - unified streaming across chat, responses, and messages
 - manual tools and typed tools backed by `schemars`
 - multimodal chat content, including image, audio, video, and file parts
-- model discovery, provider discovery, app rankings, unified benchmarks, embeddings, and ZDR endpoints
+- model discovery, provider discovery, app rankings, task classifications, unified benchmarks, embeddings, and ZDR endpoints
 - typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
 - management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
@@ -171,6 +172,7 @@ The repo includes runnable examples for the highest-value workflows:
 | [`examples/create_rerank.rs`](examples/create_rerank.rs) | `rerank().create(...)` |
 | [`examples/create_speech.rs`](examples/create_speech.rs) | `audio().speech().create(...)` |
 | [`examples/create_transcription.rs`](examples/create_transcription.rs) | `audio().transcriptions().create(...)` |
+| [`examples/create_image_generation.rs`](examples/create_image_generation.rs) | `images().create(...)` |
 | [`examples/create_video_generation.rs`](examples/create_video_generation.rs) | `videos().create(...)` |
 | [`examples/create_embedding.rs`](examples/create_embedding.rs) | `models().create_embedding(...)` |
 | [`examples/domain_management_api_keys.rs`](examples/domain_management_api_keys.rs) | API-key management via `management()` |
@@ -196,6 +198,7 @@ cargo run --example create_message
 cargo run --example create_rerank
 cargo run --example create_speech
 cargo run --example create_transcription
+cargo run --example create_image_generation
 cargo run --example create_embedding
 cargo run --example list_byok_keys
 cargo run --example list_observability_destinations
@@ -226,7 +229,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`81 / 81`)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`87 / 87`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
@@ -256,7 +259,7 @@ Full migration guide: [`MIGRATION.md`](MIGRATION.md)
 - `OpenRouterError::HttpRequest(surf::Error)` -> `OpenRouterError::HttpRequest(HttpRequestError)`
 - `ApiErrorContext.status: surf::StatusCode` -> `ApiErrorContext.status: http::StatusCode`
 - `openrouter_rs::utils::{with_bearer_auth, with_request_metadata, with_client_request_headers, handle_error}` -> caller-owned transport helpers or direct use of the canonical domain clients
-- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `videos()`, `files()`, `models()`, `management()`, and `legacy()`
+- No API migration is required if you only use `OpenRouterClient` plus `chat()`, `responses()`, `messages()`, `rerank()`, `audio()`, `images()`, `videos()`, `files()`, `models()`, `management()`, and `legacy()`
 
 ### 🔁 0.6 Naming/Pagination Migration
 
@@ -329,8 +332,8 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ### Unreleased
 
-- Added typed SDK coverage for files, analytics, app rankings, unified benchmarks, singular model lookup, preset listing/readback/versioning, workspace budgets, extended model filters, multimodal rerank documents, and richer video input references.
-- Accepted OpenAPI drift through the 2026-06-22 review and restored the tracked endpoint snapshot to `83 / 83`.
+- Added typed SDK coverage for images, task classifications, files, analytics, app rankings, unified benchmarks, singular model lookup, preset listing/readback/versioning, workspace budgets, extended model filters, multimodal rerank documents, and richer video input references.
+- Accepted OpenAPI drift through the 2026-06-29 review and restored the tracked endpoint snapshot to `87 / 87`.
 
 ### Version 0.10.0 *(Latest)*
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,19 +1,20 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-06-22
+Snapshot date: 2026-06-29
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `83` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `83 / 83` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 83` endpoints currently exercised.
+- Official OpenAPI endpoints: `87` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `87 / 87` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 87` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
 
+- Upstream added task classification discovery and image generation endpoints. The SDK now exposes task classifications through `client.models().get_task_classifications(...)` and images through `client.images().create(...)`, `stream(...)`, `list_models()`, and `list_model_endpoints(...)`. The unified benchmarks endpoint now allows an omitted `source`, and nullable benchmark metadata is reflected in the typed response.
 - Upstream replaced the two per-source benchmark dataset endpoints with unified `GET /benchmarks` and added workspace budget management. The SDK now exposes `client.models().get_benchmarks(...)` and `client.management().list_workspace_budgets(...)` / `upsert_workspace_budget(...)` / `delete_workspace_budget(...)`. The old per-source benchmark methods remain deprecated compatibility wrappers.
 - Upstream added model reasoning metadata, analytics warnings, chat server-tool usage metadata, embedding cost details, and Anthropic file document sources. The SDK now exposes typed fields/helpers for these stable surfaces while preserving flexible `Value` and `HashMap` escape hatches for high-churn payloads.
 - Official audio speech routing is now `POST /audio/speech`. The SDK keeps the canonical `client.audio().speech().create(...)` surface and retries legacy `POST /tts` only as a compatibility fallback.
@@ -40,7 +41,7 @@ Drift review note:
 Legend:
 
 - `SDK`: endpoint implemented in `openrouter-rs`.
-- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `files()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
+- Canonical surface note: docs and examples prefer domain clients (`chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `images()`, `videos()`, `files()`, `models()`, `management()`). Some rows still mention retained flat `OpenRouterClient::*` wrappers when they exist.
 - `Unit`: unit coverage depth.
   - `Path` = test asserts HTTP method/path (often with header/body checks).
   - `Contract` = serde/request-shape/parser coverage only.
@@ -64,6 +65,7 @@ Legend:
 | `DELETE /byok/{id}` | `client.management().delete_byok_key(...)` | Yes | Path | No | P1 |
 | `GET /benchmarks` | `client.models().get_benchmarks(...)` | Yes | Path | No | P2 |
 | `POST /chat/completions` | `client.chat().create(...)` / `client.chat().stream(...)` | Yes | Contract | Yes | Keep |
+| `GET /classifications/task` | `client.models().get_task_classifications(...)` | Yes | Path | No | P2 |
 | `GET /credits` | `client.get_credits()` / `client.management().get_credits()` | Yes | Path | No | P2 |
 | `POST /credits/coinbase` | `client.create_coinbase_charge(...)` / `client.management().create_coinbase_charge(...)` | Yes | Path | No | P2 |
 | `GET /datasets/app-rankings` | `client.models().get_app_rankings(...)` | Yes | Path | No | P2 |
@@ -91,6 +93,9 @@ Legend:
 | `POST /guardrails/{id}/assignments/members/remove` | `client.management().delete_guardrail_member_assignments(...)` | Yes | Path | No | P1 |
 | `GET /guardrails/assignments/keys` | `client.management().list_key_assignments(...)` | Yes | Path | No | P1 |
 | `GET /guardrails/assignments/members` | `client.management().list_member_assignments(...)` | Yes | Path | No | P1 |
+| `POST /images` | `client.images().create(...)` / `client.images().stream(...)` | Yes | Path | No | P2 |
+| `GET /images/models` | `client.images().list_models()` | Yes | Path | No | P2 |
+| `GET /images/models/{author}/{slug}/endpoints` | `client.images().list_model_endpoints(...)` | Yes | Path | No | P2 |
 | `GET /key` | `client.get_current_api_key_info()` / `client.management().get_current_api_key_info()` | Yes | Contract | Yes | Keep |
 | `GET /keys` | `client.management().list_api_keys(...)` / `client.management().list_api_keys_in_workspace(...)` | Yes | Path | Yes | Keep |
 | `POST /keys` | `client.create_api_key(...)` / `client.create_api_key_in_workspace(...)` / `client.management().create_api_key(...)` / `client.management().create_api_key_in_workspace(...)` | Yes | Path | Yes | Keep |
@@ -153,7 +158,7 @@ The endpoints below are intentionally kept as legacy compatibility and are not p
 2. P1: add management-key live smoke coverage for `/activity` and `/analytics*`.
 3. P1: add controlled file lifecycle live coverage for `/files*` once upload/download fixtures and cleanup guarantees are defined.
 4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets*`, `/benchmarks`, `/model/{author}/{slug}`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
-5. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, and `/videos*` once stable fixtures and cost controls are defined.
+5. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, `/images*`, and `/videos*` once stable fixtures and cost controls are defined.
 6. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
 7. P1: add management-key live validation for `/byok*` and `/observability/destinations*` once safe test credentials and destination fixtures are defined.
 

--- a/examples/create_image_generation.rs
+++ b/examples/create_image_generation.rs
@@ -1,0 +1,27 @@
+use openrouter_rs::{OpenRouterClient, api::images::ImageGenerationRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set");
+    let client = OpenRouterClient::builder().api_key(api_key).build()?;
+
+    let request = ImageGenerationRequest::builder()
+        .model("bytedance-seed/seedream-4.5")
+        .prompt("A red panda astronaut floating in space, studio lighting")
+        .aspect_ratio("16:9")
+        .resolution("2K")
+        .build()?;
+
+    let response = client.images().create(&request).await?;
+    println!("created: {}", response.created);
+    println!("images: {}", response.data.len());
+    if let Some(first) = response.data.first() {
+        println!("first image base64 bytes: {}", first.b64_json.len());
+        println!(
+            "first image media type: {}",
+            first.media_type.as_deref().unwrap_or("image/png")
+        );
+    }
+
+    Ok(())
+}

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1,13 +1,23 @@
 {
   "components": {
     "parameters": {
+      "AppCategories": {
+        "description": "Comma-separated list of app categories (e.g. \"cli-agent,cloud-agent\"). Used for marketplace rankings.\n",
+        "in": "header",
+        "name": "X-OpenRouter-Categories",
+        "schema": {
+          "type": "string"
+        },
+        "x-speakeasy-name-override": "appCategories"
+      },
       "AppDisplayName": {
         "description": "The app display name allows you to customize how your app appears in OpenRouter's dashboard.\n",
         "in": "header",
-        "name": "X-Title",
+        "name": "X-OpenRouter-Title",
         "schema": {
           "type": "string"
-        }
+        },
+        "x-speakeasy-name-override": "appTitle"
       },
       "AppIdentifier": {
         "description": "The app identifier should be your app's URL and is used as the primary identifier for rankings.\nThis is used to track API usage per application.\n",
@@ -209,6 +219,7 @@
           "effort": {
             "description": "Reasoning effort level for the advisor call.",
             "enum": [
+              "max",
               "xhigh",
               "high",
               "medium",
@@ -3105,6 +3116,41 @@
         ],
         "type": "object"
       },
+      "ApiErrorType": {
+        "description": "Canonical OpenRouter error type, stable across all API formats",
+        "enum": [
+          "context_length_exceeded",
+          "max_tokens_exceeded",
+          "token_limit_exceeded",
+          "string_too_long",
+          "authentication",
+          "permission_denied",
+          "payment_required",
+          "rate_limit_exceeded",
+          "provider_overloaded",
+          "provider_unavailable",
+          "invalid_request",
+          "invalid_prompt",
+          "not_found",
+          "precondition_failed",
+          "payload_too_large",
+          "unprocessable",
+          "content_policy_violation",
+          "refusal",
+          "invalid_image",
+          "image_too_large",
+          "image_too_small",
+          "unsupported_image_format",
+          "image_not_found",
+          "image_download_failed",
+          "server",
+          "timeout",
+          "unmapped"
+        ],
+        "example": "rate_limit_exceeded",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
       "AppRankingsItem": {
         "example": {
           "app_id": 12345,
@@ -3725,8 +3771,10 @@
           "google-ai-studio",
           "google-vertex",
           "groq",
+          "heygen",
           "inception",
           "inceptron",
+          "inferact-vllm",
           "inference-net",
           "infermatic",
           "inflection",
@@ -3754,9 +3802,11 @@
           "perplexity",
           "phala",
           "poolside",
+          "quiver",
           "recraft",
           "reka",
           "relace",
+          "sakana-ai",
           "sambanova",
           "seed",
           "siliconflow",
@@ -3764,6 +3814,7 @@
           "stepfun",
           "streamlake",
           "switchpoint",
+          "tenstorrent",
           "together",
           "upstage",
           "venice",
@@ -4904,7 +4955,8 @@
             "type": "integer"
           },
           "error": {
-            "$ref": "#/components/schemas/ResponsesErrorField"
+            "$ref": "#/components/schemas/ResponsesErrorField",
+            "nullable": true
           },
           "frequency_penalty": {
             "format": "double",
@@ -4915,10 +4967,12 @@
             "type": "string"
           },
           "incomplete_details": {
-            "$ref": "#/components/schemas/IncompleteDetails"
+            "$ref": "#/components/schemas/IncompleteDetails",
+            "nullable": true
           },
           "instructions": {
-            "$ref": "#/components/schemas/BaseInputs"
+            "$ref": "#/components/schemas/BaseInputs",
+            "nullable": true
           },
           "max_output_tokens": {
             "nullable": true,
@@ -5007,7 +5061,8 @@
             "type": "string"
           },
           "reasoning": {
-            "$ref": "#/components/schemas/BaseReasoningConfig"
+            "$ref": "#/components/schemas/BaseReasoningConfig",
+            "nullable": true
           },
           "safety_identifier": {
             "nullable": true,
@@ -5028,7 +5083,8 @@
             "type": "number"
           },
           "text": {
-            "$ref": "#/components/schemas/TextConfig"
+            "$ref": "#/components/schemas/TextConfig",
+            "nullable": true
           },
           "tool_choice": {
             "$ref": "#/components/schemas/OpenAIResponsesToolChoice"
@@ -5117,6 +5173,7 @@
             "type": "array"
           },
           "top_logprobs": {
+            "nullable": true,
             "type": "integer"
           },
           "top_p": {
@@ -5125,7 +5182,8 @@
             "type": "number"
           },
           "truncation": {
-            "$ref": "#/components/schemas/Truncation"
+            "$ref": "#/components/schemas/Truncation",
+            "nullable": true
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAIResponsesUsage"
@@ -5337,10 +5395,23 @@
           }
         ]
       },
-      "BigNumberUnion": {
-        "description": "Price per million prompt tokens",
-        "example": 1000,
-        "type": "string"
+      "BooleanCapability": {
+        "description": "A supported-or-not flag. Present means the parameter is accepted.",
+        "example": {
+          "type": "boolean"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "boolean"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
       },
       "BulkAddWorkspaceMembersRequest": {
         "example": {
@@ -5613,6 +5684,37 @@
         ],
         "type": "object"
       },
+      "CapabilityDescriptor": {
+        "description": "A typed descriptor for one supported request parameter.",
+        "discriminator": {
+          "mapping": {
+            "boolean": "#/components/schemas/BooleanCapability",
+            "enum": "#/components/schemas/EnumCapability",
+            "range": "#/components/schemas/RangeCapability",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "propertyName": "type"
+        },
+        "example": {
+          "type": "enum",
+          "values": [
+            "1K",
+            "2K",
+            "4K"
+          ]
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/EnumCapability"
+          },
+          {
+            "$ref": "#/components/schemas/RangeCapability"
+          },
+          {
+            "$ref": "#/components/schemas/BooleanCapability"
+          }
+        ]
+      },
       "ChatAssistantImages": {
         "description": "Generated images from image generation models",
         "example": [
@@ -5881,11 +5983,12 @@
           "image_url": {
             "properties": {
               "detail": {
-                "description": "Image detail level for vision models",
+                "description": "Image detail level for vision models. `original` is an OpenRouter extension (not in the OpenAI Chat Completions spec) requesting true original-resolution media; it is downgraded to `high` for providers that lack an original-resolution tier.",
                 "enum": [
                   "auto",
                   "low",
-                  "high"
+                  "high",
+                  "original"
                 ],
                 "type": "string",
                 "x-speakeasy-unknown-values": "allow"
@@ -6272,6 +6375,9 @@
           },
           {
             "$ref": "#/components/schemas/DatetimeServerTool"
+          },
+          {
+            "$ref": "#/components/schemas/FusionServerTool_OpenRouter"
           },
           {
             "$ref": "#/components/schemas/ImageGenerationServerTool_OpenRouter"
@@ -6687,6 +6793,7 @@
               "effort": {
                 "description": "Constrains effort on reasoning for reasoning models",
                 "enum": [
+                  "max",
                   "xhigh",
                   "high",
                   "medium",
@@ -6709,6 +6816,7 @@
           "reasoning_effort": {
             "description": "Shorthand for setting reasoning effort. Equivalent to setting reasoning.effort. Cannot be used simultaneously with reasoning.effort if they differ.",
             "enum": [
+              "max",
               "xhigh",
               "high",
               "medium",
@@ -7080,7 +7188,10 @@
             "description": "Error information",
             "example": {
               "code": 429,
-              "message": "Rate limit exceeded"
+              "message": "Rate limit exceeded",
+              "metadata": {
+                "error_type": "rate_limit_exceeded"
+              }
             },
             "properties": {
               "code": {
@@ -7093,6 +7204,22 @@
                 "description": "Error message",
                 "example": "Rate limit exceeded",
                 "type": "string"
+              },
+              "metadata": {
+                "description": "Structured error metadata",
+                "properties": {
+                  "error_type": {
+                    "$ref": "#/components/schemas/ApiErrorType"
+                  },
+                  "provider_code": {
+                    "description": "Upstream provider-specific error code, when available",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "error_type"
+                ],
+                "type": "object"
               }
             },
             "required": [
@@ -9641,6 +9768,73 @@
         },
         "type": "object"
       },
+      "DebugEvent": {
+        "description": "Debug event emitted when debug.echo_upstream_body is true. Contains the transformed upstream request body or timing milestones.",
+        "example": {
+          "debug": {
+            "echo_upstream_body": {
+              "messages": [],
+              "model": "anthropic/claude-sonnet-4"
+            }
+          },
+          "sequence_number": 1,
+          "type": "response.debug"
+        },
+        "properties": {
+          "debug": {
+            "properties": {
+              "echo_upstream_body": {
+                "additionalProperties": {
+                  "nullable": true
+                },
+                "type": "object"
+              },
+              "timings": {
+                "properties": {
+                  "epoch_ms": {
+                    "type": "integer"
+                  },
+                  "event": {
+                    "enum": [
+                      "adapter_request",
+                      "upstream_headers_received",
+                      "first_token_received",
+                      "upstream_body_ended"
+                    ],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow"
+                  },
+                  "start_ms": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "start_ms",
+                  "event",
+                  "epoch_ms"
+                ],
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "response.debug"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "debug",
+          "sequence_number"
+        ],
+        "type": "object"
+      },
       "DefaultParameters": {
         "additionalProperties": false,
         "description": "Default parameters for this model",
@@ -10017,6 +10211,36 @@
         "required": [
           "total",
           "available"
+        ],
+        "type": "object"
+      },
+      "EnumCapability": {
+        "description": "A parameter that accepts one of a discrete set of string values.",
+        "example": {
+          "type": "enum",
+          "values": [
+            "1K",
+            "2K",
+            "4K"
+          ]
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "enum"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "type",
+          "values"
         ],
         "type": "object"
       },
@@ -11324,7 +11548,8 @@
             "description": "A curated OpenRouter fusion preset (slugs follow `<task>-<tier>`, e.g. `general-high`). Expands server-side into the preset's analysis_models panel and judge model, so callers never name individual models. Explicitly provided `analysis_models` / `model` take precedence.",
             "enum": [
               "general-high",
-              "general-budget"
+              "general-budget",
+              "general-fast"
             ],
             "example": "general-high",
             "type": "string",
@@ -11460,6 +11685,9 @@
             "minItems": 1,
             "type": "array"
           },
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
           "max_completion_tokens": {
             "description": "Maximum number of output tokens (including reasoning tokens) each panelist and the judge model may produce per inner call. Controls the total output budget so reasoning-heavy models like GPT-5.5 do not exhaust their token allowance before producing visible text. When omitted, the provider's default applies.",
             "example": 16384,
@@ -11483,6 +11711,7 @@
               "effort": {
                 "description": "Reasoning effort level for panelist and judge inner calls.",
                 "enum": [
+                  "max",
                   "xhigh",
                   "high",
                   "medium",
@@ -11501,7 +11730,7 @@
             "type": "object"
           },
           "temperature": {
-            "description": "Sampling temperature forwarded to panelist and judge inner calls. When omitted, the provider's default applies.",
+            "description": "Temperature forwarded to panelist inner calls. The judge always runs at temperature 0 regardless of this value. When omitted, the provider's default applies.",
             "example": 0.7,
             "format": "double",
             "type": "number"
@@ -11570,6 +11799,28 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "FusionSource": {
+        "description": "A web page retrieved via web search during a fusion run.",
+        "example": {
+          "title": "Example article title",
+          "url": "https://example.com/article"
+        },
+        "properties": {
+          "title": {
+            "description": "Title of the retrieved web page.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the web page a panel or the judge retrieved during the run.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "title"
         ],
         "type": "object"
       },
@@ -12576,6 +12827,101 @@
         },
         "type": "object"
       },
+      "ImageEndpoint": {
+        "description": "An endpoint that serves a given image model.",
+        "example": {
+          "allowed_passthrough_parameters": [],
+          "pricing": [
+            {
+              "billable": "output_image",
+              "cost_usd": 0.05,
+              "unit": "image"
+            }
+          ],
+          "provider_name": "Bytedance",
+          "provider_slug": "bytedance",
+          "provider_tag": "bytedance",
+          "supported_parameters": {
+            "resolution": {
+              "type": "enum",
+              "values": [
+                "1K",
+                "2K",
+                "4K"
+              ]
+            },
+            "seed": {
+              "type": "boolean"
+            }
+          },
+          "supports_streaming": false
+        },
+        "properties": {
+          "allowed_passthrough_parameters": {
+            "description": "Provider-specific options accepted under provider.options[provider_slug].",
+            "example": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "pricing": {
+            "description": "Billable pricing lines for this endpoint.",
+            "example": [
+              {
+                "billable": "output_image",
+                "cost_usd": 0.05,
+                "unit": "image"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ImagePricingEntry"
+            },
+            "type": "array"
+          },
+          "provider_name": {
+            "description": "Provider display name",
+            "example": "Bytedance",
+            "type": "string"
+          },
+          "provider_slug": {
+            "description": "Provider slug",
+            "example": "bytedance",
+            "type": "string"
+          },
+          "provider_tag": {
+            "description": "Provider tag for request-side selection",
+            "example": "bytedance",
+            "nullable": true,
+            "type": "string"
+          },
+          "supported_parameters": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SupportedParameters"
+              },
+              {
+                "description": "The definitive set of parameters this endpoint accepts for this model."
+              }
+            ]
+          },
+          "supports_streaming": {
+            "description": "Whether this endpoint supports native SSE streaming (`stream: true` in the request).",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "provider_name",
+          "provider_slug",
+          "provider_tag",
+          "supported_parameters",
+          "allowed_passthrough_parameters",
+          "supports_streaming",
+          "pricing"
+        ],
+        "type": "object"
+      },
       "ImageGenCallCompletedEvent": {
         "allOf": [
           {
@@ -12649,6 +12995,343 @@
           "sequence_number": 3,
           "type": "response.image_generation_call.partial_image"
         }
+      },
+      "ImageGenCompletedEvent": {
+        "description": "Emitted when generation completes and the final image is available",
+        "example": {
+          "b64_json": "<base64-encoded-final-image>",
+          "created": 1748372400,
+          "type": "image_generation.completed",
+          "usage": {
+            "completion_tokens": 4175,
+            "cost": 0.04,
+            "prompt_tokens": 0,
+            "total_tokens": 4175
+          }
+        },
+        "properties": {
+          "b64_json": {
+            "description": "Base64-encoded final image data",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp (seconds) when the image was generated",
+            "type": "integer"
+          },
+          "media_type": {
+            "description": "Media type (MIME type) of the image. Omitted when the output is a standard raster format (PNG). Present for non-raster outputs such as SVG (`image/svg+xml`).",
+            "example": "image/svg+xml",
+            "type": "string"
+          },
+          "type": {
+            "description": "The event type",
+            "enum": [
+              "image_generation.completed"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ImageGenerationUsage"
+          }
+        },
+        "required": [
+          "type",
+          "b64_json",
+          "created"
+        ],
+        "type": "object"
+      },
+      "ImageGenPartialImageEvent": {
+        "description": "Emitted when a partial image becomes available during streaming generation",
+        "example": {
+          "b64_json": "<base64-encoded-partial-image>",
+          "partial_image_index": 0,
+          "type": "image_generation.partial_image"
+        },
+        "properties": {
+          "b64_json": {
+            "description": "Base64-encoded partial image data",
+            "type": "string"
+          },
+          "partial_image_index": {
+            "description": "0-based index indicating which partial image this is in the sequence",
+            "type": "integer"
+          },
+          "type": {
+            "description": "The event type",
+            "enum": [
+              "image_generation.partial_image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "partial_image_index",
+          "b64_json"
+        ],
+        "type": "object"
+      },
+      "ImageGenStreamErrorEvent": {
+        "description": "Emitted when streaming generation fails after the SSE response starts",
+        "example": {
+          "error": {
+            "code": "upstream_error",
+            "message": "The upstream provider returned an error",
+            "param": null,
+            "type": "provider_error"
+          },
+          "type": "error"
+        },
+        "properties": {
+          "error": {
+            "description": "Provider error details",
+            "properties": {
+              "code": {
+                "description": "Provider error code, when supplied",
+                "nullable": true,
+                "type": "string"
+              },
+              "message": {
+                "description": "Provider error message",
+                "type": "string"
+              },
+              "param": {
+                "description": "Request parameter associated with the error, when supplied",
+                "nullable": true,
+                "type": "string"
+              },
+              "type": {
+                "description": "Provider error type, when supplied",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "The event type",
+            "enum": [
+              "error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "error"
+        ],
+        "type": "object"
+      },
+      "ImageGenerationRequest": {
+        "description": "Image generation request input",
+        "example": {
+          "model": "bytedance-seed/seedream-4.5",
+          "prompt": "a red panda astronaut floating in space, studio lighting"
+        },
+        "properties": {
+          "aspect_ratio": {
+            "description": "Normalized aspect ratio of the generated image. Providers clamp to their supported subset.",
+            "enum": [
+              "1:1",
+              "1:2",
+              "1:4",
+              "1:8",
+              "2:1",
+              "2:3",
+              "3:2",
+              "3:4",
+              "4:1",
+              "4:3",
+              "4:5",
+              "5:4",
+              "8:1",
+              "9:16",
+              "16:9",
+              "9:19.5",
+              "19.5:9",
+              "9:20",
+              "20:9",
+              "9:21",
+              "21:9",
+              "auto"
+            ],
+            "example": "16:9",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "background": {
+            "description": "Background treatment. `transparent` requires an output_format that supports alpha (png or webp).",
+            "enum": [
+              "auto",
+              "transparent",
+              "opaque"
+            ],
+            "example": "auto",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "input_references": {
+            "description": "Reference images to guide image-to-image generation, as base64 data URLs or HTTP(S) URLs.",
+            "items": {
+              "$ref": "#/components/schemas/ContentPartImage"
+            },
+            "maxItems": 16,
+            "type": "array"
+          },
+          "model": {
+            "description": "The image generation model to use",
+            "example": "bytedance-seed/seedream-4.5",
+            "type": "string"
+          },
+          "n": {
+            "description": "Number of images to generate (1-10). Providers that only support single-image generation reject n > 1.",
+            "example": 1,
+            "type": "integer"
+          },
+          "output_compression": {
+            "description": "Compression level (0-100) for webp/jpeg output. Ignored for png and by providers without a compression knob.",
+            "example": 100,
+            "type": "integer"
+          },
+          "output_format": {
+            "description": "Encoding of the returned image bytes. Most models produce raster formats (png, jpeg, webp). SVG is supported by vectorization models (e.g. Quiver) \u2014 the SVG markup is UTF-8 base64-encoded in `b64_json`.",
+            "enum": [
+              "png",
+              "jpeg",
+              "webp",
+              "svg"
+            ],
+            "example": "png",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "prompt": {
+            "description": "Text description of the desired image",
+            "example": "a red panda astronaut floating in space, studio lighting",
+            "minLength": 1,
+            "type": "string"
+          },
+          "provider": {
+            "description": "Provider-specific passthrough configuration",
+            "properties": {
+              "options": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ProviderOptions"
+                  },
+                  {
+                    "example": {
+                      "black-forest-labs": {
+                        "guidance": 3,
+                        "steps": 40
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "quality": {
+            "description": "Rendering quality. Providers without a quality knob ignore this.",
+            "enum": [
+              "auto",
+              "low",
+              "medium",
+              "high"
+            ],
+            "example": "high",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "resolution": {
+            "description": "Normalized resolution tier of the generated image. Concrete pixel dimensions are derived per-provider.",
+            "enum": [
+              "512",
+              "1K",
+              "2K",
+              "4K"
+            ],
+            "example": "2K",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "seed": {
+            "description": "If specified, the generation will sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism is not guaranteed for all providers.",
+            "type": "integer"
+          },
+          "size": {
+            "description": "Optional. A convenience shorthand for output dimensions \u2014 pass a tier (\"2K\", \"4K\") or explicit pixels (\"2048x2048\") and we normalize it to the right dimensions for the chosen provider. Interchangeable with resolution + aspect_ratio; use those directly for enumerated, per-model discoverable values. Conflicting size + resolution/aspect_ratio is rejected.",
+            "example": "2K",
+            "type": "string"
+          },
+          "stream": {
+            "description": "If true, partial images are streamed as SSE events as they become available. Only supported by providers with native streaming (currently OpenAI). Non-streaming providers ignore this flag and return a buffered response.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "model",
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "ImageGenerationResponse": {
+        "description": "Image generation response",
+        "example": {
+          "created": 1748372400,
+          "data": [
+            {
+              "b64_json": "<base64-encoded-image>"
+            }
+          ],
+          "usage": {
+            "completion_tokens": 4175,
+            "cost": 0.04,
+            "prompt_tokens": 0,
+            "total_tokens": 4175
+          }
+        },
+        "properties": {
+          "created": {
+            "description": "Unix timestamp (seconds) when the image was generated",
+            "example": 1748372400,
+            "type": "integer"
+          },
+          "data": {
+            "description": "Generated images",
+            "items": {
+              "properties": {
+                "b64_json": {
+                  "description": "Base64-encoded image bytes",
+                  "type": "string"
+                },
+                "media_type": {
+                  "description": "Media type (MIME type) of the image. Omitted when the output is a standard raster format (PNG). Present for non-raster outputs such as SVG (`image/svg+xml`).",
+                  "example": "image/svg+xml",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "b64_json"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ImageGenerationUsage"
+          }
+        },
+        "required": [
+          "created",
+          "data"
+        ],
+        "type": "object"
       },
       "ImageGenerationServerTool": {
         "description": "Image generation tool configuration",
@@ -12819,6 +13502,432 @@
         "example": "completed",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "ImageGenerationUsage": {
+        "description": "Token and cost usage for the image generation request, when available",
+        "example": {
+          "completion_tokens": 4175,
+          "cost": 0.04,
+          "prompt_tokens": 0,
+          "total_tokens": 4175
+        },
+        "properties": {
+          "completion_tokens": {
+            "description": "The tokens generated",
+            "type": "integer"
+          },
+          "completion_tokens_details": {
+            "nullable": true,
+            "properties": {
+              "audio_tokens": {
+                "description": "Tokens generated by the model for audio output.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "image_tokens": {
+                "description": "Tokens generated by the model for image output.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "reasoning_tokens": {
+                "description": "Tokens generated by the model for reasoning.",
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "cost": {
+            "description": "Cost of the completion",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "cost_details": {
+            "$ref": "#/components/schemas/CostDetails"
+          },
+          "is_byok": {
+            "description": "Whether a request was made using a Bring Your Own Key configuration",
+            "type": "boolean"
+          },
+          "iterations": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicUsageIteration"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "prompt_tokens": {
+            "description": "Including images, input audio, and tools if any",
+            "type": "integer"
+          },
+          "prompt_tokens_details": {
+            "description": "Breakdown of tokens used in the prompt.",
+            "nullable": true,
+            "properties": {
+              "audio_tokens": {
+                "description": "Tokens used for input audio.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "cache_write_tokens": {
+                "description": "Tokens written to cache. Only returned for models with explicit caching and cache write pricing.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "cached_tokens": {
+                "description": "Tokens cached by the endpoint.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "file_tokens": {
+                "description": "Tokens used for input files/documents.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "video_tokens": {
+                "description": "Tokens used for input video.",
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "server_tool_use": {
+            "description": "Usage for server-side tool execution (e.g., web search)",
+            "nullable": true,
+            "properties": {
+              "tool_calls_executed": {
+                "description": "Number of OpenRouter server tool calls that executed and produced a result.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "tool_calls_requested": {
+                "description": "Total number of OpenRouter server-orchestrated tool calls the model requested, across all tool types. Provider-native tools (e.g. native web search) are not counted here.",
+                "nullable": true,
+                "type": "integer"
+              },
+              "web_search_requests": {
+                "description": "Number of web searches performed by server-side tools. For server-orchestrated tool calls a web search is also counted in tool_calls_requested; provider-native web search may report web_search_requests only. Do not sum the two.",
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "service_tier": {
+            "description": "The service tier used by the upstream provider for this request",
+            "nullable": true,
+            "type": "string"
+          },
+          "speed": {
+            "$ref": "#/components/schemas/AnthropicSpeed"
+          },
+          "total_tokens": {
+            "description": "Sum of the above two fields",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "ImageModelArchitecture": {
+        "example": {
+          "input_modalities": [
+            "text",
+            "image"
+          ],
+          "output_modalities": [
+            "image"
+          ]
+        },
+        "properties": {
+          "input_modalities": {
+            "description": "Supported input modalities",
+            "items": {
+              "$ref": "#/components/schemas/InputModality"
+            },
+            "type": "array"
+          },
+          "output_modalities": {
+            "description": "Supported output modalities",
+            "items": {
+              "$ref": "#/components/schemas/ImageOutputModality"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "input_modalities",
+          "output_modalities"
+        ],
+        "type": "object"
+      },
+      "ImageModelEndpointsResponse": {
+        "description": "The full per-endpoint records for an image model.",
+        "example": {
+          "endpoints": [
+            {
+              "allowed_passthrough_parameters": [],
+              "pricing": [
+                {
+                  "billable": "output_image",
+                  "cost_usd": 0.05,
+                  "unit": "image"
+                }
+              ],
+              "provider_name": "Bytedance",
+              "provider_slug": "bytedance",
+              "provider_tag": "bytedance",
+              "supported_parameters": {
+                "resolution": {
+                  "type": "enum",
+                  "values": [
+                    "1K",
+                    "2K",
+                    "4K"
+                  ]
+                }
+              },
+              "supports_streaming": false
+            }
+          ],
+          "id": "bytedance-seed/seedream-4.5"
+        },
+        "properties": {
+          "endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/ImageEndpoint"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Model slug",
+            "example": "bytedance-seed/seedream-4.5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "endpoints"
+        ],
+        "type": "object"
+      },
+      "ImageModelListItem": {
+        "description": "A single image model in the discovery listing.",
+        "example": {
+          "architecture": {
+            "input_modalities": [
+              "text",
+              "image"
+            ],
+            "output_modalities": [
+              "image"
+            ]
+          },
+          "created": 1692901234,
+          "description": "A text-to-image model.",
+          "endpoints": "/api/v1/images/models/bytedance-seed/seedream-4.5/endpoints",
+          "id": "bytedance-seed/seedream-4.5",
+          "name": "Seedream 4.5",
+          "supported_parameters": {
+            "resolution": {
+              "type": "enum",
+              "values": [
+                "1K",
+                "2K",
+                "4K"
+              ]
+            },
+            "seed": {
+              "type": "boolean"
+            }
+          },
+          "supports_streaming": false
+        },
+        "properties": {
+          "architecture": {
+            "$ref": "#/components/schemas/ImageModelArchitecture"
+          },
+          "created": {
+            "description": "Unix timestamp (seconds) of when the model was created",
+            "example": 1692901234,
+            "type": "integer"
+          },
+          "description": {
+            "example": "A text-to-image model.",
+            "type": "string"
+          },
+          "endpoints": {
+            "description": "Relative URL to the full per-endpoint records for this model",
+            "example": "/api/v1/images/models/bytedance-seed/seedream-4.5/endpoints",
+            "type": "string"
+          },
+          "id": {
+            "description": "Model slug",
+            "example": "bytedance-seed/seedream-4.5",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name",
+            "example": "Seedream 4.5",
+            "type": "string"
+          },
+          "supported_parameters": {
+            "$ref": "#/components/schemas/SupportedParameters"
+          },
+          "supports_streaming": {
+            "description": "Whether any endpoint of this model supports native SSE streaming on the dedicated Image API (i.e. `stream: true` in the request). OR across endpoints.",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "created",
+          "architecture",
+          "supported_parameters",
+          "supports_streaming",
+          "endpoints"
+        ],
+        "type": "object"
+      },
+      "ImageModelsListResponse": {
+        "description": "List of image generation models.",
+        "example": {
+          "data": [
+            {
+              "architecture": {
+                "input_modalities": [
+                  "text"
+                ],
+                "output_modalities": [
+                  "image"
+                ]
+              },
+              "created": 1692901234,
+              "description": "A text-to-image model.",
+              "endpoints": "/api/v1/images/models/bytedance-seed/seedream-4.5/endpoints",
+              "id": "bytedance-seed/seedream-4.5",
+              "name": "Seedream 4.5",
+              "supported_parameters": {
+                "resolution": {
+                  "type": "enum",
+                  "values": [
+                    "1K",
+                    "2K",
+                    "4K"
+                  ]
+                }
+              },
+              "supports_streaming": false
+            }
+          ]
+        },
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ImageModelListItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ImageOutputModality": {
+        "enum": [
+          "text",
+          "image",
+          "embeddings",
+          "audio",
+          "video",
+          "rerank",
+          "speech",
+          "transcription"
+        ],
+        "example": "image",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ImagePricingEntry": {
+        "description": "One billable pricing line for an image provider.",
+        "example": {
+          "billable": "output_image",
+          "cost_usd": 0.05,
+          "unit": "image"
+        },
+        "properties": {
+          "billable": {
+            "enum": [
+              "output_image",
+              "input_image",
+              "input_font",
+              "input_reference",
+              "input_text"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "cost_usd": {
+            "format": "double",
+            "type": "number"
+          },
+          "unit": {
+            "enum": [
+              "image",
+              "megapixel",
+              "token"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "variant": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "billable",
+          "unit",
+          "cost_usd"
+        ],
+        "type": "object"
+      },
+      "ImageStreamingResponse": {
+        "example": {
+          "data": {
+            "b64_json": "<base64-encoded-partial-image>",
+            "partial_image_index": 0,
+            "type": "image_generation.partial_image"
+          }
+        },
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ImageGenPartialImageEvent"
+              },
+              {
+                "$ref": "#/components/schemas/ImageGenCompletedEvent"
+              },
+              {
+                "$ref": "#/components/schemas/ImageGenStreamErrorEvent"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
       },
       "InProgressEvent": {
         "description": "Event emitted when a response is in progress",
@@ -15125,10 +16234,14 @@
       },
       "MessagesErrorDetail": {
         "example": {
+          "error_type": "invalid_request",
           "message": "Invalid request parameters",
           "type": "invalid_request_error"
         },
         "properties": {
+          "error_type": {
+            "$ref": "#/components/schemas/ApiErrorType"
+          },
           "message": {
             "type": "string"
           },
@@ -15146,6 +16259,7 @@
         "description": "Error event in the stream",
         "example": {
           "error": {
+            "error_type": "provider_overloaded",
             "message": "Overloaded",
             "type": "overloaded_error"
           },
@@ -15154,6 +16268,9 @@
         "properties": {
           "error": {
             "properties": {
+              "error_type": {
+                "$ref": "#/components/schemas/ApiErrorType"
+              },
               "message": {
                 "type": "string"
               },
@@ -15166,6 +16283,9 @@
               "message"
             ],
             "type": "object"
+          },
+          "openrouter_metadata": {
+            "$ref": "#/components/schemas/OpenRouterMetadata"
           },
           "type": {
             "enum": [
@@ -16576,12 +17696,14 @@
                   "Google",
                   "Google AI Studio",
                   "Groq",
+                  "HeyGen",
                   "Inception",
                   "Inceptron",
                   "InferenceNet",
                   "Ionstream",
                   "Infermatic",
                   "Io Net",
+                  "Inferact vLLM",
                   "Inflection",
                   "Liquid",
                   "Mara",
@@ -16608,6 +17730,7 @@
                   "Recraft",
                   "Reka",
                   "Relace",
+                  "Sakana AI",
                   "SambaNova",
                   "Seed",
                   "SiliconFlow",
@@ -16616,11 +17739,13 @@
                   "Stealth",
                   "StreamLake",
                   "Switchpoint",
+                  "Tenstorrent",
                   "Together",
                   "Upstage",
                   "Venice",
                   "Wafer",
                   "WandB",
+                  "Quiver",
                   "Xiaomi",
                   "xAI",
                   "Z.AI",
@@ -17679,6 +18804,7 @@
                 "type": "object"
               },
               "modelId": {
+                "description": "The name of the tracing project in Arize AX",
                 "minLength": 1,
                 "type": "string"
               },
@@ -20873,6 +21999,9 @@
           },
           {
             "properties": {
+              "error_type": {
+                "$ref": "#/components/schemas/ApiErrorType"
+              },
               "openrouter_metadata": {
                 "$ref": "#/components/schemas/OpenRouterMetadata"
               },
@@ -21616,6 +22745,13 @@
                 "model"
               ],
               "type": "object"
+            },
+            "type": "array"
+          },
+          "sources": {
+            "description": "Web pages the analysis panels and judge retrieved via web search during this fusion run, deduplicated by URL across the whole run. Present when at least one model cited a source.",
+            "items": {
+              "$ref": "#/components/schemas/FusionSource"
             },
             "type": "array"
           },
@@ -23912,12 +25048,14 @@
           "Google",
           "Google AI Studio",
           "Groq",
+          "HeyGen",
           "Inception",
           "Inceptron",
           "InferenceNet",
           "Ionstream",
           "Infermatic",
           "Io Net",
+          "Inferact vLLM",
           "Inflection",
           "Liquid",
           "Mara",
@@ -23944,6 +25082,7 @@
           "Recraft",
           "Reka",
           "Relace",
+          "Sakana AI",
           "SambaNova",
           "Seed",
           "SiliconFlow",
@@ -23952,11 +25091,13 @@
           "Stealth",
           "StreamLake",
           "Switchpoint",
+          "Tenstorrent",
           "Together",
           "Upstage",
           "Venice",
           "Wafer",
           "WandB",
+          "Quiver",
           "Xiaomi",
           "xAI",
           "Z.AI",
@@ -24244,6 +25385,12 @@
             },
             "type": "object"
           },
+          "heygen": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
           "huggingface": {
             "additionalProperties": {
               "nullable": true
@@ -24269,6 +25416,12 @@
             "type": "object"
           },
           "inceptron": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "inferact-vllm": {
             "additionalProperties": {
               "nullable": true
             },
@@ -24502,6 +25655,12 @@
             },
             "type": "object"
           },
+          "quiver": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
           "recraft": {
             "additionalProperties": {
               "nullable": true
@@ -24533,6 +25692,12 @@
             "type": "object"
           },
           "replicate": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "sakana-ai": {
             "additionalProperties": {
               "nullable": true
             },
@@ -24599,6 +25764,12 @@
             "type": "object"
           },
           "targon": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "type": "object"
+          },
+          "tenstorrent": {
             "additionalProperties": {
               "nullable": true
             },
@@ -24777,47 +25948,24 @@
             "description": "The object specifying the maximum price you want to pay for this request. USD price per million tokens, for prompt and completion.",
             "properties": {
               "audio": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "Price per audio unit"
-                  }
-                ]
+                "description": "Maximum price in USD per audio unit",
+                "type": "string"
               },
               "completion": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "Price per million completion tokens"
-                  }
-                ]
+                "description": "Maximum price in USD per million completion tokens",
+                "type": "string"
               },
               "image": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "Price per image"
-                  }
-                ]
+                "description": "Maximum price in USD per image",
+                "type": "string"
               },
               "prompt": {
-                "$ref": "#/components/schemas/BigNumberUnion"
+                "description": "Maximum price in USD per million prompt tokens",
+                "type": "string"
               },
               "request": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "Price per request"
-                  }
-                ]
+                "description": "Maximum price in USD per request",
+                "type": "string"
               }
             },
             "type": "object"
@@ -25010,12 +26158,14 @@
               "Google",
               "Google AI Studio",
               "Groq",
+              "HeyGen",
               "Inception",
               "Inceptron",
               "InferenceNet",
               "Ionstream",
               "Infermatic",
               "Io Net",
+              "Inferact vLLM",
               "Inflection",
               "Liquid",
               "Mara",
@@ -25042,6 +26192,7 @@
               "Recraft",
               "Reka",
               "Relace",
+              "Sakana AI",
               "SambaNova",
               "Seed",
               "SiliconFlow",
@@ -25050,11 +26201,13 @@
               "Stealth",
               "StreamLake",
               "Switchpoint",
+              "Tenstorrent",
               "Together",
               "Upstage",
               "Venice",
               "Wafer",
               "WandB",
+              "Quiver",
               "Xiaomi",
               "xAI",
               "Z.AI",
@@ -25194,138 +26347,65 @@
           "pricing": {
             "properties": {
               "audio": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per audio input token",
+                "type": "string"
               },
               "audio_output": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per audio output token",
+                "type": "string"
               },
               "completion": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per token for completion (output) generation",
+                "type": "string"
               },
               "discount": {
+                "description": "Fractional discount applied to this endpoint's pricing; the price is multiplied by (1 - discount) (0 = no discount, 1 = free)",
                 "format": "double",
                 "type": "number"
               },
               "image": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per input image",
+                "type": "string"
               },
               "image_output": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per output image",
+                "type": "string"
               },
               "image_token": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per image token",
+                "type": "string"
               },
               "input_audio_cache": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per cached audio input token",
+                "type": "string"
               },
               "input_cache_read": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per cached input token (read)",
+                "type": "string"
               },
               "input_cache_write": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price per cache-write token, in USD per token. For providers with multiple cache TTLs (e.g. Anthropic), this is the default (5-minute) cache-write rate.",
+                "type": "string"
+              },
+              "input_cache_write_1h": {
+                "description": "Price per 1-hour cache-write token, in USD per token. Only present for providers that price an extended (1-hour) cache TTL separately, such as Anthropic.",
+                "type": "string"
               },
               "internal_reasoning": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per internal reasoning token",
+                "type": "string"
               },
               "prompt": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per token for prompt (input) processing",
+                "type": "string"
               },
               "request": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per request",
+                "type": "string"
               },
               "web_search": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BigNumberUnion"
-                  },
-                  {
-                    "description": "A number or string value representing a large number"
-                  }
-                ]
+                "description": "Price in USD per web search",
+                "type": "string"
               }
             },
             "required": [
@@ -25421,138 +26501,65 @@
         },
         "properties": {
           "audio": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per audio input token",
+            "type": "string"
           },
           "audio_output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per audio output token",
+            "type": "string"
           },
           "completion": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per token for completion (output) generation",
+            "type": "string"
           },
           "discount": {
+            "description": "Fractional discount applied to this endpoint's pricing; the price is multiplied by (1 - discount) (0 = no discount, 1 = free)",
             "format": "double",
             "type": "number"
           },
           "image": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per input image",
+            "type": "string"
           },
           "image_output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per output image",
+            "type": "string"
           },
           "image_token": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per image token",
+            "type": "string"
           },
           "input_audio_cache": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per cached audio input token",
+            "type": "string"
           },
           "input_cache_read": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per cached input token (read)",
+            "type": "string"
           },
           "input_cache_write": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price per cache-write token, in USD per token. For providers with multiple cache TTLs (e.g. Anthropic), this is the default (5-minute) cache-write rate.",
+            "type": "string"
+          },
+          "input_cache_write_1h": {
+            "description": "Price per 1-hour cache-write token, in USD per token. Only present for providers that price an extended (1-hour) cache TTL separately, such as Anthropic.",
+            "type": "string"
           },
           "internal_reasoning": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per internal reasoning token",
+            "type": "string"
           },
           "prompt": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per token for prompt (input) processing",
+            "type": "string"
           },
           "request": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per request",
+            "type": "string"
           },
           "web_search": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BigNumberUnion"
-              },
-              {
-                "description": "A number or string value representing a large number"
-              }
-            ]
+            "description": "Price in USD per web search",
+            "type": "string"
           }
         },
         "required": [
@@ -25576,6 +26583,34 @@
         "example": "fp16",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "RangeCapability": {
+        "description": "A parameter that accepts any value within an inclusive numeric range.",
+        "example": {
+          "max": 100,
+          "min": 0,
+          "type": "range"
+        },
+        "properties": {
+          "max": {
+            "type": "number"
+          },
+          "min": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "range"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "min",
+          "max"
+        ],
+        "type": "object"
       },
       "RankingsDailyItem": {
         "example": {
@@ -25883,6 +26918,7 @@
       },
       "ReasoningEffort": {
         "enum": [
+          "max",
           "xhigh",
           "high",
           "medium",
@@ -26401,6 +27437,9 @@
           },
           "cache_control": {
             "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "debug": {
+            "$ref": "#/components/schemas/ChatDebugOptions"
           },
           "frequency_penalty": {
             "format": "double",
@@ -27579,6 +28618,7 @@
             "response.created": "#/components/schemas/OpenResponsesCreatedEvent",
             "response.custom_tool_call_input.delta": "#/components/schemas/CustomToolCallInputDeltaEvent",
             "response.custom_tool_call_input.done": "#/components/schemas/CustomToolCallInputDoneEvent",
+            "response.debug": "#/components/schemas/DebugEvent",
             "response.failed": "#/components/schemas/StreamEventsResponseFailed",
             "response.function_call_arguments.delta": "#/components/schemas/FunctionCallArgsDeltaEvent",
             "response.function_call_arguments.done": "#/components/schemas/FunctionCallArgsDoneEvent",
@@ -27767,6 +28807,9 @@
           },
           {
             "$ref": "#/components/schemas/FusionCallCompletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/DebugEvent"
           }
         ]
       },
@@ -28033,6 +29076,7 @@
           "effort": {
             "description": "Reasoning effort level for the subagent call.",
             "enum": [
+              "max",
               "xhigh",
               "high",
               "medium",
@@ -28118,6 +29162,259 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SupportedParameters": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/CapabilityDescriptor"
+        },
+        "description": "Union of supported parameters across every endpoint of this model. Coarse discovery aid; the definitive per-endpoint set is behind the endpoints URL.",
+        "example": {
+          "output_compression": {
+            "max": 100,
+            "min": 0,
+            "type": "range"
+          },
+          "resolution": {
+            "type": "enum",
+            "values": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "seed": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "TaskClassificationItem": {
+        "example": {
+          "category_token_share": 0.48,
+          "category_usage_share": 0.51,
+          "display_name": "Code Generation",
+          "macro_category": "code",
+          "models": [
+            {
+              "id": "openai/gpt-4.1-mini",
+              "tag_token_share": 0.75,
+              "tag_usage_share": 0.55
+            },
+            {
+              "id": "anthropic/claude-sonnet-4",
+              "tag_token_share": 0.12,
+              "tag_usage_share": 0.2
+            }
+          ],
+          "tag": "code:general_impl",
+          "token_share": 0.31,
+          "usage_share": 0.23
+        },
+        "properties": {
+          "category_token_share": {
+            "description": "Fraction of this classification's token volume within its macro-category (0\u20131). Sums to 1 across all classifications sharing the same `macro_category`.",
+            "example": 0.48,
+            "format": "double",
+            "type": "number"
+          },
+          "category_usage_share": {
+            "description": "Fraction of this classification's usage within its macro-category (0\u20131). Sums to 1 across all classifications sharing the same `macro_category`.",
+            "example": 0.51,
+            "format": "double",
+            "type": "number"
+          },
+          "display_name": {
+            "description": "Human-readable label for the classification.",
+            "example": "Code Generation",
+            "type": "string"
+          },
+          "macro_category": {
+            "description": "Coarse grouping derived from the tag prefix: `code`, `data`, `agent`, or `general`.",
+            "example": "code",
+            "type": "string"
+          },
+          "models": {
+            "description": "Top models for this classification by request volume, sorted descending. Each entry reports the model's share of this classification's requests and tokens.",
+            "items": {
+              "$ref": "#/components/schemas/TaskClassificationModel"
+            },
+            "type": "array"
+          },
+          "tag": {
+            "description": "Classification tag identifier (e.g. `code:general_impl`, `agent:web_search`).",
+            "example": "code:general_impl",
+            "type": "string"
+          },
+          "token_share": {
+            "description": "Fraction of classified sampled token volume (prompt + completion) attributed to this classification (0\u20131). The unclassified `other` bucket is excluded from the denominator.",
+            "example": 0.31,
+            "format": "double",
+            "type": "number"
+          },
+          "usage_share": {
+            "description": "Fraction of classified sampled requests attributed to this classification (0\u20131). The unclassified `other` bucket is excluded from the denominator.",
+            "example": 0.23,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "tag",
+          "display_name",
+          "macro_category",
+          "usage_share",
+          "token_share",
+          "category_usage_share",
+          "category_token_share",
+          "models"
+        ],
+        "type": "object"
+      },
+      "TaskClassificationMacroCategory": {
+        "example": {
+          "key": "code",
+          "label": "Code",
+          "token_share": 0.52,
+          "usage_share": 0.45
+        },
+        "properties": {
+          "key": {
+            "description": "Macro-category identifier.",
+            "example": "code",
+            "type": "string"
+          },
+          "label": {
+            "description": "Human-readable label for the macro-category.",
+            "example": "Code",
+            "type": "string"
+          },
+          "token_share": {
+            "description": "Combined token share of all classifications in this macro-category (0\u20131).",
+            "example": 0.52,
+            "format": "double",
+            "type": "number"
+          },
+          "usage_share": {
+            "description": "Combined usage share of all classifications in this macro-category (0\u20131).",
+            "example": 0.45,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "usage_share",
+          "token_share"
+        ],
+        "type": "object"
+      },
+      "TaskClassificationModel": {
+        "example": {
+          "id": "openai/gpt-4.1-mini",
+          "tag_token_share": 0.75,
+          "tag_usage_share": 0.55
+        },
+        "properties": {
+          "id": {
+            "description": "Model identifier (permaslug).",
+            "example": "openai/gpt-4.1-mini",
+            "type": "string"
+          },
+          "tag_token_share": {
+            "description": "Fraction of this classification's sampled token volume attributed to this model (0\u20131). Sums to \u22641 across the returned models (only top-N are included and unattributed requests are excluded).",
+            "example": 0.75,
+            "format": "double",
+            "type": "number"
+          },
+          "tag_usage_share": {
+            "description": "Fraction of this classification's sampled requests attributed to this model (0\u20131). Sums to \u22641 across the returned models (only top-N are included and unattributed requests are excluded).",
+            "example": 0.55,
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "tag_usage_share",
+          "tag_token_share"
+        ],
+        "type": "object"
+      },
+      "TaskClassificationResponse": {
+        "example": {
+          "data": {
+            "as_of": "2026-06-17",
+            "classifications": [
+              {
+                "category_token_share": 0.48,
+                "category_usage_share": 0.51,
+                "display_name": "Code Generation",
+                "macro_category": "code",
+                "models": [
+                  {
+                    "id": "openai/gpt-4.1-mini",
+                    "tag_token_share": 0.75,
+                    "tag_usage_share": 0.55
+                  }
+                ],
+                "tag": "code:general_impl",
+                "token_share": 0.31,
+                "usage_share": 0.23
+              }
+            ],
+            "macro_categories": [
+              {
+                "key": "code",
+                "label": "Code",
+                "token_share": 0.52,
+                "usage_share": 0.45
+              }
+            ],
+            "window_days": 7
+          }
+        },
+        "properties": {
+          "data": {
+            "properties": {
+              "as_of": {
+                "description": "UTC date (YYYY-MM-DD) of the window upper bound (yesterday). Data is exclusive of the current incomplete UTC day. This is the expected latest date in the snapshot; it does not confirm data presence for that date.",
+                "example": "2026-06-17",
+                "type": "string"
+              },
+              "classifications": {
+                "description": "Per-task classification market-share data, sorted by usage_share descending.",
+                "items": {
+                  "$ref": "#/components/schemas/TaskClassificationItem"
+                },
+                "type": "array"
+              },
+              "macro_categories": {
+                "description": "Aggregate market-share data per macro-category (code, data, agent, general).",
+                "items": {
+                  "$ref": "#/components/schemas/TaskClassificationMacroCategory"
+                },
+                "type": "array"
+              },
+              "window_days": {
+                "description": "Number of trailing days covered by this snapshot.",
+                "example": 7,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "window_days",
+              "as_of",
+              "classifications",
+              "macro_categories"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
         ],
         "type": "object"
       },
@@ -28748,8 +30045,9 @@
             "type": "string"
           },
           "citation": {
-            "description": "Required attribution when republishing this data.",
+            "description": "Required attribution when republishing this data, or null when results span multiple sources (attribute each item individually by its `source` discriminator).",
             "example": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+            "nullable": true,
             "type": "string"
           },
           "model_count": {
@@ -28757,18 +30055,21 @@
             "type": "integer"
           },
           "source": {
-            "description": "The source filter applied.",
+            "description": "The source filter applied, or null when all sources are returned.",
             "enum": [
               "artificial-analysis",
-              "design-arena"
+              "design-arena",
+              null
             ],
             "example": "artificial-analysis",
+            "nullable": true,
             "type": "string",
             "x-speakeasy-unknown-values": "allow"
           },
           "source_url": {
-            "description": "URL of the upstream data source.",
+            "description": "URL of the upstream data source, or null when results span multiple sources.",
             "example": "https://artificialanalysis.ai",
+            "nullable": true,
             "type": "string"
           },
           "task_type": {
@@ -28813,10 +30114,10 @@
           ],
           "meta": {
             "as_of": "2026-06-03T12:00:00Z",
-            "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+            "citation": null,
             "model_count": 1,
-            "source": "artificial-analysis",
-            "source_url": "https://artificialanalysis.ai",
+            "source": null,
+            "source_url": null,
             "task_type": null,
             "version": "v1"
           }
@@ -30946,7 +32247,18 @@
         "tags": [
           "Analytics"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/analytics/meta": {
       "get": {
@@ -31192,9 +32504,31 @@
         "tags": [
           "beta.Analytics"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/analytics/query": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Execute an analytics query with specified metrics, dimensions, filters, and time range. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "queryAnalytics",
@@ -31514,6 +32848,17 @@
       }
     },
     "/audio/speech": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Synthesizes audio from the input text. Returns a raw audio bytestream in the requested format (e.g. mp3, pcm, wav).",
         "operationId": "createAudioSpeech",
@@ -31718,6 +33063,17 @@
       }
     },
     "/audio/transcriptions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Transcribes audio into text. Accepts base64-encoded audio input and returns the transcribed text.",
         "operationId": "createAudioTranscriptions",
@@ -31930,6 +33286,17 @@
       }
     },
     "/auth/keys": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Exchange an authorization code from the PKCE flow for a user-controlled API key",
         "operationId": "exchangeAuthCodeForAPIKey",
@@ -32072,6 +33439,17 @@
       }
     },
     "/auth/keys/code": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create an authorization code for the PKCE flow to generate a user-controlled API key",
         "operationId": "createAuthKeysCode",
@@ -32327,12 +33705,12 @@
         "operationId": "getBenchmarks",
         "parameters": [
           {
-            "description": "Benchmark source to query. Determines the shape of the returned items.",
+            "description": "Benchmark source to query. Determines the shape of the returned items. When omitted, returns results from all sources.",
             "in": "query",
             "name": "source",
-            "required": true,
+            "required": false,
             "schema": {
-              "description": "Benchmark source to query. Determines the shape of the returned items.",
+              "description": "Benchmark source to query. Determines the shape of the returned items. When omitted, returns results from all sources.",
               "enum": [
                 "artificial-analysis",
                 "design-arena"
@@ -32388,15 +33766,13 @@
             }
           },
           {
-            "description": "Max results to return (1\u2013100, default 50).",
+            "description": "Maximum number of items to return. When omitted, all matching results are returned.",
             "in": "query",
             "name": "max_results",
             "required": false,
             "schema": {
-              "default": 50,
-              "description": "Max results to return (1\u2013100, default 50).",
-              "example": 20,
-              "maximum": 100,
+              "description": "Maximum number of items to return. When omitted, all matching results are returned.",
+              "example": 50,
               "minimum": 1,
               "type": "integer"
             }
@@ -32423,10 +33799,10 @@
                   ],
                   "meta": {
                     "as_of": "2026-06-03T12:00:00Z",
-                    "citation": "Source: Artificial Analysis (artificialanalysis.ai) via OpenRouter (openrouter.ai/rankings).",
+                    "citation": null,
                     "model_count": 1,
-                    "source": "artificial-analysis",
-                    "source_url": "https://artificialanalysis.ai",
+                    "source": null,
+                    "source_url": null,
                     "task_type": null,
                     "version": "v1"
                   }
@@ -32507,7 +33883,18 @@
         "tags": [
           "Benchmarks"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/byok": {
       "get": {
@@ -32596,8 +33983,10 @@
                 "google-ai-studio",
                 "google-vertex",
                 "groq",
+                "heygen",
                 "inception",
                 "inceptron",
+                "inferact-vllm",
                 "inference-net",
                 "infermatic",
                 "inflection",
@@ -32625,9 +34014,11 @@
                 "perplexity",
                 "phala",
                 "poolside",
+                "quiver",
                 "recraft",
                 "reka",
                 "relace",
+                "sakana-ai",
                 "sambanova",
                 "seed",
                 "siliconflow",
@@ -32635,6 +34026,7 @@
                 "stepfun",
                 "streamlake",
                 "switchpoint",
+                "tenstorrent",
                 "together",
                 "upstage",
                 "venice",
@@ -32737,8 +34129,19 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
-        "description": "Create a new bring-your-own-key (BYOK) provider credential. The raw key is encrypted at rest and never returned in API responses. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Create a new bring-your-own-key (BYOK) provider credential. The raw key is encrypted at rest and never returned in API responses. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. Treat the raw key as write-only; it is never returned after creation. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createBYOKKey",
         "requestBody": {
           "content": {
@@ -33040,6 +34443,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing bring-your-own-key (BYOK) provider credential by its `id`. Include the `key` field to rotate the raw provider API key in-place (the previous key material is overwritten). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateBYOKKey",
@@ -33171,6 +34585,17 @@
       }
     },
     "/chat/completions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming modes.",
         "operationId": "sendChatCompletionRequest",
@@ -33557,6 +34982,152 @@
         "x-speakeasy-stream-request-field": "stream"
       }
     },
+    "/classifications/task": {
+      "get": {
+        "description": "Returns the market-share breakdown of OpenRouter traffic by task classification\n(e.g. code generation, web search, summarization) over a trailing time window.\n\nEach classification reports its share of classified sampled requests (`usage_share`)\nand classified sampled token volume (`token_share`) as fractions between 0 and 1.\nThe unclassified `other` bucket is excluded. Absolute volumes are not exposed\nbecause the underlying data is sampled.\n\nEach classification also includes a `models` array listing the top models by\nrequest volume within that classification, with their within-tag usage and token shares.\n\nClassifications are grouped into macro-categories (Code, Data, Agent, General)\nwith aggregate shares provided for each.\n\nAuthenticate with any valid OpenRouter API key (same key used for inference).\nRate-limited to 30 requests/minute per key and 500 requests/day per account.\n\nWhen republishing or quoting this data, cite as:\n\"Source: OpenRouter (openrouter.ai/rankings), as of {as_of}.\"",
+        "operationId": "getTaskClassifications",
+        "parameters": [
+          {
+            "description": "Trailing time window for the classification data. Currently only `7d` (trailing 7 days) is supported.",
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "default": "7d",
+              "description": "Trailing time window for the classification data. Currently only `7d` (trailing 7 days) is supported.",
+              "enum": [
+                "7d"
+              ],
+              "example": "7d",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "as_of": "2026-06-17",
+                    "classifications": [
+                      {
+                        "category_token_share": 0.48,
+                        "category_usage_share": 0.51,
+                        "display_name": "Code Generation",
+                        "macro_category": "code",
+                        "models": [
+                          {
+                            "id": "openai/gpt-4.1-mini",
+                            "tag_token_share": 0.75,
+                            "tag_usage_share": 0.55
+                          }
+                        ],
+                        "tag": "code:general_impl",
+                        "token_share": 0.31,
+                        "usage_share": 0.23
+                      }
+                    ],
+                    "macro_categories": [
+                      {
+                        "key": "code",
+                        "label": "Code",
+                        "token_share": 0.52,
+                        "usage_share": 0.45
+                      }
+                    ],
+                    "window_days": 7
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TaskClassificationResponse"
+                }
+              }
+            },
+            "description": "Task classification market-share data for the requested trailing window."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Task classification market share",
+        "tags": [
+          "Classifications"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
     "/credits": {
       "get": {
         "description": "Get total credits purchased and used for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
@@ -33669,9 +35240,31 @@
           "Credits"
         ],
         "x-speakeasy-name-override": "getCredits"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/credits/coinbase": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "deprecated": true,
         "description": "Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been removed. Use the web credits purchase flow instead.",
@@ -33952,7 +35545,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/datasets/rankings-daily": {
       "get": {
@@ -34089,9 +35693,31 @@
         "tags": [
           "Datasets"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/embeddings": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits an embedding request to the embeddings router",
         "operationId": "createEmbeddings",
@@ -34740,7 +36366,18 @@
           "Embeddings"
         ],
         "x-speakeasy-name-override": "listModels"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/endpoints/zdr": {
       "get": {
@@ -34875,7 +36512,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "listZdrEndpoints"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/files": {
       "get": {
@@ -35032,6 +36680,17 @@
           "type": "cursor"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Uploads a file to be referenced in future API calls. The file is stored under the workspace of the authenticating API key. Maximum file size: 100 MB.",
         "operationId": "uploadFile",
@@ -35424,7 +37083,18 @@
           "Files"
         ],
         "x-speakeasy-name-override": "retrieve"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/files/{file_id}/content": {
       "get": {
@@ -35552,7 +37222,18 @@
           "Files"
         ],
         "x-speakeasy-name-override": "download"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation": {
       "get": {
@@ -35757,7 +37438,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/generation/content": {
       "get": {
@@ -35936,7 +37628,18 @@
         "tags": [
           "Generations"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails": {
       "get": {
@@ -36074,6 +37777,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new guardrail for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createGuardrail",
@@ -36326,7 +38040,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/assignments/members": {
       "get": {
@@ -36440,7 +38165,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/guardrails/{id}": {
       "delete": {
@@ -36633,8 +38369,19 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
-        "description": "Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Update an existing guardrail. Collection fields use replace semantics: send the full desired set on every update. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
         "parameters": [
           {
@@ -36914,8 +38661,19 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
-        "description": "Assign multiple API keys to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Assign multiple API keys to a specific guardrail. A key may hold at most one guardrail; assigning replaces any existing assignment. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignKeysToGuardrail",
         "parameters": [
           {
@@ -37033,6 +38791,17 @@
       }
     },
     "/guardrails/{id}/assignments/keys/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple API keys from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignKeysFromGuardrail",
@@ -37292,6 +39061,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Assign multiple organization members to a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAssignMembersToGuardrail",
@@ -37412,6 +39192,17 @@
       }
     },
     "/guardrails/{id}/assignments/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Unassign multiple organization members from a specific guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkUnassignMembersFromGuardrail",
@@ -37530,6 +39321,440 @@
         ],
         "x-speakeasy-name-override": "bulkUnassignMembers"
       }
+    },
+    "/images": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
+      "post": {
+        "description": "Generates an image from a text prompt via the image generation router",
+        "operationId": "createImages",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "model": "bytedance-seed/seedream-4.5",
+                "prompt": "a red panda astronaut floating in space, studio lighting"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ImageGenerationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "created": 1748372400,
+                  "data": [
+                    {
+                      "b64_json": "<base64-encoded-image>"
+                    }
+                  ],
+                  "usage": {
+                    "completion_tokens": 4175,
+                    "cost": 0.04,
+                    "prompt_tokens": 0,
+                    "total_tokens": 4175
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ImageGenerationResponse"
+                }
+              },
+              "text/event-stream": {
+                "example": {
+                  "data": {
+                    "b64_json": "<base64-encoded-partial-image>",
+                    "partial_image_index": 0,
+                    "type": "image_generation.partial_image"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ImageStreamingResponse"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            },
+            "description": "Image generation response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 402,
+                    "message": "Insufficient credits. Add more using https://openrouter.ai/credits"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredResponse"
+                }
+              }
+            },
+            "description": "Payment Required - Insufficient credits or quota to complete request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 429,
+                    "message": "Rate limit exceeded"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests - Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "524": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 524,
+                    "message": "Request timed out. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeNetworkTimeoutResponse"
+                }
+              }
+            },
+            "description": "Infrastructure Timeout - Provider request timed out at edge network"
+          },
+          "529": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 529,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderOverloadedResponse"
+                }
+              }
+            },
+            "description": "Provider Overloaded - Provider is temporarily overloaded"
+          }
+        },
+        "summary": "Generate an image",
+        "tags": [
+          "Images"
+        ],
+        "x-speakeasy-name-override": "generate"
+      }
+    },
+    "/images/models": {
+      "get": {
+        "description": "Lists every image generation model with its top-level supported-parameter superset and a URL to its full per-endpoint records.",
+        "operationId": "listImageModels",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "architecture": {
+                        "input_modalities": [
+                          "text"
+                        ],
+                        "output_modalities": [
+                          "image"
+                        ]
+                      },
+                      "created": 1692901234,
+                      "description": "A text-to-image model.",
+                      "endpoints": "/api/v1/images/models/bytedance-seed/seedream-4.5/endpoints",
+                      "id": "bytedance-seed/seedream-4.5",
+                      "name": "Seedream 4.5",
+                      "supported_parameters": {
+                        "resolution": {
+                          "type": "enum",
+                          "values": [
+                            "1K",
+                            "2K",
+                            "4K"
+                          ]
+                        }
+                      },
+                      "supports_streaming": false
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ImageModelsListResponse"
+                }
+              }
+            },
+            "description": "List of image generation models"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List image generation models",
+        "tags": [
+          "Images"
+        ],
+        "x-speakeasy-name-override": "listModels"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
+    },
+    "/images/models/{author}/{slug}/endpoints": {
+      "get": {
+        "description": "Returns the full per-endpoint records for an image model: each endpoint's definitive supported parameters, pricing, and passthrough allowlist.",
+        "operationId": "listImageModelEndpoints",
+        "parameters": [
+          {
+            "description": "Model author/organization",
+            "in": "path",
+            "name": "author",
+            "required": true,
+            "schema": {
+              "description": "Model author/organization",
+              "example": "bytedance-seed",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Model slug",
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "description": "Model slug",
+              "example": "seedream-4.5",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "endpoints": [
+                    {
+                      "allowed_passthrough_parameters": [],
+                      "pricing": [
+                        {
+                          "billable": "output_image",
+                          "cost_usd": 0.05,
+                          "unit": "image"
+                        }
+                      ],
+                      "provider_name": "Bytedance",
+                      "provider_slug": "bytedance",
+                      "provider_tag": "bytedance",
+                      "supported_parameters": {
+                        "resolution": {
+                          "type": "enum",
+                          "values": [
+                            "1K",
+                            "2K",
+                            "4K"
+                          ]
+                        }
+                      },
+                      "supports_streaming": false
+                    }
+                  ],
+                  "id": "bytedance-seed/seedream-4.5"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ImageModelEndpointsResponse"
+                }
+              }
+            },
+            "description": "The full per-endpoint records for an image model"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List endpoints for an image model",
+        "tags": [
+          "Images"
+        ],
+        "x-speakeasy-name-override": "listModelEndpoints"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/key": {
       "get": {
@@ -37833,7 +40058,18 @@
           "API Keys"
         ],
         "x-speakeasy-name-override": "getCurrentKeyMetadata"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/keys": {
       "get": {
@@ -38179,8 +40415,19 @@
         ],
         "x-speakeasy-name-override": "list"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
-        "description": "Create a new API key for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Create a new API key for the authenticated user. The plaintext `key` is returned only in this response. Treat it as a write-only, sensitive value; it cannot be retrieved later. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createKeys",
         "requestBody": {
           "content": {
@@ -39039,6 +41286,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateKeys",
@@ -39444,6 +41702,17 @@
       }
     },
     "/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended thinking.",
         "operationId": "createMessages",
@@ -39839,7 +42108,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "get"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models": {
       "get": {
@@ -39894,12 +42174,12 @@
             }
           },
           {
-            "description": "Sort the returned models server-side. Prefer this over fetching the full list and sorting client-side. Options: pricing-low-to-high, pricing-high-to-low (average prompt/completion price), context-high-to-low (context length), throughput-high-to-low, latency-low-to-high (recent median performance), most-popular, top-weekly (tokens processed in the last week), newest (creation date). When omitted, the existing default ordering is preserved.",
+            "description": "Sort the returned models server-side. Prefer this over fetching the full list and sorting client-side. Options: pricing-low-to-high, pricing-high-to-low (average prompt/completion price), context-high-to-low (context length), throughput-high-to-low, latency-low-to-high (recent median performance), most-popular, top-weekly (tokens processed in the last week), newest (creation date), intelligence-high-to-low (Artificial Analysis intelligence index), design-arena-elo-high-to-low (best Design Arena ELO across arenas). Models without a score for the chosen benchmark are placed last. When omitted, the existing default ordering is preserved.",
             "in": "query",
             "name": "sort",
             "required": false,
             "schema": {
-              "description": "Sort the returned models server-side. Prefer this over fetching the full list and sorting client-side. Options: pricing-low-to-high, pricing-high-to-low (average prompt/completion price), context-high-to-low (context length), throughput-high-to-low, latency-low-to-high (recent median performance), most-popular, top-weekly (tokens processed in the last week), newest (creation date). When omitted, the existing default ordering is preserved.",
+              "description": "Sort the returned models server-side. Prefer this over fetching the full list and sorting client-side. Options: pricing-low-to-high, pricing-high-to-low (average prompt/completion price), context-high-to-low (context length), throughput-high-to-low, latency-low-to-high (recent median performance), most-popular, top-weekly (tokens processed in the last week), newest (creation date), intelligence-high-to-low (Artificial Analysis intelligence index), design-arena-elo-high-to-low (best Design Arena ELO across arenas). Models without a score for the chosen benchmark are placed last. When omitted, the existing default ordering is preserved.",
               "enum": [
                 "most-popular",
                 "newest",
@@ -39908,7 +42188,9 @@
                 "pricing-high-to-low",
                 "context-high-to-low",
                 "throughput-high-to-low",
-                "latency-low-to-high"
+                "latency-low-to-high",
+                "intelligence-high-to-low",
+                "design-arena-elo-high-to-low"
               ],
               "example": "newest",
               "type": "string",
@@ -40150,7 +42432,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/count": {
       "get": {
@@ -40222,7 +42515,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "count"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/user": {
       "get": {
@@ -40345,7 +42649,18 @@
           "Models"
         ],
         "x-speakeasy-name-override": "listForUser"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/models/{author}/{slug}/endpoints": {
       "get": {
@@ -40511,7 +42826,18 @@
           "Endpoints"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/observability/destinations": {
       "get": {
@@ -40648,6 +42974,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new observability destination. A maximum of 5 destinations per type is allowed. Defaults to the authenticated entity's default workspace; use the `workspace_id` body field to scope to a different workspace. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createObservabilityDestination",
@@ -40979,6 +43316,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing observability destination. Only the fields provided in the request body are updated. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateObservabilityDestination",
@@ -41315,7 +43663,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/presets": {
       "get": {
@@ -41455,7 +43814,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/presets/{slug}": {
       "get": {
@@ -41589,9 +43959,31 @@
           "Presets"
         ],
         "x-speakeasy-name-override": "get"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/presets/{slug}/chat/completions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsChatCompletions",
@@ -41781,6 +44173,17 @@
       }
     },
     "/presets/{slug}/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsMessages",
@@ -41967,6 +44370,17 @@
       }
     },
     "/presets/{slug}/responses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a preset (or a new version of an existing one) from an inference request body. Only fields that overlap with the preset config are persisted; other fields (e.g. `messages`, `stream`, `prompt`) are silently ignored.",
         "operationId": "createPresetsResponses",
@@ -42311,7 +44725,18 @@
           },
           "type": "offsetLimit"
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/presets/{slug}/versions/{version}": {
       "get": {
@@ -42444,7 +44869,18 @@
           "Presets"
         ],
         "x-speakeasy-name-override": "getVersion"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/providers": {
       "get": {
@@ -43095,9 +45531,31 @@
           "Providers"
         ],
         "x-speakeasy-name-override": "list"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/rerank": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a rerank request to the rerank router",
         "operationId": "createRerank",
@@ -43498,6 +45956,17 @@
       }
     },
     "/responses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Creates a streaming or non-streaming response using OpenResponses API format",
         "operationId": "createResponses",
@@ -43864,6 +46333,17 @@
       }
     },
     "/videos": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Submits a video generation request and returns a polling URL to check status",
         "operationId": "createVideos",
@@ -44089,7 +46569,18 @@
         "tags": [
           "Video Generation"
         ]
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}": {
       "get": {
@@ -44184,7 +46675,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getGeneration"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos/{jobId}/content": {
       "get": {
@@ -44217,7 +46719,7 @@
         "responses": {
           "200": {
             "content": {
-              "application/octet-stream": {
+              "video/mp4": {
                 "example": "<binary video data>",
                 "schema": {
                   "format": "binary",
@@ -44225,7 +46727,7 @@
                 }
               }
             },
-            "description": "Video content stream"
+            "description": "Video content stream. The body is the raw video bytes proxied from the upstream provider, and the Content-Type reflects the provider media type (video/mp4)."
           },
           "400": {
             "content": {
@@ -44313,7 +46815,18 @@
           "Video Generation"
         ],
         "x-speakeasy-name-override": "getVideoContent"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/workspaces": {
       "get": {
@@ -44437,6 +46950,17 @@
           "type": "offsetLimit"
         }
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Create a new workspace for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "createWorkspace",
@@ -44562,7 +47086,7 @@
     },
     "/workspaces/{id}": {
       "delete": {
-        "description": "Delete an existing workspace. The default workspace cannot be deleted. Workspaces with active API keys cannot be deleted. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Delete an existing workspace. The default workspace cannot be deleted. Workspaces with active API keys cannot be deleted; remove the keys first. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "deleteWorkspace",
         "parameters": [
           {
@@ -44781,6 +47305,17 @@
         ],
         "x-speakeasy-name-override": "get"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "patch": {
         "description": "Update an existing workspace by ID or slug. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateWorkspace",
@@ -45025,7 +47560,18 @@
           "Workspaces"
         ],
         "x-speakeasy-name-override": "listBudgets"
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/workspaces/{id}/budgets/{interval}": {
       "delete": {
@@ -45124,6 +47670,17 @@
         ],
         "x-speakeasy-name-override": "deleteBudget"
       },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "put": {
         "description": "Create or update the budget for a given interval. Budget limits must strictly decrease as the interval narrows (lifetime > monthly > weekly > daily). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "upsertWorkspaceBudget",
@@ -45258,6 +47815,17 @@
       }
     },
     "/workspaces/{id}/members/add": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Add multiple organization members to a workspace. Members are assigned the same role they hold in the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkAddWorkspaceMembers",
@@ -45403,6 +47971,17 @@
       }
     },
     "/workspaces/{id}/members/remove": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
       "post": {
         "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkRemoveWorkspaceMembers",
@@ -45577,6 +48156,10 @@
       "name": "Chat"
     },
     {
+      "description": "Task classification market-share endpoints",
+      "name": "Classifications"
+    },
+    {
       "description": "Credit management endpoints",
       "name": "Credits"
     },
@@ -45603,6 +48186,10 @@
     {
       "description": "Guardrails endpoints",
       "name": "Guardrails"
+    },
+    {
+      "description": "Images endpoints",
+      "name": "Images"
     },
     {
       "description": "Model information endpoints",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-06-22T14:37:38+00:00",
+  "captured_at": "2026-06-29T14:45:40+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,11 +14,11 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 83,
+  "operation_count": 87,
   "operations": [
     {
       "deprecated": false,
-      "fingerprint": "54fa253a00ac5c42",
+      "fingerprint": "6f91deb041a1b1fa",
       "id": "DELETE /byok/{id}",
       "method": "DELETE",
       "operation_id": "deleteBYOKKey",
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "47da8e59e02d600d",
+      "fingerprint": "4ca18f79ffb216d8",
       "id": "DELETE /files/{file_id}",
       "method": "DELETE",
       "operation_id": "deleteFile",
@@ -40,7 +40,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2fb8480286edd199",
+      "fingerprint": "8004f3e140aff889",
       "id": "DELETE /guardrails/{id}",
       "method": "DELETE",
       "operation_id": "deleteGuardrail",
@@ -51,7 +51,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1745c85b0992ea6e",
+      "fingerprint": "733cf850bfa8a450",
       "id": "DELETE /keys/{hash}",
       "method": "DELETE",
       "operation_id": "deleteKeys",
@@ -62,7 +62,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7af9e020afb4c928",
+      "fingerprint": "8291a7a0a00636a7",
       "id": "DELETE /observability/destinations/{id}",
       "method": "DELETE",
       "operation_id": "deleteObservabilityDestination",
@@ -73,7 +73,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4cc4b797882b36d3",
+      "fingerprint": "2e01d56dde1346eb",
       "id": "DELETE /workspaces/{id}",
       "method": "DELETE",
       "operation_id": "deleteWorkspace",
@@ -84,7 +84,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9372d297621cc309",
+      "fingerprint": "2ea9e8d64a7e483e",
       "id": "DELETE /workspaces/{id}/budgets/{interval}",
       "method": "DELETE",
       "operation_id": "deleteWorkspaceBudget",
@@ -95,7 +95,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d9c39756fe253cfc",
+      "fingerprint": "ae78503d01b50758",
       "id": "GET /activity",
       "method": "GET",
       "operation_id": "getUserActivity",
@@ -106,7 +106,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1aec2d13e09c30e0",
+      "fingerprint": "b69b2e0455fcf869",
       "id": "GET /analytics/meta",
       "method": "GET",
       "operation_id": "getAnalyticsMeta",
@@ -117,7 +117,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c3f36f83f80a7074",
+      "fingerprint": "b699fceaa5cd6f2c",
       "id": "GET /benchmarks",
       "method": "GET",
       "operation_id": "getBenchmarks",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a594718fe535598f",
+      "fingerprint": "9e1ace6b3ac88941",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e047496712531dc0",
+      "fingerprint": "2fb6a2c371cb9f08",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -150,7 +150,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3c98257b3b15ba09",
+      "fingerprint": "f70a2390a175972b",
+      "id": "GET /classifications/task",
+      "method": "GET",
+      "operation_id": "getTaskClassifications",
+      "path": "/classifications/task",
+      "tags": [
+        "Classifications"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "a8de6e34f937d228",
       "id": "GET /credits",
       "method": "GET",
       "operation_id": "getCredits",
@@ -161,7 +172,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dd4808939eae0f28",
+      "fingerprint": "536e2f01051821eb",
       "id": "GET /datasets/app-rankings",
       "method": "GET",
       "operation_id": "getAppRankings",
@@ -172,7 +183,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "32a5aa933d91ab37",
+      "fingerprint": "83504c0454c4196d",
       "id": "GET /datasets/rankings-daily",
       "method": "GET",
       "operation_id": "getRankingsDaily",
@@ -183,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ec6055f82bb199b1",
+      "fingerprint": "21340d2b93ab5e0b",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -194,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f9560f5aeb6653a5",
+      "fingerprint": "0bd97f17af93c158",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -205,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "22c98b85de29d359",
+      "fingerprint": "52e3f38ade280a25",
       "id": "GET /files",
       "method": "GET",
       "operation_id": "listFiles",
@@ -216,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "964fb978cb483f37",
+      "fingerprint": "21192490b76d7137",
       "id": "GET /files/{file_id}",
       "method": "GET",
       "operation_id": "getFileMetadata",
@@ -227,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "07b67840637ef665",
+      "fingerprint": "75e30dae37e11592",
       "id": "GET /files/{file_id}/content",
       "method": "GET",
       "operation_id": "downloadFileContent",
@@ -238,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "efcbb378ebef2a31",
+      "fingerprint": "bc8588d66f558e5a",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -249,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1deaadf338b00e36",
+      "fingerprint": "51f1c957e6966d83",
       "id": "GET /generation/content",
       "method": "GET",
       "operation_id": "listGenerationContent",
@@ -260,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c971fe86ab8e6f1e",
+      "fingerprint": "ef509670a9999d44",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -271,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "35e6f73bb468cb70",
+      "fingerprint": "4bfed3ae865133d0",
       "id": "GET /guardrails/assignments/keys",
       "method": "GET",
       "operation_id": "listKeyAssignments",
@@ -282,7 +293,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "03bb4f3b9c8e6c2e",
+      "fingerprint": "f593364bb80429da",
       "id": "GET /guardrails/assignments/members",
       "method": "GET",
       "operation_id": "listMemberAssignments",
@@ -293,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7e90108dc4db6649",
+      "fingerprint": "d504d0be2f9c3b1a",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -304,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a9e5751ca222eb49",
+      "fingerprint": "df9126ac57b2e8a6",
       "id": "GET /guardrails/{id}/assignments/keys",
       "method": "GET",
       "operation_id": "listGuardrailKeyAssignments",
@@ -315,7 +326,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bdcbd251388c2a9f",
+      "fingerprint": "3f4a4fd0be15d281",
       "id": "GET /guardrails/{id}/assignments/members",
       "method": "GET",
       "operation_id": "listGuardrailMemberAssignments",
@@ -326,7 +337,29 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "98111f144a36687a",
+      "fingerprint": "0009a5b54f51c682",
+      "id": "GET /images/models",
+      "method": "GET",
+      "operation_id": "listImageModels",
+      "path": "/images/models",
+      "tags": [
+        "Images"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "db342379cf260880",
+      "id": "GET /images/models/{author}/{slug}/endpoints",
+      "method": "GET",
+      "operation_id": "listImageModelEndpoints",
+      "path": "/images/models/{author}/{slug}/endpoints",
+      "tags": [
+        "Images"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "5e74c6f64f3895ab",
       "id": "GET /key",
       "method": "GET",
       "operation_id": "getCurrentKey",
@@ -337,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "de272d5aefee14f8",
+      "fingerprint": "9fda652a77216fb3",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -348,7 +381,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4c7015c8e6d592b1",
+      "fingerprint": "d47719cebfea6fce",
       "id": "GET /keys/{hash}",
       "method": "GET",
       "operation_id": "getKey",
@@ -359,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9690afbafdf4f325",
+      "fingerprint": "eaa05d1e6f9d84e0",
       "id": "GET /model/{author}/{slug}",
       "method": "GET",
       "operation_id": "getModel",
@@ -370,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d061c5615ce84bb4",
+      "fingerprint": "b9614769e7c54412",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -381,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "da4869e1fabb1f97",
+      "fingerprint": "62cf82894c93d8a5",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -392,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cec3115b64b924c2",
+      "fingerprint": "6edf23e96075fc99",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -403,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2574d2e1f2d090b9",
+      "fingerprint": "62a873c744da1a36",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -414,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4684d46d3e9ed4ba",
+      "fingerprint": "e6b60e663bdeb4b5",
       "id": "GET /observability/destinations",
       "method": "GET",
       "operation_id": "listObservabilityDestinations",
@@ -425,7 +458,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f6a02d96a127d2fb",
+      "fingerprint": "510a50aa20bc478d",
       "id": "GET /observability/destinations/{id}",
       "method": "GET",
       "operation_id": "getObservabilityDestination",
@@ -436,7 +469,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9312fc5514215fa6",
+      "fingerprint": "1688e70dc78a6d2e",
       "id": "GET /organization/members",
       "method": "GET",
       "operation_id": "listOrganizationMembers",
@@ -447,7 +480,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a90b5c3dd05907d3",
+      "fingerprint": "64b8b887344334a0",
       "id": "GET /presets",
       "method": "GET",
       "operation_id": "listPresets",
@@ -458,7 +491,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "74aabffbcb745a92",
+      "fingerprint": "2f401e04bbdce18c",
       "id": "GET /presets/{slug}",
       "method": "GET",
       "operation_id": "getPreset",
@@ -469,7 +502,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8cc0d3d675380036",
+      "fingerprint": "0e2ac7a69da8f49b",
       "id": "GET /presets/{slug}/versions",
       "method": "GET",
       "operation_id": "listPresetVersions",
@@ -480,7 +513,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cc40dcaf01755861",
+      "fingerprint": "b40dbfe8a12b0060",
       "id": "GET /presets/{slug}/versions/{version}",
       "method": "GET",
       "operation_id": "getPresetVersion",
@@ -491,7 +524,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0190e638a75a742c",
+      "fingerprint": "8ff8eb8b38fdeadd",
       "id": "GET /providers",
       "method": "GET",
       "operation_id": "listProviders",
@@ -502,7 +535,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b0430f4a6ffa4c65",
+      "fingerprint": "280fb5424a4592c1",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -513,7 +546,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb1755e343f1ad00",
+      "fingerprint": "d362ff6551959875",
       "id": "GET /videos/{jobId}",
       "method": "GET",
       "operation_id": "getVideos",
@@ -524,7 +557,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "800226a4045deb52",
+      "fingerprint": "7d98bdb1e4517410",
       "id": "GET /videos/{jobId}/content",
       "method": "GET",
       "operation_id": "listVideosContent",
@@ -535,7 +568,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f620e15efc87f708",
+      "fingerprint": "634565e76efca746",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -546,7 +579,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5e91b64f55580e2e",
+      "fingerprint": "04c5ff4b21a5f2d8",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -557,7 +590,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c3eb5912b9234772",
+      "fingerprint": "7f05766153a038a1",
       "id": "GET /workspaces/{id}/budgets",
       "method": "GET",
       "operation_id": "listWorkspaceBudgets",
@@ -568,7 +601,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c842a460f3c4a1be",
+      "fingerprint": "bfe80e24eca398d9",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -579,7 +612,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4f57a8b8f08fbbee",
+      "fingerprint": "4eef56f24cf213b9",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -590,7 +623,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ebfe6f0d6437a64d",
+      "fingerprint": "0fbc8d8c7c39be05",
       "id": "PATCH /keys/{hash}",
       "method": "PATCH",
       "operation_id": "updateKeys",
@@ -601,7 +634,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f131c45a71b39858",
+      "fingerprint": "43f31fd2d1723823",
       "id": "PATCH /observability/destinations/{id}",
       "method": "PATCH",
       "operation_id": "updateObservabilityDestination",
@@ -612,7 +645,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "649393331ddf22fa",
+      "fingerprint": "63b7e147e7befdae",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -623,7 +656,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "01f96879b8a1e317",
+      "fingerprint": "fe9a662ed53226ee",
       "id": "POST /analytics/query",
       "method": "POST",
       "operation_id": "queryAnalytics",
@@ -634,7 +667,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d12e8b9041f8f80f",
+      "fingerprint": "46a4d52f9cd42f0a",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -645,7 +678,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9dce64a7a8c3e600",
+      "fingerprint": "712e87e8ceb2f8f4",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -656,7 +689,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c424a5da1b3397d0",
+      "fingerprint": "d493aa172fcebce7",
       "id": "POST /auth/keys",
       "method": "POST",
       "operation_id": "exchangeAuthCodeForAPIKey",
@@ -667,7 +700,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "79c3df353d9a81c4",
+      "fingerprint": "ceb109a1b4b0ff2c",
       "id": "POST /auth/keys/code",
       "method": "POST",
       "operation_id": "createAuthKeysCode",
@@ -678,7 +711,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7e331bbbb6def65c",
+      "fingerprint": "caab380934d6390e",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -689,7 +722,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f092096268bd0c64",
+      "fingerprint": "195ae999d7774ddc",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -700,7 +733,7 @@
     },
     {
       "deprecated": true,
-      "fingerprint": "460f78d19065c975",
+      "fingerprint": "b01e3928aa482584",
       "id": "POST /credits/coinbase",
       "method": "POST",
       "operation_id": "createCoinbaseCharge",
@@ -711,7 +744,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d8539cd4dfe48055",
+      "fingerprint": "2d7483da97e6554b",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -722,7 +755,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "21587cdf56af8364",
+      "fingerprint": "6bc0405724ba1da1",
       "id": "POST /files",
       "method": "POST",
       "operation_id": "uploadFile",
@@ -733,7 +766,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1fce35e980af57e9",
+      "fingerprint": "fa02a19eae7e5167",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -744,7 +777,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1e173c303b2ff6ba",
+      "fingerprint": "d3bf39f02a393587",
       "id": "POST /guardrails/{id}/assignments/keys",
       "method": "POST",
       "operation_id": "bulkAssignKeysToGuardrail",
@@ -755,7 +788,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7b9cda7b1e3ce55f",
+      "fingerprint": "3a6c0c7a7694c7eb",
       "id": "POST /guardrails/{id}/assignments/keys/remove",
       "method": "POST",
       "operation_id": "bulkUnassignKeysFromGuardrail",
@@ -766,7 +799,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "64055d638a961139",
+      "fingerprint": "2f024097c594b765",
       "id": "POST /guardrails/{id}/assignments/members",
       "method": "POST",
       "operation_id": "bulkAssignMembersToGuardrail",
@@ -777,7 +810,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "642759fa50e0f210",
+      "fingerprint": "c13b770c0e4a29da",
       "id": "POST /guardrails/{id}/assignments/members/remove",
       "method": "POST",
       "operation_id": "bulkUnassignMembersFromGuardrail",
@@ -788,7 +821,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dc02bce8d250dcc5",
+      "fingerprint": "8641cb058df652c1",
+      "id": "POST /images",
+      "method": "POST",
+      "operation_id": "createImages",
+      "path": "/images",
+      "tags": [
+        "Images"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "56e0a2b04ddc58dd",
       "id": "POST /keys",
       "method": "POST",
       "operation_id": "createKeys",
@@ -799,7 +843,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "83c130d286f04c98",
+      "fingerprint": "fd55bfbba90f9c45",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -810,7 +854,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5086e3ca90802aa9",
+      "fingerprint": "aabc5a92b0ef0a7f",
       "id": "POST /observability/destinations",
       "method": "POST",
       "operation_id": "createObservabilityDestination",
@@ -821,7 +865,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "02a5cadb680a8406",
+      "fingerprint": "1b40c868f2e81ab7",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -832,7 +876,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8f48682816552737",
+      "fingerprint": "1c823f3193cd2eb7",
       "id": "POST /presets/{slug}/messages",
       "method": "POST",
       "operation_id": "createPresetsMessages",
@@ -843,7 +887,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "699e6676994f161c",
+      "fingerprint": "3bd42e9634a515f5",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -854,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "23afa870a3b5fc86",
+      "fingerprint": "8ba1ce07d80b3661",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -865,7 +909,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2f8138db981da192",
+      "fingerprint": "c3356b21052c4b2a",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -876,7 +920,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d962d3d1324b6269",
+      "fingerprint": "faf099addeb73012",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -887,7 +931,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "397a8a2e22c940f0",
+      "fingerprint": "bd9843e05ec237fb",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -898,7 +942,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bcd57c55024b39f7",
+      "fingerprint": "2556147014e762fc",
       "id": "POST /workspaces/{id}/members/add",
       "method": "POST",
       "operation_id": "bulkAddWorkspaceMembers",
@@ -909,7 +953,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d3a2a804cb7e2d88",
+      "fingerprint": "921b0ff6f318c0df",
       "id": "POST /workspaces/{id}/members/remove",
       "method": "POST",
       "operation_id": "bulkRemoveWorkspaceMembers",
@@ -920,7 +964,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f51f3d510f964b63",
+      "fingerprint": "a3bd69b5a2e0f2a4",
       "id": "PUT /workspaces/{id}/budgets/{interval}",
       "method": "PUT",
       "operation_id": "upsertWorkspaceBudget",

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -300,6 +300,64 @@ pub struct AppRankingsResponse {
     pub meta: RankingsDailyMeta,
 }
 
+/// Top model share for one task classification.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct TaskClassificationModel {
+    pub id: String,
+    pub tag_usage_share: f64,
+    pub tag_token_share: f64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// One task classification row returned by `GET /classifications/task`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct TaskClassificationItem {
+    pub tag: String,
+    pub display_name: String,
+    pub macro_category: String,
+    pub usage_share: f64,
+    pub token_share: f64,
+    pub category_usage_share: f64,
+    pub category_token_share: f64,
+    pub models: Vec<TaskClassificationModel>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Aggregate market-share data for one task macro-category.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct TaskClassificationMacroCategory {
+    pub key: String,
+    pub label: String,
+    pub usage_share: f64,
+    pub token_share: f64,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Data payload returned by `GET /classifications/task`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct TaskClassificationsData {
+    pub window_days: u64,
+    pub as_of: String,
+    pub classifications: Vec<TaskClassificationItem>,
+    pub macro_categories: Vec<TaskClassificationMacroCategory>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Task classification response returned by `GET /classifications/task`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct TaskClassificationsResponse {
+    pub data: TaskClassificationsData,
+}
+
 /// OpenRouter benchmark pricing payload.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
@@ -412,12 +470,13 @@ pub struct BenchmarksDAResponse {
 }
 
 /// Query parameters for the unified benchmarks endpoint.
-#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
 pub struct UnifiedBenchmarksParams {
-    #[builder(setter(into))]
-    pub source: String,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_type: Option<String>,
@@ -439,7 +498,7 @@ impl UnifiedBenchmarksParams {
 
     pub fn artificial_analysis() -> Self {
         Self {
-            source: "artificial-analysis".to_string(),
+            source: Some("artificial-analysis".to_string()),
             task_type: None,
             arena: None,
             category: None,
@@ -449,7 +508,7 @@ impl UnifiedBenchmarksParams {
 
     pub fn design_arena() -> Self {
         Self {
-            source: "design-arena".to_string(),
+            source: Some("design-arena".to_string()),
             task_type: None,
             arena: None,
             category: None,
@@ -507,9 +566,9 @@ pub enum UnifiedBenchmarkItem {
 pub struct UnifiedBenchmarksMeta {
     pub as_of: String,
     pub version: String,
-    pub source: String,
-    pub source_url: String,
-    pub citation: String,
+    pub source: Option<String>,
+    pub source_url: Option<String>,
+    pub citation: Option<String>,
     pub model_count: u64,
     pub task_type: Option<String>,
     #[serde(flatten)]
@@ -687,6 +746,38 @@ pub(crate) async fn get_app_rankings_with_client(
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "app rankings").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Return task classification market-share data (`GET /classifications/task`).
+pub async fn get_task_classifications(
+    base_url: &str,
+    api_key: &str,
+    window: Option<&str>,
+) -> Result<TaskClassificationsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_task_classifications_with_client(&http_client, base_url, api_key, window).await
+}
+
+pub(crate) async fn get_task_classifications_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    window: Option<&str>,
+) -> Result<TaskClassificationsResponse, OpenRouterError> {
+    let url = format!("{base_url}/classifications/task");
+    let req =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key);
+    let response = match window {
+        Some(window) => req.query(&[("window", window)]).send().await?,
+        None => req.send().await?,
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "task classifications").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/api/images.rs
+++ b/src/api/images.rs
@@ -468,7 +468,7 @@ fn buffered_image_response_stream(
 ) -> BoxStream<'static, Result<ImageStreamingResponse, OpenRouterError>> {
     let created = response.created;
     let data = response.data;
-    let usage = response.usage;
+    let mut usage = response.usage;
     let response_extra = response.extra;
 
     stream::iter(data.into_iter().map(move |image| {
@@ -478,7 +478,7 @@ fn buffered_image_response_stream(
                 b64_json: image.b64_json,
                 created,
                 media_type: image.media_type,
-                usage: usage.clone(),
+                usage: usage.take(),
                 extra: image.extra,
             }),
             extra: response_extra.clone(),

--- a/src/api/images.rs
+++ b/src/api/images.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
-use futures_util::{StreamExt, stream::BoxStream};
-use reqwest::Client as HttpClient;
+use futures_util::{
+    StreamExt,
+    stream::{self, BoxStream},
+};
+use reqwest::{Client as HttpClient, header::CONTENT_TYPE};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use urlencoding::encode;
@@ -420,22 +423,68 @@ pub(crate) async fn stream_image_generation_with_client(
     .await?;
 
     if response.status().is_success() {
-        let lines = parse_sse_frames(response_lines(response))
-            .filter_map(async |line| match line {
-                Ok(frame) if frame.data == "[DONE]" => None,
-                Ok(frame) => Some(
-                    serde_json::from_str::<ImageStreamingResponse>(&frame.data)
-                        .map_err(OpenRouterError::Serialization),
-                ),
-                Err(error) => Some(Err(error)),
-            })
-            .boxed();
+        if is_sse_response(&response) {
+            let lines = parse_sse_frames(response_lines(response))
+                .filter_map(async |line| match line {
+                    Ok(frame) if frame.data == "[DONE]" => None,
+                    Ok(frame) => Some(
+                        serde_json::from_str::<ImageStreamingResponse>(&frame.data)
+                            .map_err(OpenRouterError::Serialization),
+                    ),
+                    Err(error) => Some(Err(error)),
+                })
+                .boxed();
 
-        Ok(lines)
+            Ok(lines)
+        } else {
+            let response: ImageGenerationResponse =
+                transport_response::parse_json_response(response, "image generation").await?;
+            Ok(buffered_image_response_stream(response))
+        }
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()
     }
+}
+
+fn is_sse_response(response: &reqwest::Response) -> bool {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .eq_ignore_ascii_case("text/event-stream")
+        })
+        .unwrap_or(false)
+}
+
+fn buffered_image_response_stream(
+    response: ImageGenerationResponse,
+) -> BoxStream<'static, Result<ImageStreamingResponse, OpenRouterError>> {
+    let created = response.created;
+    let data = response.data;
+    let usage = response.usage;
+    let response_extra = response.extra;
+
+    stream::iter(data.into_iter().map(move |image| {
+        Ok(ImageStreamingResponse {
+            data: ImageStreamEvent::Completed(ImageCompletedEvent {
+                event_type: "image_generation.completed".to_string(),
+                b64_json: image.b64_json,
+                created,
+                media_type: image.media_type,
+                usage: usage.clone(),
+                extra: image.extra,
+            }),
+            extra: response_extra.clone(),
+        })
+    }))
+    .boxed()
 }
 
 /// List all image generation models.

--- a/src/api/images.rs
+++ b/src/api/images.rs
@@ -1,0 +1,503 @@
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use futures_util::{StreamExt, stream::BoxStream};
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use urlencoding::encode;
+
+use crate::{
+    error::OpenRouterError,
+    strip_option_vec_setter,
+    transport::{
+        request as transport_request, response as transport_response, sse::response_lines,
+    },
+    utils::parse_sse_frames,
+};
+
+/// One image URL payload used as an image generation reference.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageUrl {
+    pub url: String,
+}
+
+impl ImageUrl {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+/// Reference image used to guide image generation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageInputReference {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub image_url: ImageUrl,
+}
+
+impl ImageInputReference {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self::image_url(url)
+    }
+
+    pub fn image_url(url: impl Into<String>) -> Self {
+        Self {
+            content_type: "image_url".to_string(),
+            image_url: ImageUrl::new(url),
+        }
+    }
+}
+
+/// Provider-specific passthrough options for image generation.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ImageProviderOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<HashMap<String, Value>>,
+}
+
+impl ImageProviderOptions {
+    pub fn new(options: HashMap<String, Value>) -> Self {
+        Self {
+            options: Some(options),
+        }
+    }
+}
+
+/// Request payload for `POST /images`.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct ImageGenerationRequest {
+    #[builder(setter(into))]
+    pub model: String,
+    #[builder(setter(into))]
+    pub prompt: String,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aspect_ratio: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<String>,
+    #[builder(setter(custom), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_references: Option<Vec<ImageInputReference>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n: Option<u32>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_compression: Option<u32>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ImageProviderOptions>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quality: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i64>,
+    #[builder(setter(into, strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[builder(setter(skip), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+}
+
+impl ImageGenerationRequestBuilder {
+    strip_option_vec_setter!(input_references, ImageInputReference);
+}
+
+impl ImageGenerationRequest {
+    pub fn builder() -> ImageGenerationRequestBuilder {
+        ImageGenerationRequestBuilder::default()
+    }
+
+    fn stream(&self, stream: bool) -> Self {
+        let mut req = self.clone();
+        req.stream = Some(stream);
+        req
+    }
+}
+
+/// One generated image returned by `POST /images`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct GeneratedImage {
+    pub b64_json: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Token and cost usage returned by image generation responses.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageGenerationUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_byok: Option<bool>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Non-streaming response returned by `POST /images`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageGenerationResponse {
+    pub created: u64,
+    pub data: Vec<GeneratedImage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<ImageGenerationUsage>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Descriptor for one supported image-generation request parameter.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageCapabilityDescriptor {
+    #[serde(rename = "type")]
+    pub capability_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Architecture metadata returned by image model discovery endpoints.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageModelArchitecture {
+    pub input_modalities: Vec<String>,
+    pub output_modalities: Vec<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Image model metadata returned by `GET /images/models`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageModel {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub created: u64,
+    pub architecture: ImageModelArchitecture,
+    pub supported_parameters: HashMap<String, ImageCapabilityDescriptor>,
+    pub supports_streaming: bool,
+    pub endpoints: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// One billable pricing line for an image provider.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImagePricingEntry {
+    pub billable: String,
+    pub unit: String,
+    pub cost_usd: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Endpoint metadata for one image generation provider.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageEndpoint {
+    pub provider_name: String,
+    pub provider_slug: String,
+    pub provider_tag: Option<String>,
+    pub supported_parameters: HashMap<String, ImageCapabilityDescriptor>,
+    #[serde(default)]
+    pub allowed_passthrough_parameters: Vec<String>,
+    pub supports_streaming: bool,
+    pub pricing: Vec<ImagePricingEntry>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Response returned by `GET /images/models/{author}/{slug}/endpoints`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageModelEndpointsResponse {
+    pub id: String,
+    pub endpoints: Vec<ImageEndpoint>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Partial-image event emitted by streaming image generation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImagePartialImageEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub partial_image_index: u32,
+    pub b64_json: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Completion event emitted by streaming image generation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageCompletedEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub b64_json: String,
+    pub created: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<ImageGenerationUsage>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Error details emitted by streaming image generation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageStreamError {
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub error_type: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Error event emitted by streaming image generation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageStreamErrorEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub error: ImageStreamError,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Streaming image generation event payload.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum ImageStreamEvent {
+    PartialImage(ImagePartialImageEvent),
+    Completed(ImageCompletedEvent),
+    Error(ImageStreamErrorEvent),
+    Other(Value),
+}
+
+/// SSE data wrapper returned by `POST /images` when `stream=true`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ImageStreamingResponse {
+    pub data: ImageStreamEvent,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Submit an image generation request.
+pub async fn create_image_generation(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &ImageGenerationRequest,
+) -> Result<ImageGenerationResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_image_generation_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn create_image_generation_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &ImageGenerationRequest,
+) -> Result<ImageGenerationResponse, OpenRouterError> {
+    let url = format!("{base_url}/images");
+    let request = request.stream(false);
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+    )?
+    .json(&request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "image generation").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Stream image generation events.
+pub async fn stream_image_generation(
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &ImageGenerationRequest,
+) -> Result<BoxStream<'static, Result<ImageStreamingResponse, OpenRouterError>>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    stream_image_generation_with_client(
+        &http_client,
+        base_url,
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn stream_image_generation_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    x_title: &Option<String>,
+    http_referer: &Option<String>,
+    app_categories: &Option<Vec<String>>,
+    request: &ImageGenerationRequest,
+) -> Result<BoxStream<'static, Result<ImageStreamingResponse, OpenRouterError>>, OpenRouterError> {
+    let url = format!("{base_url}/images");
+    let request = request.stream(true);
+    let response = transport_request::with_client_request_headers(
+        transport_request::post(http_client, &url),
+        api_key,
+        x_title,
+        http_referer,
+        app_categories,
+    )?
+    .json(&request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let lines = parse_sse_frames(response_lines(response))
+            .filter_map(async |line| match line {
+                Ok(frame) if frame.data == "[DONE]" => None,
+                Ok(frame) => Some(
+                    serde_json::from_str::<ImageStreamingResponse>(&frame.data)
+                        .map_err(OpenRouterError::Serialization),
+                ),
+                Err(error) => Some(Err(error)),
+            })
+            .boxed();
+
+        Ok(lines)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// List all image generation models.
+pub async fn list_image_models(
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<ImageModel>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_image_models_with_client(&http_client, base_url, api_key).await
+}
+
+pub(crate) async fn list_image_models_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<ImageModel>, OpenRouterError> {
+    let url = format!("{base_url}/images/models");
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        let payload: crate::types::ApiResponse<Vec<ImageModel>> =
+            transport_response::parse_json_response(response, "image models").await?;
+        Ok(payload.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// List provider endpoints for one image generation model.
+pub async fn list_image_model_endpoints(
+    base_url: &str,
+    api_key: &str,
+    author: &str,
+    slug: &str,
+) -> Result<ImageModelEndpointsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_image_model_endpoints_with_client(&http_client, base_url, api_key, author, slug).await
+}
+
+pub(crate) async fn list_image_model_endpoints_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    author: &str,
+    slug: &str,
+) -> Result<ImageModelEndpointsResponse, OpenRouterError> {
+    let encoded_author = encode(author);
+    let encoded_slug = encode(slug);
+    let url = format!("{base_url}/images/models/{encoded_author}/{encoded_slug}/endpoints");
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "image model endpoints").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@
 //! - `client.messages()` -> [`messages`]
 //! - `client.rerank()` -> [`rerank`]
 //! - `client.audio().speech()` / `client.audio().transcriptions()` -> [`audio`]
+//! - `client.images()` -> [`images`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
 //! - `client.management()` -> [`api_keys`], [`auth`], [`byok`], [`credits`], [`generation`], [`guardrails`], [`observability`], [`organization`], [`presets`], [`workspaces`]
@@ -22,6 +23,8 @@
 //! - Anthropic-compatible Messages API
 //! - rerank
 //! - audio speech generation and transcription
+//! - image generation and streaming
+//! - image generation and streaming
 //! - video generation and polling
 //! - model discovery, providers, user model filters, model counts, rankings, and ZDR endpoints
 //! - embeddings
@@ -129,6 +132,7 @@ pub mod errors;
 pub mod files;
 pub mod generation;
 pub mod guardrails;
+pub mod images;
 pub mod messages;
 pub mod models;
 pub mod observability;

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    api::chat::{CacheControl, Plugin, TraceOptions},
+    api::chat::{CacheControl, DebugOptions, Plugin, TraceOptions},
     error::OpenRouterError,
     strip_option_map_setter, strip_option_vec_setter,
     transport::{
@@ -173,6 +173,10 @@ pub struct ResponsesRequest {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     trace: Option<TraceOptions>,
+
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    debug: Option<DebugOptions>,
 }
 
 impl ResponsesRequestBuilder {

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,8 +6,8 @@ use crate::api::legacy::completion;
 use crate::{
     api::{
         analytics, api_keys, audio, auth, byok, chat, credits, discovery, embeddings, files,
-        generation, guardrails, messages, models, observability, organization, presets, rerank,
-        responses, videos, workspaces,
+        generation, guardrails, images, messages, models, observability, organization, presets,
+        rerank, responses, videos, workspaces,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -139,6 +139,11 @@ impl OpenRouterClient {
     /// Domain client for audio operations.
     pub fn audio(&self) -> AudioClient<'_> {
         AudioClient { client: self }
+    }
+
+    /// Domain client for image generation operations.
+    pub fn images(&self) -> ImagesClient<'_> {
+        ImagesClient { client: self }
     }
 
     /// Domain client for text-to-speech operations.
@@ -1312,6 +1317,80 @@ impl OpenRouterClient {
         self.create_speech(request).await
     }
 
+    /// Submit an image generation request.
+    pub async fn create_image_generation(
+        &self,
+        request: &images::ImageGenerationRequest,
+    ) -> Result<images::ImageGenerationResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            images::create_image_generation_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                &self.x_title,
+                &self.http_referer,
+                &self.app_categories,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Stream image generation events.
+    pub async fn stream_image_generation(
+        &self,
+        request: &images::ImageGenerationRequest,
+    ) -> Result<
+        BoxStream<'static, Result<images::ImageStreamingResponse, OpenRouterError>>,
+        OpenRouterError,
+    > {
+        if let Some(api_key) = &self.api_key {
+            images::stream_image_generation_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                &self.x_title,
+                &self.http_referer,
+                &self.app_categories,
+                request,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List all available image generation models.
+    pub async fn list_image_models(&self) -> Result<Vec<images::ImageModel>, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            images::list_image_models_with_client(self.http_client(), &self.base_url, api_key).await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// List provider endpoints for one image generation model.
+    pub async fn list_image_model_endpoints(
+        &self,
+        author: &str,
+        slug: &str,
+    ) -> Result<images::ImageModelEndpointsResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            images::list_image_model_endpoints_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                author,
+                slug,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Submit a video generation request.
     pub async fn create_video_generation(
         &self,
@@ -1876,6 +1955,26 @@ impl OpenRouterClient {
                 &self.base_url,
                 api_key,
                 params,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
+    /// Return task classification market-share data.
+    ///
+    /// Equivalent to `GET /classifications/task`.
+    pub async fn get_task_classifications(
+        &self,
+        window: Option<&str>,
+    ) -> Result<discovery::TaskClassificationsResponse, OpenRouterError> {
+        if let Some(api_key) = &self.api_key {
+            discovery::get_task_classifications_with_client(
+                self.http_client(),
+                &self.base_url,
+                api_key,
+                window,
             )
             .await
         } else {
@@ -2603,6 +2702,47 @@ impl<'a> TranscriptionsClient<'a> {
     }
 }
 
+/// Domain client for image generation endpoints.
+#[derive(Debug, Clone, Copy)]
+pub struct ImagesClient<'a> {
+    client: &'a OpenRouterClient,
+}
+
+impl<'a> ImagesClient<'a> {
+    /// Submit an image generation request (`POST /images`).
+    pub async fn create(
+        &self,
+        request: &images::ImageGenerationRequest,
+    ) -> Result<images::ImageGenerationResponse, OpenRouterError> {
+        self.client.create_image_generation(request).await
+    }
+
+    /// Stream image generation events (`POST /images`, `stream=true`).
+    pub async fn stream(
+        &self,
+        request: &images::ImageGenerationRequest,
+    ) -> Result<
+        BoxStream<'static, Result<images::ImageStreamingResponse, OpenRouterError>>,
+        OpenRouterError,
+    > {
+        self.client.stream_image_generation(request).await
+    }
+
+    /// List available image generation models (`GET /images/models`).
+    pub async fn list_models(&self) -> Result<Vec<images::ImageModel>, OpenRouterError> {
+        self.client.list_image_models().await
+    }
+
+    /// List provider endpoints for one image generation model.
+    pub async fn list_model_endpoints(
+        &self,
+        author: &str,
+        slug: &str,
+    ) -> Result<images::ImageModelEndpointsResponse, OpenRouterError> {
+        self.client.list_image_model_endpoints(author, slug).await
+    }
+}
+
 /// Domain client for video generation endpoints.
 #[derive(Debug, Clone, Copy)]
 pub struct VideosClient<'a> {
@@ -2779,6 +2919,14 @@ impl<'a> ModelsClient<'a> {
         params: Option<&discovery::AppRankingsParams>,
     ) -> Result<discovery::AppRankingsResponse, OpenRouterError> {
         self.client.get_app_rankings(params).await
+    }
+
+    /// Return task classification market-share data (`GET /classifications/task`).
+    pub async fn get_task_classifications(
+        &self,
+        window: Option<&str>,
+    ) -> Result<discovery::TaskClassificationsResponse, OpenRouterError> {
+        self.client.get_task_classifications(window).await
     }
 
     /// Return benchmark rows from a selected source (`GET /benchmarks`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # OpenRouter Rust SDK
 //!
 //! `openrouter-rs` is a type-safe, async Rust SDK for the [OpenRouter API](https://openrouter.ai/),
-//! providing typed access to chat, responses, messages, rerank, audio speech/transcription, video generation,
+//! providing typed access to chat, responses, messages, rerank, audio speech/transcription, image generation, video generation,
 //! discovery, embeddings, presets, and management endpoints.
 //!
 //! ## ✨ Key Features
@@ -9,7 +9,7 @@
 //! - **🔒 Type Safety**: Leverages Rust's type system for compile-time error prevention
 //! - **⚡ Async/Await**: Built on `tokio` for high-performance async operations  
 //! - **🏗️ Builder Pattern**: Ergonomic client and request construction
-//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `videos()`, `models()`, `management()`
+//! - **🧭 Domain Clients**: Grouped API access via `chat()`, `responses()`, `messages()`, `rerank()`, `audio().speech()`, `audio().transcriptions()`, `images()`, `videos()`, `models()`, `management()`
 //! - **📡 Streaming Support**: Real-time response streaming with `futures`
 //! - **🧩 Unified Streaming Events**: Shared stream event model across chat/responses/messages
 //! - **🧠 Reasoning Tokens**: Advanced support for chain-of-thought reasoning
@@ -147,6 +147,7 @@
 //! | Rerank | ✅ | [`api::rerank`] |
 //! | Audio Speech | ✅ | [`api::audio`] |
 //! | Audio Transcription | ✅ | [`api::audio`] |
+//! | Image Generation | ✅ | [`api::images`] |
 //! | Video Generation | ✅ | [`api::videos`] |
 //! | Legacy Text Completions (`legacy-completions`) | ✅ | `api::legacy::completion` |
 //! | Model Information | ✅ | [`api::models`] |

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -10,7 +10,7 @@ use openrouter_rs::{
     OpenRouterClient,
     api::{
         analytics, audio, auth, byok, chat, credits, discovery, embeddings, files, guardrails,
-        messages, observability, rerank, responses, videos, workspaces,
+        images, messages, observability, rerank, responses, videos, workspaces,
     },
     error::OpenRouterError,
     types::{ModelCategory, PaginationOptions, Role, SupportedParameters},
@@ -326,6 +326,12 @@ async fn test_models_domain_renamed_methods_require_api_key() {
         Err(OpenRouterError::KeyNotConfigured)
     ));
 
+    let task_classifications = client.models().get_task_classifications(Some("7d")).await;
+    assert!(matches!(
+        task_classifications,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+
     let benchmark_params = discovery::UnifiedBenchmarksParams::artificial_analysis();
     let benchmarks = client.models().get_benchmarks(&benchmark_params).await;
     assert!(matches!(benchmarks, Err(OpenRouterError::KeyNotConfigured)));
@@ -453,6 +459,38 @@ async fn test_audio_transcriptions_domain_requires_api_key() {
 
     let result = client.audio().transcriptions().create(&request).await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_images_domain_requires_api_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let request = images::ImageGenerationRequest::builder()
+        .model("bytedance-seed/seedream-4.5")
+        .prompt("Generate a clean product render")
+        .build()
+        .expect("image generation request should build");
+
+    assert!(matches!(
+        client.images().create(&request).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.images().stream(&request).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.images().list_models().await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .images()
+            .list_model_endpoints("bytedance-seed", "seedream-4.5")
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 }
 
 #[tokio::test]
@@ -1225,6 +1263,59 @@ async fn test_videos_domain_methods_delegate_to_api_module() {
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture request");
     assert_eq!(captured.request_line, "GET /api/v1/videos/models HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_images_domain_methods_delegate_to_api_module() {
+    let response_body = r#"{"data":[]}"#;
+    let (base_url, rx, server) = spawn_json_server(response_body);
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .build()
+        .expect("client should build");
+
+    let response = client
+        .images()
+        .list_models()
+        .await
+        .expect("list image models should succeed");
+    assert!(response.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "GET /api/v1/images/models HTTP/1.1");
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_models_domain_get_task_classifications_delegates() {
+    let response_body = r#"{"data":{"window_days":7,"as_of":"2026-06-17","classifications":[],"macro_categories":[]}}"#;
+    let (base_url, rx, server) = spawn_json_server(response_body);
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .api_key("api-key")
+        .build()
+        .expect("client should build");
+
+    let response = client
+        .models()
+        .get_task_classifications(Some("7d"))
+        .await
+        .expect("task classifications should succeed");
+    assert_eq!(response.data.window_days, 7);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/classifications/task?window=7d HTTP/1.1"
+    );
 
     server.join().expect("server thread should finish");
 }

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -10,7 +10,8 @@ use openrouter_rs::{
     api::discovery::{
         self, ActivityItem, AppRankingsParams, AppRankingsResponse, BenchmarksAAResponse,
         BenchmarksDAResponse, BigNumber, ModelsCountData, Provider, PublicEndpoint,
-        RankingsDailyResponse, UnifiedBenchmarkItem, UnifiedBenchmarksParams, UserModel,
+        RankingsDailyResponse, TaskClassificationsResponse, UnifiedBenchmarkItem,
+        UnifiedBenchmarksParams, UserModel,
     },
     types::{ApiResponse, Effort},
 };
@@ -289,6 +290,46 @@ fn test_app_rankings_response_deserialization() {
     assert_eq!(parsed.data[0].app_name, "Cline");
     assert_eq!(parsed.data[0].total_tokens, "12345678");
     assert_eq!(parsed.meta.start_date, "2026-04-12");
+}
+
+#[test]
+fn test_task_classifications_response_deserialization() {
+    let raw = r#"{
+        "data": {
+            "window_days": 7,
+            "as_of": "2026-06-17",
+            "classifications": [{
+                "tag": "code:general_impl",
+                "display_name": "Code Generation",
+                "macro_category": "code",
+                "usage_share": 0.23,
+                "token_share": 0.31,
+                "category_usage_share": 0.51,
+                "category_token_share": 0.48,
+                "models": [{
+                    "id": "openai/gpt-4.1-mini",
+                    "tag_usage_share": 0.55,
+                    "tag_token_share": 0.75
+                }]
+            }],
+            "macro_categories": [{
+                "key": "code",
+                "label": "Code",
+                "usage_share": 0.45,
+                "token_share": 0.52
+            }]
+        }
+    }"#;
+
+    let parsed: TaskClassificationsResponse =
+        serde_json::from_str(raw).expect("task classifications should deserialize");
+    assert_eq!(parsed.data.window_days, 7);
+    assert_eq!(parsed.data.classifications[0].tag, "code:general_impl");
+    assert_eq!(
+        parsed.data.classifications[0].models[0].id,
+        "openai/gpt-4.1-mini"
+    );
+    assert_eq!(parsed.data.macro_categories[0].key, "code");
 }
 
 #[test]
@@ -637,6 +678,35 @@ async fn test_get_app_rankings_path_query_and_auth_header() {
 }
 
 #[tokio::test]
+async fn test_get_task_classifications_path_query_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"window_days":7,"as_of":"2026-06-17","classifications":[],"macro_categories":[]}}"#,
+    );
+
+    let response = discovery::get_task_classifications(&base_url, "api-key", Some("7d"))
+        .await
+        .expect("task classifications request should succeed");
+    assert_eq!(response.data.window_days, 7);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/classifications/task?window=7d HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include API key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
 async fn test_get_benchmarks_path_queries_and_auth_header() {
     let (base_url, rx, server) = spawn_json_server(
         r#"{"data":[{"source":"artificial-analysis","model_permaslug":"openai/gpt-4o","display_name":"GPT-4o","intelligence_index":71.2,"coding_index":65.8,"agentic_index":58.3,"pricing":{"prompt":"0.0000025","completion":"0.00001"}}],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"artificial-analysis","source_url":"https://artificialanalysis.ai","citation":"Source","model_count":1,"task_type":"coding"}}"#,
@@ -650,7 +720,7 @@ async fn test_get_benchmarks_path_queries_and_auth_header() {
     let aa = discovery::get_benchmarks(&base_url, "api-key", &params)
         .await
         .expect("benchmark request should succeed");
-    assert_eq!(aa.meta.source, "artificial-analysis");
+    assert_eq!(aa.meta.source.as_deref(), Some("artificial-analysis"));
     assert!(matches!(
         &aa.data[0],
         UnifiedBenchmarkItem::ArtificialAnalysis(item) if item.display_name == "GPT-4o"
@@ -691,6 +761,27 @@ async fn test_get_benchmarks_path_queries_and_auth_header() {
     server
         .join()
         .expect("Design Arena server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_benchmarks_all_sources_omits_source_query() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":null,"source_url":null,"citation":null,"model_count":0,"task_type":null}}"#,
+    );
+    let params = UnifiedBenchmarksParams::default();
+    let benchmarks = discovery::get_benchmarks(&base_url, "api-key", &params)
+        .await
+        .expect("benchmark request should succeed");
+    assert!(benchmarks.data.is_empty());
+    assert_eq!(benchmarks.meta.source, None);
+    assert_eq!(benchmarks.meta.citation, None);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "GET /api/v1/benchmarks HTTP/1.1");
+
+    server.join().expect("server thread should finish");
 }
 
 #[tokio::test]

--- a/tests/unit/images.rs
+++ b/tests/unit/images.rs
@@ -349,6 +349,62 @@ async fn test_stream_image_generation_path_body_and_sse() {
 }
 
 #[tokio::test]
+async fn test_stream_image_generation_handles_buffered_json_fallback() {
+    let response = r#"{
+        "created": 1748372400,
+        "data": [{
+            "b64_json": "aW1hZ2U=",
+            "media_type": "image/png"
+        }],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 4175,
+            "total_tokens": 4175,
+            "cost": 0.04
+        }
+    }"#;
+    let (base_url, rx, server) = spawn_server(response, "application/json");
+    let request = ImageGenerationRequest::builder()
+        .model("bytedance-seed/seedream-4.5")
+        .prompt("buffered image")
+        .build()
+        .expect("image request should build");
+
+    let mut stream =
+        images::stream_image_generation(&base_url, "api-key", &None, &None, &None, &request)
+            .await
+            .expect("stream should open");
+    let event = stream
+        .next()
+        .await
+        .expect("buffered response should yield one event")
+        .expect("event should deserialize");
+    match event.data {
+        ImageStreamEvent::Completed(event) => {
+            assert_eq!(event.b64_json, "aW1hZ2U=");
+            assert_eq!(event.created, 1748372400);
+            assert_eq!(event.media_type.as_deref(), Some("image/png"));
+            assert_eq!(
+                event.usage.expect("usage should be present").cost,
+                Some(0.04)
+            );
+        }
+        other => panic!("expected completed image event, got {other:?}"),
+    }
+    assert!(stream.next().await.is_none());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "POST /api/v1/images HTTP/1.1");
+    let body_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body_json["stream"], true);
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
 async fn test_list_image_models_path_and_auth_header() {
     let (base_url, rx, server) = spawn_server(r#"{"data":[]}"#, "application/json");
     let models = images::list_image_models(&base_url, "api-key")

--- a/tests/unit/images.rs
+++ b/tests/unit/images.rs
@@ -355,6 +355,9 @@ async fn test_stream_image_generation_handles_buffered_json_fallback() {
         "data": [{
             "b64_json": "aW1hZ2U=",
             "media_type": "image/png"
+        }, {
+            "b64_json": "aW1hZ2Uy",
+            "media_type": "image/webp"
         }],
         "usage": {
             "prompt_tokens": 0,
@@ -387,6 +390,22 @@ async fn test_stream_image_generation_handles_buffered_json_fallback() {
             assert_eq!(
                 event.usage.expect("usage should be present").cost,
                 Some(0.04)
+            );
+        }
+        other => panic!("expected completed image event, got {other:?}"),
+    }
+    let event = stream
+        .next()
+        .await
+        .expect("buffered response should yield each image")
+        .expect("event should deserialize");
+    match event.data {
+        ImageStreamEvent::Completed(event) => {
+            assert_eq!(event.b64_json, "aW1hZ2Uy");
+            assert_eq!(event.media_type.as_deref(), Some("image/webp"));
+            assert!(
+                event.usage.is_none(),
+                "aggregate usage should only be emitted once"
             );
         }
         other => panic!("expected completed image event, got {other:?}"),

--- a/tests/unit/images.rs
+++ b/tests/unit/images.rs
@@ -1,0 +1,392 @@
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use futures_util::StreamExt;
+use openrouter_rs::api::images::{
+    self, ImageGenerationRequest, ImageGenerationResponse, ImageInputReference, ImageModel,
+    ImageModelEndpointsResponse, ImageProviderOptions, ImageStreamEvent, ImageStreamingResponse,
+};
+
+struct CapturedRequest {
+    request_line: String,
+    request_text: String,
+    body_text: String,
+}
+
+fn spawn_server(
+    response_body: &str,
+    content_type: &str,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let body = response_body.to_string();
+    let content_type = content_type.to_string();
+    let (tx, rx) = mpsc::channel::<CapturedRequest>();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("server should accept one connection");
+
+        let mut request_bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            if read == 0 {
+                break None;
+            }
+            request_bytes.extend_from_slice(&chunk[..read]);
+            if let Some(pos) = request_bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+            {
+                break Some(pos + 4);
+            }
+        }
+        .expect("request should contain header terminator");
+
+        let header_text = String::from_utf8_lossy(&request_bytes[..header_end]).to_string();
+        let request_line = header_text.lines().next().unwrap_or_default().to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line.split(':').nth(1)?.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let mut body_bytes = request_bytes[header_end..].to_vec();
+        while body_bytes.len() < content_length {
+            let read = stream
+                .read(&mut chunk)
+                .expect("server should read request body");
+            if read == 0 {
+                break;
+            }
+            body_bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        let body_text = String::from_utf8_lossy(&body_bytes[..content_length]).to_string();
+        let request_text = format!("{header_text}{body_text}");
+        tx.send(CapturedRequest {
+            request_line,
+            request_text,
+            body_text,
+        })
+        .expect("server should send captured request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            content_type,
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+#[test]
+fn test_image_generation_request_serialization() {
+    let mut provider_options = HashMap::new();
+    provider_options.insert(
+        "black-forest-labs".to_string(),
+        serde_json::json!({
+            "guidance": 3,
+            "steps": 40
+        }),
+    );
+
+    let request = ImageGenerationRequest::builder()
+        .model("bytedance-seed/seedream-4.5")
+        .prompt("a red panda astronaut floating in space")
+        .aspect_ratio("16:9")
+        .background("transparent")
+        .input_references(vec![ImageInputReference::new(
+            "https://example.com/reference.png",
+        )])
+        .n(2)
+        .output_compression(80)
+        .output_format("webp")
+        .provider(ImageProviderOptions::new(provider_options))
+        .quality("high")
+        .resolution("2K")
+        .seed(42)
+        .size("2048x1152")
+        .build()
+        .expect("image generation request should build");
+
+    let value = serde_json::to_value(&request).expect("image request should serialize");
+    assert_eq!(value["model"], "bytedance-seed/seedream-4.5");
+    assert_eq!(value["prompt"], "a red panda astronaut floating in space");
+    assert_eq!(value["aspect_ratio"], "16:9");
+    assert_eq!(value["input_references"][0]["type"], "image_url");
+    assert_eq!(
+        value["input_references"][0]["image_url"]["url"],
+        "https://example.com/reference.png"
+    );
+    assert_eq!(
+        value["provider"]["options"]["black-forest-labs"]["steps"],
+        40
+    );
+    assert!(value.get("stream").is_none());
+}
+
+#[test]
+fn test_image_generation_response_deserialization() {
+    let raw = r#"{
+        "created": 1748372400,
+        "data": [{
+            "b64_json": "aW1hZ2U=",
+            "media_type": "image/svg+xml"
+        }],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 4175,
+            "total_tokens": 4175,
+            "cost": 0.04,
+            "is_byok": false
+        }
+    }"#;
+
+    let parsed: ImageGenerationResponse =
+        serde_json::from_str(raw).expect("image generation response should deserialize");
+    assert_eq!(parsed.created, 1748372400);
+    assert_eq!(parsed.data[0].b64_json, "aW1hZ2U=");
+    assert_eq!(parsed.data[0].media_type.as_deref(), Some("image/svg+xml"));
+    assert_eq!(
+        parsed.usage.expect("usage should be present").cost,
+        Some(0.04)
+    );
+}
+
+#[test]
+fn test_image_models_and_endpoints_deserialization() {
+    let models_raw = r#"{
+        "data": [{
+            "id": "bytedance-seed/seedream-4.5",
+            "name": "Seedream 4.5",
+            "description": "A text-to-image model.",
+            "created": 1692901234,
+            "architecture": {
+                "input_modalities": ["text", "image"],
+                "output_modalities": ["image"]
+            },
+            "supported_parameters": {
+                "resolution": {"type": "enum", "values": ["1K", "2K"]},
+                "seed": {"type": "boolean"}
+            },
+            "supports_streaming": false,
+            "endpoints": "/api/v1/images/models/bytedance-seed/seedream-4.5/endpoints"
+        }]
+    }"#;
+
+    let parsed: openrouter_rs::types::ApiResponse<Vec<ImageModel>> =
+        serde_json::from_str(models_raw).expect("image models should deserialize");
+    assert_eq!(parsed.data[0].id, "bytedance-seed/seedream-4.5");
+    assert_eq!(
+        parsed.data[0]
+            .supported_parameters
+            .get("resolution")
+            .expect("resolution should exist")
+            .values
+            .as_deref(),
+        Some(&["1K".to_string(), "2K".to_string()][..])
+    );
+
+    let endpoints_raw = r#"{
+        "id": "bytedance-seed/seedream-4.5",
+        "endpoints": [{
+            "provider_name": "Bytedance",
+            "provider_slug": "bytedance",
+            "provider_tag": null,
+            "supported_parameters": {
+                "resolution": {"type": "enum", "values": ["1K"]}
+            },
+            "allowed_passthrough_parameters": [],
+            "supports_streaming": false,
+            "pricing": [{
+                "billable": "output_image",
+                "unit": "image",
+                "cost_usd": 0.05
+            }]
+        }]
+    }"#;
+
+    let endpoints: ImageModelEndpointsResponse =
+        serde_json::from_str(endpoints_raw).expect("image endpoints should deserialize");
+    assert_eq!(endpoints.endpoints[0].provider_name, "Bytedance");
+    assert_eq!(endpoints.endpoints[0].provider_tag, None);
+    assert_eq!(endpoints.endpoints[0].pricing[0].cost_usd, 0.05);
+}
+
+#[test]
+fn test_image_streaming_response_deserialization() {
+    let raw = r#"{
+        "data": {
+            "type": "image_generation.partial_image",
+            "partial_image_index": 0,
+            "b64_json": "cGFydGlhbA=="
+        }
+    }"#;
+
+    let parsed: ImageStreamingResponse =
+        serde_json::from_str(raw).expect("streaming response should deserialize");
+    match parsed.data {
+        ImageStreamEvent::PartialImage(event) => {
+            assert_eq!(event.partial_image_index, 0);
+            assert_eq!(event.b64_json, "cGFydGlhbA==");
+        }
+        other => panic!("expected partial image event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_image_generation_path_body_and_headers() {
+    let response = r#"{
+        "created": 1748372400,
+        "data": [{"b64_json":"aW1hZ2U="}]
+    }"#;
+    let (base_url, rx, server) = spawn_server(response, "application/json");
+    let request = ImageGenerationRequest::builder()
+        .model("bytedance-seed/seedream-4.5")
+        .prompt("a red panda astronaut")
+        .resolution("2K")
+        .build()
+        .expect("image request should build");
+
+    let response = images::create_image_generation(
+        &base_url,
+        "api-key",
+        &Some("openrouter-rs".to_string()),
+        &Some("https://example.com".to_string()),
+        &Some(vec!["cli-agent".to_string()]),
+        &request,
+    )
+    .await
+    .expect("image generation should succeed");
+    assert_eq!(response.data[0].b64_json, "aW1hZ2U=");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "POST /api/v1/images HTTP/1.1");
+    let body_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body_json["model"], "bytedance-seed/seedream-4.5");
+    assert_eq!(body_json["prompt"], "a red panda astronaut");
+    assert_eq!(body_json["stream"], false);
+
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include api key, request:\n{}",
+        captured.request_text
+    );
+    assert!(
+        request_lower.contains("x-openrouter-title: openrouter-rs"),
+        "metadata header should be sent, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_stream_image_generation_path_body_and_sse() {
+    let response = concat!(
+        "data: {\"data\":{\"type\":\"image_generation.partial_image\",\"partial_image_index\":0,\"b64_json\":\"cGFydGlhbA==\"}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let (base_url, rx, server) = spawn_server(response, "text/event-stream");
+    let request = ImageGenerationRequest::builder()
+        .model("openai/gpt-image-1")
+        .prompt("stream an image")
+        .build()
+        .expect("image request should build");
+
+    let mut stream =
+        images::stream_image_generation(&base_url, "api-key", &None, &None, &None, &request)
+            .await
+            .expect("stream should open");
+    let event = stream
+        .next()
+        .await
+        .expect("stream should emit one event")
+        .expect("event should deserialize");
+    assert!(matches!(event.data, ImageStreamEvent::PartialImage(_)));
+    assert!(stream.next().await.is_none());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "POST /api/v1/images HTTP/1.1");
+    let body_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("body should be valid json");
+    assert_eq!(body_json["stream"], true);
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_image_models_path_and_auth_header() {
+    let (base_url, rx, server) = spawn_server(r#"{"data":[]}"#, "application/json");
+    let models = images::list_image_models(&base_url, "api-key")
+        .await
+        .expect("list image models should succeed");
+    assert!(models.is_empty());
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(captured.request_line, "GET /api/v1/images/models HTTP/1.1");
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer api-key")
+            || request_lower.contains("authorization:bearer api-key"),
+        "authorization header should include api key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_list_image_model_endpoints_path_and_auth_header() {
+    let response = r#"{"id":"author/model","endpoints":[]}"#;
+    let (base_url, rx, server) = spawn_server(response, "application/json");
+    let endpoints = images::list_image_model_endpoints(&base_url, "api-key", "author", "model")
+        .await
+        .expect("list image endpoints should succeed");
+    assert_eq!(endpoints.id, "author/model");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/images/models/author/model/endpoints HTTP/1.1"
+    );
+
+    server.join().expect("server thread should finish");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -24,6 +24,7 @@ pub mod error_model;
 pub mod files;
 pub mod generation;
 pub mod guardrails;
+pub mod images;
 pub mod messages;
 pub mod models;
 pub mod observability;

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures_util::StreamExt;
 use openrouter_rs::api::{
-    chat::{CacheControl, Plugin, TraceOptions},
+    chat::{CacheControl, DebugOptions, Plugin, TraceOptions},
     responses::{
         ResponsesRequest, ResponsesResponse, ResponsesStreamEvent, create_response, stream_response,
     },
@@ -153,6 +153,11 @@ fn test_responses_request_serialization() {
             trace.span_name = Some("responses.unit".to_string());
             trace
         })
+        .debug({
+            let mut debug = DebugOptions::default();
+            debug.echo_upstream_body = Some(true);
+            debug
+        })
         .plugins(vec![Plugin::new("web").option("max_results", 3)])
         .build()
         .expect("responses request should build");
@@ -170,6 +175,7 @@ fn test_responses_request_serialization() {
     assert!(value["cache_control"].get("ttl").is_none());
     assert_eq!(value["trace"]["trace_id"], "trace-1");
     assert_eq!(value["trace"]["span_name"], "responses.unit");
+    assert_eq!(value["debug"]["echo_upstream_body"], true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add typed image generation support via api::images and client.images()
- add task classification discovery through client.models().get_task_classifications(...)
- accept related schema drift for unified benchmarks and Responses debug options
- refresh the tracked OpenAPI baseline to 87 / 87 and update docs/tests/example coverage

## Validation
- just openapi-drift-check
- just quality-ci

Closes #225