### PR TITLE
fix: stabilize scheduled live checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Accepted new and future provider-defined reasoning effort strings in model metadata, including OpenRouter's `max` effort value, so `/models` deserialization and CLI model listing remain forward-compatible with upstream taxonomy additions.
+- Reduced scheduled live-test noise by treating per-model Responses hot-sweep runtime statuses such as `incomplete` as service warnings while keeping SDK deserialization/protocol failures as hard failures.
+
 ## [0.11.0] - 2026-06-29
 
 ### Added

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -54,6 +54,7 @@
 //! use openrouter_rs::types::Effort;
 //!
 //! let xhigh_effort = Effort::Xhigh;   // Extra high reasoning depth
+//! let max_effort = Effort::Max;       // Maximum reasoning depth
 //! let high_effort = Effort::High;     // High reasoning depth
 //! let medium_effort = Effort::Medium; // Balanced reasoning
 //! let low_effort = Effort::Low;       // Quick reasoning
@@ -148,7 +149,7 @@ pub mod typed_tool;
 
 use std::fmt::Display;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use {
     completion::*, pagination::*, provider::*, response_format::*, stream::*, tool::*,
@@ -242,13 +243,14 @@ impl Display for Role {
 ///     .build()?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-#[serde(rename_all = "lowercase")]
 pub enum Effort {
     /// Extra high reasoning depth and thoroughness
     Xhigh,
     /// Maximum reasoning depth and thoroughness
+    Max,
+    /// High reasoning depth and thoroughness
     High,
     /// Balanced reasoning effort
     Medium,
@@ -258,18 +260,56 @@ pub enum Effort {
     Minimal,
     /// Disable reasoning effort
     None,
+    /// Provider-defined reasoning effort not yet known by this SDK.
+    Other(String),
+}
+
+impl Effort {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Effort::Xhigh => "xhigh",
+            Effort::Max => "max",
+            Effort::High => "high",
+            Effort::Medium => "medium",
+            Effort::Low => "low",
+            Effort::Minimal => "minimal",
+            Effort::None => "none",
+            Effort::Other(value) => value.as_str(),
+        }
+    }
+}
+
+impl Serialize for Effort {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Effort {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "xhigh" => Effort::Xhigh,
+            "max" => Effort::Max,
+            "high" => Effort::High,
+            "medium" => Effort::Medium,
+            "low" => Effort::Low,
+            "minimal" => Effort::Minimal,
+            "none" => Effort::None,
+            _ => Effort::Other(value),
+        })
+    }
 }
 
 impl Display for Effort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Effort::Xhigh => write!(f, "xhigh"),
