### PR TITLE
chore: prepare 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.0] - 2026-06-30
+## [0.11.0] - 2026-06-29
 
 ### Added
 - Added typed SDK support for image generation (`POST /images`, `GET /images/models`, and `GET /images/models/{author}/{slug}/endpoints`) via `api::images` and the canonical `client.images()` surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-30
+
 ### Added
 - Added typed SDK support for image generation (`POST /images`, `GET /images/models`, and `GET /images/models/{author}/{slug}/endpoints`) via `api::images` and the canonical `client.images()` surface.
 - Added typed SDK support for task classification discovery via `GET /classifications/task` and `client.models().get_task_classifications(...)`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The current repo snapshot implements `87 / 87` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.10.0"
+openrouter-rs = "0.11.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -47,7 +47,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.10.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.11.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -332,10 +332,16 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ### Unreleased
 
-- Added typed SDK coverage for images, task classifications, files, analytics, app rankings, unified benchmarks, singular model lookup, preset listing/readback/versioning, workspace budgets, extended model filters, multimodal rerank documents, and richer video input references.
+- No unreleased changes.
+
+### Version 0.11.0 *(Latest)*
+
+- Added typed SDK coverage for image generation, files, analytics, app rankings, task classifications, unified benchmarks, singular model lookup, rankings-daily, preset listing/readback/versioning, workspace budgets, and expanded model filters.
+- Added automatic prompt caching request support through top-level `cache_control` builders for chat completions and Responses API requests.
+- Refreshed multimodal and metadata schemas, including rerank image-only document echoes, nullable model/generation metadata, Responses debug options, and Anthropic Messages system-role helpers.
 - Accepted OpenAPI drift through the 2026-06-29 review and restored the tracked endpoint snapshot to `87 / 87`.
 
-### Version 0.10.0 *(Latest)*
+### Version 0.10.0
 
 - Marked high-churn public SDK request, response, metadata, usage, pricing, discovery, streaming, and upstream taxonomy types as `#[non_exhaustive]`; use builders, constructors, helpers, serde deserialization, or wildcard enum arms when migrating from `0.9.x`.
 - Added typed SDK coverage for audio transcriptions, BYOK provider credentials, observability destinations, multimodal embedding media parts, experimental response metadata, and model/generation metadata refreshes.

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.10.0", path = "../.." }
+openrouter-rs = { version = "0.11.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.10.0"
+//! openrouter-rs = "0.11.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- Bump openrouter-rs to 0.11.0 and align README/src lib install snippets
- Move Unreleased changelog entries into 0.11.0 dated 2026-06-29
- Update README release history and align openrouter-cli workspace dependency on openrouter-rs 0.11.0

## Validation
- just quality
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.11.0
- just quality-ci
- cargo package --locked --allow-dirty
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.11.0 after release-date fix