### PR TITLE
chore: prepare 0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-07-01
+
 ### Fixed
-- Accepted new and future provider-defined reasoning effort strings in model metadata, including OpenRouter's `max` effort value, so `/models` deserialization and CLI model listing remain forward-compatible with upstream taxonomy additions.
-- Reduced scheduled live-test noise by treating per-model Responses hot-sweep runtime statuses such as `incomplete` as service warnings while keeping SDK deserialization/protocol failures as hard failures.
+- Accepted OpenRouter's new `max` reasoning effort and preserved future provider-defined effort strings in model metadata, so `/models` deserialization and CLI model listing remain forward-compatible with upstream taxonomy additions.
+- Hardened scheduled live Responses checks so transient runtime statuses such as `incomplete` remain service warnings while completed empty outputs, SDK deserialization failures, and non-retryable API errors remain hard failures.
 
 ## [0.11.0] - 2026-06-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The current repo snapshot implements `87 / 87` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.11.0"
+openrouter-rs = "0.11.1"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -47,7 +47,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.11.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.11.1", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -334,7 +334,12 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 - No unreleased changes.
 
-### Version 0.11.0 *(Latest)*
+### Version 0.11.1 *(Latest)*
+
+- Accepted OpenRouter's new `max` reasoning effort and preserved future provider-defined effort strings in model metadata, keeping `/models` deserialization and CLI model listing forward-compatible with upstream taxonomy additions.
+- Hardened scheduled live Responses checks so transient runtime statuses stay service warnings while completed empty outputs, SDK deserialization failures, and non-retryable API errors remain hard failures.
+
+### Version 0.11.0
 
 - Added typed SDK coverage for image generation, files, analytics, app rankings, task classifications, unified benchmarks, singular model lookup, rankings-daily, preset listing/readback/versioning, workspace budgets, and expanded model filters.
 - Added automatic prompt caching request support through top-level `cache_control` builders for chat completions and Responses API requests.

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.11.0", path = "../.." }
+openrouter-rs = { version = "0.11.1", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.11.0"
+//! openrouter-rs = "0.11.1"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
Release prep for SDK 0.11.1.

Summary:
- Bump openrouter-rs package, docs, changelog, README release history, and CLI workspace dependency to 0.11.1.
- Capture fixes from PR #229: reasoning effort max and unknown strings, plus hardened scheduled Responses checks.

Validation:
- just quality
- bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.11.1
- cargo package --locked --allow-dirty
- just quality-ci