-            Effort::High => write!(f, "high"),
-            Effort::Medium => write!(f, "medium"),
-            Effort::Low => write!(f, "low"),
-            Effort::Minimal => write!(f, "minimal"),
-            Effort::None => write!(f, "none"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/tests/integration/chat.rs
+++ b/tests/integration/chat.rs
@@ -40,6 +40,20 @@ async fn test_basic_chat_completion() -> Result<(), OpenRouterError> {
 
 #[allow(clippy::result_large_err)]
 fn validate_chat_response(response: &CompletionsResponse) -> Result<(), OpenRouterError> {
+    validate_chat_response_envelope(response)?;
+
+    let content = get_first_content(response).trim();
+    let reasoning = response.choices[0].reasoning().unwrap_or_default().trim();
+    assert!(
+        !content.is_empty() || !reasoning.is_empty(),
+        "Response should contain content or reasoning"
+    );
+
+    Ok(())
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_chat_response_envelope(response: &CompletionsResponse) -> Result<(), OpenRouterError> {
     assert!(!response.id.is_empty(), "Response ID should not be empty");
     assert!(
         !response.model.is_empty(),
@@ -48,13 +62,6 @@ fn validate_chat_response(response: &CompletionsResponse) -> Result<(), OpenRout
     assert!(
         !response.choices.is_empty(),
         "Response should have at least one choice"
-    );
-
-    let content = get_first_content(response).trim();
-    let reasoning = response.choices[0].reasoning().unwrap_or_default().trim();
-    assert!(
-        !content.is_empty() || !reasoning.is_empty(),
-        "Response should contain content or reasoning"
     );
 
     Ok(())
@@ -224,7 +231,7 @@ async fn test_excluded_reasoning() -> Result<(), OpenRouterError> {
         .build()?;
 
     let response = client.send_chat_completion(&request).await?;
-    validate_chat_response(&response)?;
+    validate_chat_response_envelope(&response)?;
 
     let reasoning = response.choices[0].reasoning();
     // When excluded, reasoning should be None or empty

--- a/tests/integration/responses.rs
+++ b/tests/integration/responses.rs
@@ -122,6 +122,37 @@ fn validate_responses_output_for_model(response: &ResponsesResponse) -> Result<(
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HotResponseOutcome {
+    Passed,
+    ServiceWarning(String),
+}
+
+fn validate_hot_responses_output_for_model(
+    response: &ResponsesResponse,
+) -> Result<HotResponseOutcome, String> {
+    let id = response.id.as_deref().unwrap_or_default().trim();
+    if id.is_empty() {
+        return Err("missing response ID".to_string());
+    }
+
+    let status = response.status.as_deref().unwrap_or_default().trim();
+    if matches!(status, "failed" | "cancelled" | "incomplete") {
+        return Ok(HotResponseOutcome::ServiceWarning(format!(
+            "responses status {status}"
+        )));
+    }
+
+    let text = collect_response_text(response);
+    if text.trim().is_empty() {
+        return Ok(HotResponseOutcome::ServiceWarning(
+            "no output_text or reasoning text in response".to_string(),
+        ));
+    }
+
+    Ok(HotResponseOutcome::Passed)
+}
+
 #[tokio::test]
 #[allow(clippy::result_large_err)]
 async fn test_create_response_non_streaming() -> Result<(), OpenRouterError> {
@@ -207,6 +238,24 @@ fn test_validate_responses_output_rejects_empty_payloads() {
     assert_eq!(
         validate_responses_output_for_model(&response),
         Err("no output_text or reasoning text in response".to_string())
+    );
+}
+
+#[test]
+fn test_validate_hot_responses_output_warns_for_incomplete_status() {
+    let response: ResponsesResponse = serde_json::from_value(json!({
+        "id": "resp_incomplete",
+        "object": "response",
+        "status": "incomplete",
+        "output": []
+    }))
+    .expect("response should deserialize");
+
+    assert_eq!(
+        validate_hot_responses_output_for_model(&response),
+        Ok(HotResponseOutcome::ServiceWarning(
+            "responses status incomplete".to_string()
+        ))
     );
 }
 
@@ -297,7 +346,9 @@ async fn test_hot_responses_model_sweep() -> Result<(), OpenRouterError> {
     );
 
     let client = create_test_client()?;
-    let mut failures = Vec::new();
+    let mut passed = 0usize;
+    let mut service_warnings = Vec::new();
+    let mut hard_failures = Vec::new();
 
     println!(
         "Running hot responses model sweep across {} models",
@@ -309,21 +360,46 @@ async fn test_hot_responses_model_sweep() -> Result<(), OpenRouterError> {
         let request = hot_responses_request(&model)?;
 
         match client.responses().create(&request).await {
-            Ok(response) => {
-                if let Err(reason) = validate_responses_output_for_model(&response) {
-                    failures.push(format!("{model}: {reason}"));
-                } else {
+            Ok(response) => match validate_hot_responses_output_for_model(&response) {
+                Ok(HotResponseOutcome::Passed) => {
+                    passed += 1;
                     println!("Hot responses model check passed: {model}");
                 }
+                Ok(HotResponseOutcome::ServiceWarning(reason)) => {
+                    service_warnings.push(format!("{model}: {reason}"));
+                }
+                Err(reason) => hard_failures.push(format!("{model}: {reason}")),
+            },
+            Err(err) => {
+                let message = err.to_string();
+                if matches!(
+                    &err,
+                    OpenRouterError::Serialization(_) | OpenRouterError::Unknown(_)
+                ) {
+                    hard_failures.push(format!("{model}: {message}"));
+                } else {
+                    service_warnings.push(format!("{model}: {message}"));
+                }
             }
-            Err(err) => failures.push(format!("{model}: {err}")),
         }
     }
 
+    if !service_warnings.is_empty() {
+        println!(
+            "Hot responses model service warnings:\n{}",
+            service_warnings.join("\n")
+        );
+    }
+
     assert!(
-        failures.is_empty(),
-        "hot responses model sweep had failures:\n{}",
-        failures.join("\n")
+        hard_failures.is_empty(),
+        "hot responses model sweep had SDK/protocol failures:\n{}",
+        hard_failures.join("\n")
+    );
+    assert!(
+        passed > 0,
+        "hot responses model sweep did not get any completed model response; service warnings:\n{}",
+        service_warnings.join("\n")
     );
 
     Ok(())

--- a/tests/integration/responses.rs
+++ b/tests/integration/responses.rs
@@ -1,9 +1,10 @@
 use std::{env, time::Duration};
 
 use futures_util::StreamExt;
+use http::StatusCode;
 use openrouter_rs::{
     api::responses::{ResponsesRequest, ResponsesResponse},
-    error::OpenRouterError,
+    error::{ApiErrorContext, ApiErrorKind, OpenRouterError},
     types::stream::{UnifiedStreamEvent, UnifiedStreamSource},
 };
 use serde_json::{Value, json};
@@ -151,6 +152,14 @@ fn validate_hot_responses_output_for_model(
     Ok(HotResponseOutcome::Passed)
 }
 
+fn is_hot_responses_hard_error(error: &OpenRouterError) -> bool {
+    match error {
+        OpenRouterError::Api(api_error) => !api_error.is_retryable(),
+        OpenRouterError::Serialization(_) | OpenRouterError::Unknown(_) => true,
+        _ => false,
+    }
+}
+
 #[tokio::test]
 #[allow(clippy::result_large_err)]
 async fn test_create_response_non_streaming() -> Result<(), OpenRouterError> {
@@ -273,6 +282,33 @@ fn test_validate_hot_responses_output_rejects_completed_empty_payloads() {
     );
 }
 
+fn api_error(status: StatusCode) -> OpenRouterError {
+    OpenRouterError::Api(Box::new(ApiErrorContext {
+        status,
+        api_code: None,
+        message: format!("test status {status}"),
+        request_id: None,
+        metadata: None,
+        kind: ApiErrorKind::Generic,
+    }))
+}
+
+#[test]
+fn test_hot_responses_error_classification_keeps_client_api_errors_hard() {
+    assert!(is_hot_responses_hard_error(&api_error(
+        StatusCode::BAD_REQUEST
+    )));
+    assert!(is_hot_responses_hard_error(&api_error(
+        StatusCode::UNPROCESSABLE_ENTITY
+    )));
+    assert!(!is_hot_responses_hard_error(&api_error(
+        StatusCode::TOO_MANY_REQUESTS
+    )));
+    assert!(!is_hot_responses_hard_error(&api_error(
+        StatusCode::BAD_GATEWAY
+    )));
+}
+
 #[tokio::test]
 #[allow(clippy::result_large_err)]
 async fn test_stream_response_unified_done_semantics() -> Result<(), OpenRouterError> {
@@ -386,10 +422,7 @@ async fn test_hot_responses_model_sweep() -> Result<(), OpenRouterError> {
             },
             Err(err) => {
                 let message = err.to_string();
-                if matches!(
-                    &err,
-                    OpenRouterError::Serialization(_) | OpenRouterError::Unknown(_)
-                ) {
+                if is_hot_responses_hard_error(&err) {
                     hard_failures.push(format!("{model}: {message}"));
                 } else {
                     service_warnings.push(format!("{model}: {message}"));

--- a/tests/integration/responses.rs
+++ b/tests/integration/responses.rs
@@ -145,9 +145,7 @@ fn validate_hot_responses_output_for_model(
 
     let text = collect_response_text(response);
     if text.trim().is_empty() {
-        return Ok(HotResponseOutcome::ServiceWarning(
-            "no output_text or reasoning text in response".to_string(),
-        ));
+        return Err("no output_text or reasoning text in response".to_string());
     }
 
     Ok(HotResponseOutcome::Passed)
@@ -256,6 +254,22 @@ fn test_validate_hot_responses_output_warns_for_incomplete_status() {
         Ok(HotResponseOutcome::ServiceWarning(
             "responses status incomplete".to_string()
         ))
+    );
+}
+
+#[test]
+fn test_validate_hot_responses_output_rejects_completed_empty_payloads() {
+    let response: ResponsesResponse = serde_json::from_value(json!({
+        "id": "resp_completed_empty",
+        "object": "response",
+        "status": "completed",
+        "output": []
+    }))
+    .expect("response should deserialize");
+
+    assert_eq!(
+        validate_hot_responses_output_for_model(&response),
+        Err("no output_text or reasoning text in response".to_string())
     );
 }
 

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -11,11 +11,16 @@ use serde_json::json;
 fn test_reasoning_effort_extended_values_serialize() {
     let efforts = vec![
         (Effort::Xhigh, "xhigh"),
+        (Effort::Max, "max"),
         (Effort::High, "high"),
         (Effort::Medium, "medium"),
         (Effort::Low, "low"),
         (Effort::Minimal, "minimal"),
         (Effort::None, "none"),
+        (
+            Effort::Other("provider-custom".to_string()),
+            "provider-custom",
+        ),
     ];
 
     for (effort, expected) in efforts {
@@ -29,6 +34,21 @@ fn test_reasoning_effort_extended_values_serialize() {
         let json = serde_json::to_value(&request).expect("request should serialize");
         assert_eq!(json["reasoning"]["effort"], expected);
     }
+}
+
+#[test]
+fn test_reasoning_effort_deserializes_max_and_unknown_values() {
+    let max: Effort = serde_json::from_value(json!("max")).expect("max should deserialize");
+    assert!(matches!(max, Effort::Max));
+    assert_eq!(max.to_string(), "max");
+
+    let custom: Effort =
+        serde_json::from_value(json!("provider-custom")).expect("unknown values should parse");
+    assert!(matches!(custom, Effort::Other(ref value) if value == "provider-custom"));
+    assert_eq!(
+        serde_json::to_value(custom).expect("unknown effort should serialize"),
+        json!("provider-custom")
+    );
 }
 
 #[test]

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -202,10 +202,10 @@ fn test_model_response_deserializes_links_and_benchmarks() {
                 }]
             },
             "reasoning": {
-                "default_effort": "high",
+                "default_effort": "max",
                 "default_enabled": true,
                 "mandatory": false,
-                "supported_efforts": ["high", "medium", "low", "minimal"],
+                "supported_efforts": ["max", "high", "medium", "provider-custom"],
                 "supports_max_tokens": true
             }
         }
@@ -241,7 +241,14 @@ fn test_model_response_deserializes_links_and_benchmarks() {
         .expect("reasoning metadata should be present");
     assert!(matches!(
         reasoning.default_effort.as_ref(),
-        Some(openrouter_rs::types::Effort::High)
+        Some(openrouter_rs::types::Effort::Max)
+    ));
+    assert!(matches!(
+        reasoning
+            .supported_efforts
+            .as_ref()
+            .and_then(|efforts| efforts.last()),
+        Some(openrouter_rs::types::Effort::Other(value)) if value == "provider-custom"
     ));
     assert_eq!(reasoning.supports_max_tokens, Some(true));
 }


### PR DESCRIPTION
## Summary
- accept OpenRouter new `max` reasoning effort and preserve future provider-defined effort strings instead of failing model metadata deserialization
- relax the `exclude_reasoning` live test to validate the response envelope plus hidden reasoning without requiring visible content from reasoning-only providers
- keep Responses hot-sweep SDK/protocol failures hard while reporting per-model runtime statuses such as `incomplete` as service warnings

## Root cause
Recent scheduled runs failed because `/models` now returns `reasoning.default_effort` or `supported_efforts` with `max`, which the SDK enum rejected. The same deserialization failure broke Live Contract Checks, CLI models list, and several live integration model-list tests. The remaining live integration failures were from provider/runtime variability rather than SDK parsing regressions.

## Validation
- `cargo fmt --all`
- `just test-unit`
- `cargo test --test integration test_validate -- --nocapture`
- `just test-integration-subsets`
- `just quality`
- `just quality-ci`