### PR TITLE
feat: accept server tools OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added OpenRouter server-tool request helpers via `ServerTool` for chat completions, Responses API, Anthropic-compatible Messages, and preset creation request bodies, including `openrouter:web_search`, `openrouter:datetime`, raw custom server-tool escape hatches, and server-tool `tool_choice` helpers.
+- Added management-key SDK support for `GET /workspaces/{id}/members` via `api::workspaces::list_workspace_members(...)` and `client.management().list_workspace_members(...)`.
+
+### Changed
+- Accepted the 2026-07-06 OpenAPI drift review for server-tool request schemas and workspace member listing, restoring the repository snapshot to `88 / 88` official OpenAPI endpoint coverage.
+
 ## [0.11.1] - 2026-07-01
 
 ### Fixed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# OpenRouter Rust SDK
+
+This context defines project-specific language for compatibility work in the OpenRouter Rust SDK.
+
+## Language
+
+**OpenAPI drift acceptance**:
+A reviewed upstream OpenAPI change that the SDK agrees to implement and then records in the tracked baseline. Acceptance includes SDK surface work, tests, documentation, and a refreshed drift baseline.
+_Avoid_: Baseline refresh, spec sync
+
+**OpenAPI baseline**:
+The tracked reviewed OpenAPI snapshot used by the repository's drift checker. It is evidence of accepted upstream behavior, not a substitute for SDK implementation.
+_Avoid_: Generated source, upstream truth
+
+**Server tool**:
+An OpenRouter-operated tool provided in a request `tools` array and executed by OpenRouter on behalf of the model, typically identified by an `openrouter:*` tool type.
+_Avoid_: Plugin, function tool
+
+**Function tool**:
+A caller-defined tool whose invocation is suggested by the model but executed by the caller's application. In chat-completions payloads it is serialized with `type: "function"` and a `function` definition.
+_Avoid_: Server tool, plugin
+
+**Plugin**:
+An OpenRouter request extension configured through the `plugins` array. Plugins are distinct from tools and must not be used as the canonical model for server-tool support.
+_Avoid_: Server tool, function tool

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 `openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, image generation, video generation, models, embeddings, files, presets, analytics, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `87 / 87` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `88 / 88` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
@@ -250,7 +250,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`87 / 87`)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`88 / 88`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The current repo snapshot implements `87 / 87` official OpenAPI method/path entr
 - Typed request/response models with builder-style ergonomics
 - Tokio-native `reqwest + rustls` transport with no `surf` / `curl` dependency chain
 - Streaming support for chat, responses, messages, and image generation, including a unified stream abstraction
-- Typed tools, manual JSON-schema tools, and multimodal chat content
+- Typed tools, manual JSON-schema tools, OpenRouter server tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
 - Opt-in OpenRouter response metadata for chat, Responses API, and Anthropic-compatible Messages requests
 - Discovery, rankings and benchmark datasets, task classifications, rerank, audio speech/transcription, image generation, video generation, files, embeddings, API-key management, preset creation/readback/versioning, analytics, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
@@ -109,7 +109,7 @@ The canonical public surface is domain-oriented:
 | `videos()` | `create`, `list_models`, `get_generation`, `get_content` | `/videos*` | API key |
 | `files()` | `list`, `upload`, `get_metadata`, `download_content`, `delete` | `/files*` | API key |
 | `models()` | `list`, `list_filtered`, `list_by_category`, `list_by_parameters`, `get`, `list_endpoints`, `list_providers`, `list_user_models`, `get_model_count`, `get_rankings_daily`, `get_app_rankings`, `get_task_classifications`, `get_benchmarks`, `list_zdr_endpoints`, `create_embedding`, `list_embedding_models` | `/model*`, `/models*`, `/providers`, `/datasets/*`, `/classifications/task`, `/benchmarks`, `/endpoints/zdr`, `/embeddings*` | API key |
-| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_presets`, `get_preset`, `list_preset_versions`, `get_preset_version`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `get_analytics_meta`, `query_analytics`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `list_workspace_budgets`, `upsert_workspace_budget`, `delete_workspace_budget`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/analytics*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
+| `management()` | `create_api_key`, `create_api_key_in_workspace`, `list_api_keys`, `list_api_keys_in_workspace`, `list_presets`, `get_preset`, `list_preset_versions`, `get_preset_version`, `create_chat_completion_preset`, `create_response_preset`, `create_message_preset`, `get_analytics_meta`, `query_analytics`, `list_byok_keys`, `create_byok_key`, `get_byok_key`, `update_byok_key`, `delete_byok_key`, `list_observability_destinations`, `create_observability_destination`, `get_observability_destination`, `update_observability_destination`, `delete_observability_destination`, `create_auth_code`, `create_api_key_from_auth_code`, `list_guardrails`, `list_guardrails_in_workspace`, `create_guardrail`, `list_organization_members`, `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace`, `list_workspace_budgets`, `upsert_workspace_budget`, `delete_workspace_budget`, `list_workspace_members`, `add_workspace_members`, `remove_workspace_members`, `get_activity`, `get_credits`, `create_coinbase_charge`, `get_generation`, `get_generation_content` | `/keys*`, `/presets*`, `/analytics*`, `/byok*`, `/observability/destinations*`, `/auth/keys*`, `/guardrails*`, `/organization/members`, `/workspaces*`, `/activity`, `/credits*`, `/generation*`, `/key` | Governed endpoints require a management key; billing/session endpoints still use the normal API key because that is how OpenRouter authenticates them |
 | `legacy()` | `completions().create` | `/completions` | `legacy-completions` feature + API key |
 
 At runtime, the builder/client exposes the values the SDK directly consumes:
@@ -131,13 +131,34 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 - chat completions, responses, and Anthropic-compatible messages
 - rerank, audio speech generation, audio transcription, image generation, and video generation polling/content retrieval
 - unified streaming across chat, responses, and messages
-- manual tools and typed tools backed by `schemars`
+- manual tools, typed tools backed by `schemars`, and OpenRouter server tools such as `openrouter:web_search` and `openrouter:datetime`
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, app rankings, task classifications, unified benchmarks, embeddings, and ZDR endpoints
 - typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
-- management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace membership, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
+- management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace member listing/mutation, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.
+
+### Server Tools
+
+OpenRouter server tools use the same `ServerTool` type across chat completions, Responses API, Anthropic-compatible Messages, and preset creation request bodies:
+
+```rust
+use openrouter_rs::{
+    api::chat::{ChatCompletionRequest, Message},
+    types::{Role, ServerTool},
+};
+use serde_json::json;
+
+let request = ChatCompletionRequest::builder()
+    .model("openai/gpt-5")
+    .messages(vec![Message::new(Role::User, "Find current OpenRouter docs.")])
+    .server_tool(ServerTool::web_search_with_parameters(json!({
+        "max_results": 3
+    })))
+    .force_server_tool("openrouter:web_search")
+    .build()?;
+```
 
 ## Examples
 
@@ -332,7 +353,8 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ### Unreleased
 
-- No unreleased changes.
+- Added OpenRouter server-tool request helpers for chat completions, Responses API, Anthropic-compatible Messages, and preset creation request bodies.
+- Added typed management-key SDK support for `GET /workspaces/{id}/members`, restoring accepted OpenAPI endpoint coverage to `88 / 88`.
 
 ### Version 0.11.1 *(Latest)*
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,19 +1,21 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-06-29
+Snapshot date: 2026-07-06
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `87` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `87 / 87` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 87` endpoints currently exercised.
+- Official OpenAPI endpoints: `88` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `88 / 88` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 88` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
 
+- Upstream added OpenRouter server-tool variants to chat completions, Responses API, Anthropic-compatible Messages, and preset creation request schemas. The SDK now exposes `ServerTool` helpers and preserves raw `Value` escape hatches for high-churn server-tool payloads.
+- Upstream added `GET /workspaces/{id}/members`, now exposed as `client.management().list_workspace_members(...)`.
 - Upstream added task classification discovery and image generation endpoints. The SDK now exposes task classifications through `client.models().get_task_classifications(...)` and images through `client.images().create(...)`, `stream(...)`, `list_models()`, and `list_model_endpoints(...)`. The unified benchmarks endpoint now allows an omitted `source`, and nullable benchmark metadata is reflected in the typed response.
 - Upstream replaced the two per-source benchmark dataset endpoints with unified `GET /benchmarks` and added workspace budget management. The SDK now exposes `client.models().get_benchmarks(...)` and `client.management().list_workspace_budgets(...)` / `upsert_workspace_budget(...)` / `delete_workspace_budget(...)`. The old per-source benchmark methods remain deprecated compatibility wrappers.
 - Upstream added model reasoning metadata, analytics warnings, chat server-tool usage metadata, embedding cost details, and Anthropic file document sources. The SDK now exposes typed fields/helpers for these stable surfaces while preserving flexible `Value` and `HashMap` escape hatches for high-churn payloads.
@@ -124,6 +126,7 @@ Legend:
 | `GET /workspaces` | `client.management().list_workspaces(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}` | `client.management().get_workspace(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}/budgets` | `client.management().list_workspace_budgets(...)` | Yes | Path | No | P1 |
+| `GET /workspaces/{id}/members` | `client.management().list_workspace_members(...)` | Yes | Path | No | P1 |
 | `POST /messages` | `client.messages().create(...)` / `client.messages().stream(...)` | Yes | Path | Yes | Keep |
 | `POST /rerank` | `client.rerank().create(...)` | Yes | Path | Yes | Keep |
 | `POST /responses` | `client.responses().create(...)` / `client.responses().stream(...)` | Yes | Contract | Yes | Keep |

--- a/openspec/changes/accept-server-tools-openapi-drift/.openspec.yaml
+++ b/openspec/changes/accept-server-tools-openapi-drift/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/accept-server-tools-openapi-drift/README.md
+++ b/openspec/changes/accept-server-tools-openapi-drift/README.md
@@ -1,0 +1,3 @@
+# accept-server-tools-openapi-drift
+
+Accept the current upstream OpenAPI drift that introduces OpenRouter server tools in request and response schemas, while keeping the SDK's function-tool ergonomics and drift baseline aligned.

--- a/openspec/changes/accept-server-tools-openapi-drift/design.md
+++ b/openspec/changes/accept-server-tools-openapi-drift/design.md
@@ -1,0 +1,78 @@
+## Context
+
+The current tracked baseline has `87` method/path entries, while the latest upstream OpenAPI snapshot has `88`. The current drift report shows one added operation and four changed operations:
+
+- `GET /workspaces/{id}/members`
+- `POST /chat/completions`
+- `POST /presets/{slug}/chat/completions`
+- `POST /presets/{slug}/responses`
+- `POST /responses`
+
+The upstream schema now includes server-tool components such as `OpenRouterWebSearchServerTool`, `DatetimeServerTool`, `ChatWebSearchShorthand`, `ChatServerToolChoice`, `OutputWebSearchServerToolItem`, and `OutputDatetimeItem`. This makes issue #228 an OpenAPI drift acceptance task, not a docs-only feature request.
+
+Current SDK shape is partially ready but uneven:
+
+- Chat completions currently expose `types::Tool` as a function-tool struct with a required `function` definition.
+- Responses requests already accept `tools: Vec<serde_json::Value>`, which is flexible but not ergonomic.
+- Messages requests expose `AnthropicTool`, which covers Anthropic-style hosted tools but does not cleanly represent every OpenRouter `openrouter:*` server tool shape.
+- The drift classifier already treats Responses and Messages tool payload internals as flexible, but not the chat-completions tool payload.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement the OpenAPI-defined server-tool surface for chat completions, Responses, Messages, and relevant preset creation endpoints.
+- Keep existing function-tool construction and serialization source-compatible for callers.
+- Make server tools first-class enough for common use, especially `openrouter:web_search` and `openrouter:datetime`, while preserving raw escape hatches for beta churn.
+- Deserialize and expose server-tool output and usage details that appear in OpenAPI response schemas.
+- Refresh the OpenAPI baseline after implementation and finish with zero drift.
+
+**Non-Goals:**
+
+- Do not treat server tools as plugins or migrate plugin APIs.
+- Do not replace existing function-tool helpers with untyped JSON-only APIs.
+- Do not refresh the OpenAPI baseline before the accepted drift is implemented or explicitly deferred.
+- Do not implement local execution for server tools; OpenRouter executes these tools server-side.
+
+## Decisions
+
+1. Treat this as OpenAPI drift acceptance.
+
+   The upstream OpenAPI already contains server-tool request and response schemas. The implementation will follow the drift workflow: inspect the current report, implement accepted SDK behavior, refresh the baseline, and verify `just openapi-drift-check` reaches zero drift. A helper-only change without baseline refresh would leave the repository with contradictory sources of truth.
+
+2. Preserve `types::Tool` as the function-tool model.
+
+   Existing callers can construct and inspect `Tool` as a function-tool struct. Replacing it with an enum would be a broad source break. Chat and Messages request builders should instead add additive server-tool helpers and merge function tools plus server tools into the wire `tools` array during serialization.
+
+3. Introduce a flexible server-tool model.
+
+   The server-tool model should carry a string tool type, optional typed parameters, and a flattened extra map. Typed constructors should cover stable/common OpenRouter tools such as web search and datetime. A raw constructor should allow beta tool variants that appear in OpenAPI before the SDK grows dedicated helpers.
+
+4. Keep endpoint-specific wire semantics explicit.
+
+   Chat, Responses, and Messages have different tool schemas. Shared server-tool helpers can provide common constructors, but each endpoint should own the conversion into its wire request shape. This prevents an Anthropic-hosted-tool shape from leaking into generic OpenRouter server tools, or vice versa.
+
+5. Update drift classification only after support exists.
+
+   Once chat and preset request builders can pass the OpenAPI-defined server-tool variants, the drift classifier may mark future item-level additions inside `tools` arrays as already supported. Container-shape changes, new required top-level fields, or new operations must remain actionable.
+
+## Risks / Trade-offs
+
+- Server-tool schemas are beta and may churn -> Use non-exhaustive public types, flexible string enums, flattened extras, and raw constructors.
+- Additive helpers could diverge across chat, Responses, and Messages -> Keep endpoint-specific tests that assert exact JSON payloads for each endpoint.
+- A broad baseline refresh could hide unrelated drift -> Inspect and implement or explicitly defer every actionable operation before running `just openapi-refresh-baseline`.
+- Custom serialization for merged tool arrays can be brittle -> Add unit tests for function-only, server-only, and mixed-tool requests.
+- Preset creation endpoints reuse request bodies -> Include preset-specific request-shape tests or update drift classification only when preset paths are demonstrably covered.
+
+## Migration Plan
+
+1. Implement request and response support behind additive helpers.
+2. Add unit tests for serialization/deserialization and drift classifier behavior.
+3. Add or update examples and public documentation for `openrouter:web_search`.
+4. Run `just openapi-refresh-baseline`.
+5. Run `just openapi-drift-check` and require `added=0, removed=0, changed=0`.
+6. Run `just quality-ci`.
+
+## Open Questions
+
+- None for the OpenSpec boundary. During implementation, the live drift report should decide whether any non-server-tool drift is accepted in this slice or explicitly deferred before baseline refresh.

--- a/openspec/changes/accept-server-tools-openapi-drift/proposal.md
+++ b/openspec/changes/accept-server-tools-openapi-drift/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Issue #228 asked for OpenRouter server-tool support, especially web search. Current upstream `openapi.json` already includes server-tool schemas in chat, Responses, and Messages request surfaces, so this must be treated as OpenAPI drift acceptance rather than a docs-only helper.
+
+## What Changes
+
+- Add typed SDK support for OpenAPI-defined server tools in chat completions, Responses API, and Anthropic-compatible Messages where the upstream schema exposes them.
+- Preserve existing function-tool ergonomics while allowing server tools to be sent in the same wire `tools` array.
+- Add support for server-tool-specific tool choice and server-tool output/usage payloads where the OpenAPI schema exposes them.
+- Accept the full current actionable drift in the same implementation slice, including the new `GET /workspaces/{id}/members` operation or an explicit documented deferral before baseline refresh.
+- Refresh the tracked OpenAPI baseline only after SDK behavior, tests, docs, and drift classification match the accepted upstream surface.
+
+## Capabilities
+
+### New Capabilities
+
+- `openapi-drift-acceptance`: Rules for accepting this upstream OpenAPI drift batch, including server-tool request/response support and baseline refresh discipline.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: `src/types/tool.rs`, chat/responses/messages request builders, Responses output types, workspace management client methods, preset request surfaces that reuse chat/responses bodies, and OpenAPI drift classification.
+- Affected docs: `README.md`, `CHANGELOG.md`, `docs/operations/official-endpoint-test-matrix.md`, and examples for server-tool usage.
+- API impact: additive public SDK surface for server tools and workspace member listing. Existing function-tool callers should remain source-compatible.
+- Validation impact: run `just openapi-refresh-baseline`, `just openapi-drift-check`, `just quality-ci`, and targeted unit/integration tests before opening a PR.

--- a/openspec/changes/accept-server-tools-openapi-drift/specs/openapi-drift-acceptance/spec.md
+++ b/openspec/changes/accept-server-tools-openapi-drift/specs/openapi-drift-acceptance/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: OpenAPI drift acceptance is implemented before baseline refresh
+The SDK SHALL refresh the tracked OpenAPI baseline only after all accepted actionable drift in the current upstream snapshot is implemented or explicitly documented as deferred.
+
+#### Scenario: Current drift is accepted
+- **WHEN** the upstream drift report includes server-tool schema changes and added operations
+- **THEN** the implementation covers every accepted changed or added operation before running `just openapi-refresh-baseline`
+
+#### Scenario: Drift is deferred
+- **WHEN** an actionable drift item is not implemented in this change
+- **THEN** the change documents the deferral and does not classify that drift item as already supported
+
+### Requirement: Chat completions support OpenAPI-defined server tools
+Chat completion requests SHALL support OpenAPI-defined server-tool entries in the wire `tools` array while preserving existing function-tool construction.
+
+#### Scenario: Function and server tools are mixed
+- **WHEN** a chat completion request includes both caller-defined function tools and OpenRouter server tools
+- **THEN** the serialized request contains both entries in the same `tools` array using their OpenAPI wire shapes
+
+#### Scenario: Server tool choice is forced
+- **WHEN** a chat completion request forces an OpenRouter server tool through `tool_choice`
+- **THEN** the serialized `tool_choice` matches the OpenAPI `ChatServerToolChoice` shape
+
+### Requirement: Responses API supports server-tool request and output shapes
+Responses API requests and responses SHALL support the server-tool request variants and output items defined by the accepted OpenAPI schema.
+
+#### Scenario: Responses request uses web search
+- **WHEN** a Responses request includes an OpenRouter web-search server tool
+- **THEN** the serialized `tools` entry matches the accepted OpenAPI server-tool schema
+
+#### Scenario: Responses output contains server-tool item
+- **WHEN** OpenRouter returns server-tool output items such as web-search or datetime output
+- **THEN** the SDK deserializes them without losing status, type, identifier, and tool-specific payload fields
+
+### Requirement: Messages API supports accepted server-tool shapes
+Anthropic-compatible Messages requests SHALL support the server-tool variants included in the accepted OpenAPI schema without regressing existing Anthropic custom and hosted tool support.
+
+#### Scenario: Existing Messages tools still serialize
+- **WHEN** a caller builds an Anthropic custom or hosted tool request
+- **THEN** the serialized request remains compatible with the existing SDK behavior
+
+#### Scenario: OpenRouter server tool is included
+- **WHEN** a Messages request includes an OpenRouter server tool from the accepted schema
+- **THEN** the serialized `tools` entry matches the OpenAPI shape for that tool
+
+### Requirement: Workspace member listing is covered or explicitly deferred
+The implementation SHALL handle the new `GET /workspaces/{id}/members` operation from the same drift batch, unless the change explicitly documents deferral before refreshing the baseline.
+
+#### Scenario: Workspace member listing is accepted
+- **WHEN** the drift batch is implemented without deferral
+- **THEN** the SDK exposes a management-key workspace member listing method and tests its path, authentication, and response shape
+
+### Requirement: Drift classifier remains conservative
+The OpenAPI drift classifier SHALL mark future tool item-shape additions as already supported only for operations whose SDK request surfaces can pass those tool payloads through correctly.
+
+#### Scenario: Supported tool item changes
+- **WHEN** upstream adds another item variant inside a supported `tools` array
+- **THEN** the drift report classifies that item-level schema change as already supported
+
+#### Scenario: Unsupported structural changes
+- **WHEN** upstream changes the `tools` container type, adds a new operation, or introduces unsupported required top-level fields
+- **THEN** the drift report keeps the change actionable

--- a/openspec/changes/accept-server-tools-openapi-drift/tasks.md
+++ b/openspec/changes/accept-server-tools-openapi-drift/tasks.md
@@ -1,0 +1,42 @@
+## 1. Drift Review
+
+- [x] 1.1 Fetch the latest upstream OpenAPI snapshot and generate the drift report.
+- [x] 1.2 Record every actionable item in the current drift batch, including server-tool schema changes and `GET /workspaces/{id}/members`.
+- [x] 1.3 Decide whether each actionable drift item is accepted in this slice or explicitly deferred before baseline refresh.
+
+## 2. Tool Request Surface
+
+- [x] 2.1 Add a flexible server-tool model with typed helpers for `openrouter:web_search` and `openrouter:datetime` plus a raw escape hatch.
+- [x] 2.2 Add chat-completions helpers that serialize function tools and server tools into one wire `tools` array.
+- [x] 2.3 Add chat-completions `tool_choice` support for OpenAPI `ChatServerToolChoice`.
+- [x] 2.4 Add Responses API typed helpers or conversions for accepted server-tool request variants while preserving raw `Value` support.
+- [x] 2.5 Add Messages API support for accepted OpenRouter server-tool shapes without regressing existing Anthropic tool support.
+- [x] 2.6 Ensure preset chat/responses creation paths can carry the same accepted server-tool request payloads.
+
+## 3. Response And Management Coverage
+
+- [x] 3.1 Add or update Responses output deserialization for server-tool output items such as web search and datetime.
+- [x] 3.2 Verify chat and Messages response usage/server-tool blocks deserialize accepted server-tool usage fields.
+- [x] 3.3 Add `GET /workspaces/{id}/members` SDK support or document explicit deferral before baseline refresh.
+
+## 4. Tests And Drift Tooling
+
+- [x] 4.1 Add unit tests for chat function-only, server-only, and mixed-tool serialization.
+- [x] 4.2 Add unit tests for Responses and Messages server-tool serialization/deserialization.
+- [x] 4.3 Add unit tests for server-tool `tool_choice` serialization.
+- [x] 4.4 Add OpenAPI drift classifier tests so supported tool item additions are already supported and structural changes remain actionable.
+- [x] 4.5 Add or update live/integration coverage where API keys and stable upstream behavior make it practical.
+
+## 5. Documentation And Examples
+
+- [x] 5.1 Update README or examples with a minimal `openrouter:web_search` server-tool request.
+- [x] 5.2 Update `CHANGELOG.md` with the accepted OpenAPI drift and new SDK surface.
+- [x] 5.3 Update `docs/operations/official-endpoint-test-matrix.md` for changed endpoint coverage.
+- [x] 5.4 Reference issue #228 in the PR description and closeout notes.
+
+## 6. Baseline And Verification
+
+- [x] 6.1 Run `just openapi-refresh-baseline` after accepted drift is implemented.
+- [x] 6.2 Run `just openapi-drift-check` and require `added=0, removed=0, changed=0`.
+- [x] 6.3 Run `just quality-ci`.
+- [x] 6.4 Inspect `git diff --check` and keep the PR scoped to the accepted drift plus documentation.

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -78,6 +78,32 @@ REPO_FLEXIBLE_PLUGIN_OPERATION_KEYS = frozenset(
     {
         "POST /chat/completions",
         "POST /messages",
+        "POST /presets/{slug}/chat/completions",
+        "POST /presets/{slug}/messages",
+        "POST /presets/{slug}/responses",
+        "POST /responses",
+    }
+)
+REPO_FLEXIBLE_CHAT_TOOL_OPERATION_KEYS = frozenset(
+    {
+        "POST /chat/completions",
+        "POST /presets/{slug}/chat/completions",
+    }
+)
+REPO_FLEXIBLE_MESSAGES_TOOL_OPERATION_KEYS = frozenset(
+    {
+        "POST /messages",
+        "POST /presets/{slug}/messages",
+    }
+)
+REPO_FLEXIBLE_RESPONSES_TOOL_OPERATION_KEYS = frozenset(
+    {
+        "POST /presets/{slug}/responses",
+        "POST /responses",
+    }
+)
+REPO_FLEXIBLE_RESPONSES_OUTPUT_OPERATION_KEYS = frozenset(
+    {
         "POST /responses",
     }
 )
@@ -455,21 +481,40 @@ def is_repo_supported_messages_tool_payload_path(
     operation_key: str,
     path: tuple[Any, ...],
 ) -> bool:
-    return operation_key == "POST /messages" and is_request_schema_property_path(path, "tools")
+    return (
+        operation_key in REPO_FLEXIBLE_MESSAGES_TOOL_OPERATION_KEYS
+        and is_request_schema_property_path(path, "tools")
+    )
+
+
+def is_repo_supported_chat_tool_payload_path(
+    operation_key: str,
+    path: tuple[Any, ...],
+) -> bool:
+    return (
+        operation_key in REPO_FLEXIBLE_CHAT_TOOL_OPERATION_KEYS
+        and is_request_schema_property_path(path, "tools")
+    )
 
 
 def is_repo_supported_responses_tool_payload_path(
     operation_key: str,
     path: tuple[Any, ...],
 ) -> bool:
-    return operation_key == "POST /responses" and is_request_schema_property_path(path, "tools")
+    return (
+        operation_key in REPO_FLEXIBLE_RESPONSES_TOOL_OPERATION_KEYS
+        and is_request_schema_property_path(path, "tools")
+    )
 
 
 def is_repo_supported_responses_output_payload_path(
     operation_key: str,
     path: tuple[Any, ...],
 ) -> bool:
-    return operation_key == "POST /responses" and is_response_schema_property_path(path, "output")
+    return (
+        operation_key in REPO_FLEXIBLE_RESPONSES_OUTPUT_OPERATION_KEYS
+        and is_response_schema_property_path(path, "output")
+    )
 
 
 def is_repo_supported_flexible_plugin_payload(
@@ -488,6 +533,16 @@ def is_repo_supported_messages_tool_payload(
     value: Any,
 ) -> bool:
     return is_repo_supported_messages_tool_payload_path(
+        operation_key, path
+    ) and schema_has_type(value, "array")
+
+
+def is_repo_supported_chat_tool_payload(
+    operation_key: str,
+    path: tuple[Any, ...],
+    value: Any,
+) -> bool:
+    return is_repo_supported_chat_tool_payload_path(
         operation_key, path
     ) and schema_has_type(value, "array")
 
@@ -523,6 +578,9 @@ def strip_repo_supported_schema_details(
 
         if is_repo_supported_messages_tool_payload(operation_key, path, value):
             return {"<repo-supported-messages-tool-payload>": True}
+
+        if is_repo_supported_chat_tool_payload(operation_key, path, value):
+            return {"<repo-supported-chat-tool-payload>": True}
 
         if is_repo_supported_responses_tool_payload(operation_key, path, value):
             return {"<repo-supported-responses-tool-payload>": True}
@@ -580,6 +638,8 @@ def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[
                 rules.add("flexible plugin payload")
             if is_repo_supported_messages_tool_payload(operation_key, path, item):
                 rules.add("Messages flexible tool payload")
+            if is_repo_supported_chat_tool_payload(operation_key, path, item):
+                rules.add("Chat flexible tool payload")
             if is_repo_supported_responses_tool_payload(operation_key, path, item):
                 rules.add("Responses flexible tool payload")
             if is_repo_supported_responses_output_payload(operation_key, path, item):

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import datetime as dt
 import difflib
 import hashlib
@@ -105,6 +106,16 @@ REPO_FLEXIBLE_RESPONSES_TOOL_OPERATION_KEYS = frozenset(
 REPO_FLEXIBLE_RESPONSES_OUTPUT_OPERATION_KEYS = frozenset(
     {
         "POST /responses",
+    }
+)
+REPO_CHAT_SUPPORTED_FUNCTION_TOOL_FIELDS = frozenset({"cache_control"})
+REPO_CHAT_SUPPORTED_FUNCTION_DEFINITION_FIELDS = frozenset({"strict"})
+REPO_CHAT_SERVER_TOOL_TYPE_MARKERS = frozenset(
+    {
+        "web_search",
+        "web_search_2025_08_26",
+        "web_search_preview",
+        "web_search_preview_2025_03_11",
     }
 )
 BASELINE_TOP_LEVEL_FIELDS = (
@@ -547,6 +558,103 @@ def is_repo_supported_chat_tool_payload(
     ) and schema_has_type(value, "array")
 
 
+def schema_direct_type_values(value: Any) -> set[str]:
+    if not isinstance(value, dict):
+        return set()
+
+    properties = value.get("properties")
+    if not isinstance(properties, dict):
+        return set()
+
+    type_schema = properties.get("type")
+    return {item for item in scalar_enum_values(type_schema) if isinstance(item, str)}
+
+
+def is_repo_supported_chat_server_tool_variant(value: Any) -> bool:
+    type_values = schema_direct_type_values(value)
+    if not type_values:
+        return False
+
+    return all(
+        item != "function"
+        and (
+            item.startswith("openrouter:")
+            or item in REPO_CHAT_SERVER_TOOL_TYPE_MARKERS
+        )
+        for item in type_values
+    )
+
+
+def strip_repo_supported_chat_function_tool_fields(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+
+    stripped = copy.deepcopy(value)
+    properties = stripped.get("properties")
+    if not isinstance(properties, dict):
+        return stripped
+
+    for field_name in REPO_CHAT_SUPPORTED_FUNCTION_TOOL_FIELDS:
+        properties.pop(field_name, None)
+
+    function_schema = properties.get("function")
+    if isinstance(function_schema, dict):
+        function_properties = function_schema.get("properties")
+        if isinstance(function_properties, dict):
+            for field_name in REPO_CHAT_SUPPORTED_FUNCTION_DEFINITION_FIELDS:
+                function_properties.pop(field_name, None)
+
+    return stripped
+
+
+def strip_repo_supported_chat_tool_payload_details(value: Any) -> Any:
+    stripped = copy.deepcopy(value)
+    items = stripped.get("items")
+    if not isinstance(items, dict):
+        return stripped
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = items.get(union_key)
+        if not isinstance(variants, list):
+            continue
+
+        items[union_key] = [
+            strip_repo_supported_chat_function_tool_fields(variant)
+            for variant in variants
+            if not is_repo_supported_chat_server_tool_variant(variant)
+        ]
+
+    return stripped
+
+
+def chat_tool_payload_has_supported_details(value: Any) -> tuple[bool, bool]:
+    if not isinstance(value, dict):
+        return (False, False)
+
+    has_server_tool_variant = False
+    has_supported_function_fields = False
+
+    items = value.get("items")
+    if not isinstance(items, dict):
+        return (False, False)
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = items.get(union_key)
+        if not isinstance(variants, list):
+            continue
+
+        for variant in variants:
+            if is_repo_supported_chat_server_tool_variant(variant):
+                has_server_tool_variant = True
+                continue
+
+            stripped_variant = strip_repo_supported_chat_function_tool_fields(variant)
+            if stripped_variant != variant:
+                has_supported_function_fields = True
+
+    return (has_server_tool_variant, has_supported_function_fields)
+
+
 def is_repo_supported_responses_tool_payload(
     operation_key: str,
     path: tuple[Any, ...],
@@ -580,7 +688,7 @@ def strip_repo_supported_schema_details(
             return {"<repo-supported-messages-tool-payload>": True}
 
         if is_repo_supported_chat_tool_payload(operation_key, path, value):
-            return {"<repo-supported-chat-tool-payload>": True}
+            return strip_repo_supported_chat_tool_payload_details(value)
 
         if is_repo_supported_responses_tool_payload(operation_key, path, value):
             return {"<repo-supported-responses-tool-payload>": True}
@@ -639,7 +747,13 @@ def collect_repo_supported_schema_rules(operation_key: str, value: Any) -> list[
             if is_repo_supported_messages_tool_payload(operation_key, path, item):
                 rules.add("Messages flexible tool payload")
             if is_repo_supported_chat_tool_payload(operation_key, path, item):
-                rules.add("Chat flexible tool payload")
+                has_server_tool_variant, has_supported_function_fields = (
+                    chat_tool_payload_has_supported_details(item)
+                )
+                if has_server_tool_variant:
+                    rules.add("Chat server-tool payload")
+                if has_supported_function_fields:
+                    rules.add("Chat supported function-tool fields")
             if is_repo_supported_responses_tool_payload(operation_key, path, item):
                 rules.add("Responses flexible tool payload")
             if is_repo_supported_responses_output_payload(operation_key, path, item):

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -6377,7 +6377,7 @@
             "$ref": "#/components/schemas/DatetimeServerTool"
           },
           {
-            "$ref": "#/components/schemas/FusionServerTool_OpenRouter"
+            "$ref": "#/components/schemas/FilesServerTool"
           },
           {
             "$ref": "#/components/schemas/ImageGenerationServerTool_OpenRouter"
@@ -10629,6 +10629,34 @@
         ],
         "type": "object"
       },
+      "FilesServerTool": {
+        "description": "OpenRouter built-in server tool: read, write, edit, and list workspace files via the Files API. Requires the `x-openrouter-file-ids: openrouter` request header.",
+        "example": {
+          "parameters": {},
+          "type": "openrouter:files"
+        },
+        "properties": {
+          "parameters": {
+            "$ref": "#/components/schemas/FilesServerToolConfig"
+          },
+          "type": {
+            "enum": [
+              "openrouter:files"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "FilesServerToolConfig": {
+        "description": "Configuration for the openrouter:files server tool",
+        "example": {},
+        "properties": {},
+        "type": "object"
+      },
       "ForbiddenResponse": {
         "description": "Forbidden - Authentication successful but insufficient permissions",
         "example": {
@@ -14511,6 +14539,9 @@
                   "$ref": "#/components/schemas/OutputSubagentServerToolItem"
                 },
                 {
+                  "$ref": "#/components/schemas/OutputFilesServerToolItem"
+                },
+                {
                   "$ref": "#/components/schemas/LocalShellCallItem"
                 },
                 {
@@ -15262,6 +15293,39 @@
         },
         "required": [
           "data"
+        ],
+        "type": "object"
+      },
+      "ListWorkspaceMembersResponse": {
+        "example": {
+          "data": [
+            {
+              "created_at": "2025-08-24T10:30:00Z",
+              "id": "660e8400-e29b-41d4-a716-446655440000",
+              "role": "member",
+              "user_id": "user_abc123",
+              "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "data": {
+            "description": "List of workspace members",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceMember"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "Total number of members in the workspace",
+            "example": 5,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
         ],
         "type": "object"
       },
@@ -22664,6 +22728,56 @@
         ],
         "type": "object"
       },
+      "OutputFilesServerToolItem": {
+        "description": "An openrouter:files server tool output item",
+        "example": {
+          "filename": "notes.txt",
+          "id": "fl_tmp_abc123",
+          "operation": "read",
+          "result": "{\"id\":\"file_abc\",\"filename\":\"notes.txt\",\"content\":\"hello\"}",
+          "status": "completed",
+          "type": "openrouter:files"
+        },
+        "properties": {
+          "error": {
+            "description": "Error message when the file operation failed.",
+            "type": "string"
+          },
+          "file_id": {
+            "description": "The target file id supplied in the tool-call arguments.",
+            "type": "string"
+          },
+          "filename": {
+            "description": "The target filename supplied in the tool-call arguments.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "operation": {
+            "description": "The file operation performed (list, read, write, or edit).",
+            "type": "string"
+          },
+          "result": {
+            "description": "JSON-serialized result of the file operation.",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolCallStatus"
+          },
+          "type": {
+            "enum": [
+              "openrouter:files"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "type"
+        ],
+        "type": "object"
+      },
       "OutputFunctionCallItem": {
         "allOf": [
           {
@@ -23423,6 +23537,7 @@
             "openrouter:datetime": "#/components/schemas/OutputDatetimeItem",
             "openrouter:experimental__search_models": "#/components/schemas/OutputSearchModelsServerToolItem",
             "openrouter:file_search": "#/components/schemas/OutputFileSearchServerToolItem",
+            "openrouter:files": "#/components/schemas/OutputFilesServerToolItem",
             "openrouter:fusion": "#/components/schemas/OutputFusionServerToolItem",
             "openrouter:image_generation": "#/components/schemas/OutputImageGenerationServerToolItem",
             "openrouter:mcp": "#/components/schemas/OutputMcpServerToolItem",
@@ -23535,6 +23650,9 @@
           },
           {
             "$ref": "#/components/schemas/OutputSubagentServerToolItem"
+          },
+          {
+            "$ref": "#/components/schemas/OutputFilesServerToolItem"
           },
           {
             "$ref": "#/components/schemas/OutputCustomToolCallItem"
@@ -27705,6 +27823,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/DatetimeServerTool"
+                },
+                {
+                  "$ref": "#/components/schemas/FilesServerTool"
                 },
                 {
                   "$ref": "#/components/schemas/FusionServerTool_OpenRouter"
@@ -47813,6 +47934,174 @@
         ],
         "x-speakeasy-name-override": "setBudget"
       }
+    },
+    "/workspaces/{id}/members": {
+      "get": {
+        "description": "List all members of a workspace. Returns paginated results. For the default workspace, returns all organization members (implicit membership). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listWorkspaceMembers",
+        "parameters": [
+          {
+            "description": "The workspace ID (UUID) or slug",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The workspace ID (UUID) or slug",
+              "example": "production",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "created_at": "2025-08-24T10:30:00Z",
+                      "id": "660e8400-e29b-41d4-a716-446655440000",
+                      "role": "member",
+                      "user_id": "user_abc123",
+                      "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
+                    }
+                  ],
+                  "total_count": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkspaceMembersResponse"
+                }
+              }
+            },
+            "description": "List of workspace members"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List workspace members",
+        "tags": [
+          "Workspaces"
+        ],
+        "x-speakeasy-name-override": "listMembers",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/workspaces/{id}/members/add": {
       "parameters": [

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-06-29T14:45:40+00:00",
+  "captured_at": "2026-07-06T03:28:58+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,7 +14,7 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 87,
+  "operation_count": 88,
   "operations": [
     {
       "deprecated": false,
@@ -601,6 +601,17 @@
     },
     {
       "deprecated": false,
+      "fingerprint": "152669ca130f94c3",
+      "id": "GET /workspaces/{id}/members",
+      "method": "GET",
+      "operation_id": "listWorkspaceMembers",
+      "path": "/workspaces/{id}/members",
+      "tags": [
+        "Workspaces"
+      ]
+    },
+    {
+      "deprecated": false,
       "fingerprint": "bfe80e24eca398d9",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
@@ -722,7 +733,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "195ae999d7774ddc",
+      "fingerprint": "1ad793dc6337d5a1",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -865,7 +876,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1b40c868f2e81ab7",
+      "fingerprint": "240209c788ebed75",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -887,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3bd42e9634a515f5",
+      "fingerprint": "27e9667881aacbe3",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -909,7 +920,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c3356b21052c4b2a",
+      "fingerprint": "148aa2cd8a4bbf97",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -470,7 +470,7 @@ impl From<Vec<String>> for StopSequence {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[derive(Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
 pub struct ChatCompletionRequest {
@@ -619,6 +619,10 @@ pub struct ChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<crate::types::Tool>>,
 
+    #[builder(setter(custom), default)]
+    #[serde(skip, default)]
+    server_tools: Option<Vec<crate::types::ServerTool>>,
+
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::types::ToolChoice>,
@@ -626,6 +630,112 @@ pub struct ChatCompletionRequest {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     parallel_tool_calls: Option<bool>,
+}
+
+fn insert_json_field<T, E>(
+    map: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: &T,
+) -> Result<(), E>
+where
+    T: Serialize,
+    E: serde::ser::Error,
+{
+    map.insert(
+        key.to_string(),
+        serde_json::to_value(value).map_err(E::custom)?,
+    );
+    Ok(())
+}
+
+fn insert_json_option<T, E>(
+    map: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: &Option<T>,
+) -> Result<(), E>
+where
+    T: Serialize,
+    E: serde::ser::Error,
+{
+    if let Some(value) = value {
+        insert_json_field::<T, E>(map, key, value)?;
+    }
+    Ok(())
+}
+
+impl Serialize for ChatCompletionRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serde_json::Map::new();
+
+        insert_json_field::<_, S::Error>(&mut map, "model", &self.model)?;
+        insert_json_field::<_, S::Error>(&mut map, "messages", &self.messages)?;
+        insert_json_option::<_, S::Error>(&mut map, "stream", &self.stream)?;
+        insert_json_option::<_, S::Error>(&mut map, "max_tokens", &self.max_tokens)?;
+        insert_json_option::<_, S::Error>(
+            &mut map,
+            "max_completion_tokens",
+            &self.max_completion_tokens,
+        )?;
+        insert_json_option::<_, S::Error>(&mut map, "temperature", &self.temperature)?;
+        insert_json_option::<_, S::Error>(&mut map, "seed", &self.seed)?;
+        insert_json_option::<_, S::Error>(&mut map, "top_p", &self.top_p)?;
+        insert_json_option::<_, S::Error>(&mut map, "top_k", &self.top_k)?;
+        insert_json_option::<_, S::Error>(&mut map, "frequency_penalty", &self.frequency_penalty)?;
+        insert_json_option::<_, S::Error>(&mut map, "presence_penalty", &self.presence_penalty)?;
+        insert_json_option::<_, S::Error>(
+            &mut map,
+            "repetition_penalty",
+            &self.repetition_penalty,
+        )?;
+        insert_json_option::<_, S::Error>(&mut map, "logit_bias", &self.logit_bias)?;
+        insert_json_option::<_, S::Error>(&mut map, "logprobs", &self.logprobs)?;
+        insert_json_option::<_, S::Error>(&mut map, "top_logprobs", &self.top_logprobs)?;
+        insert_json_option::<_, S::Error>(&mut map, "min_p", &self.min_p)?;
+        insert_json_option::<_, S::Error>(&mut map, "top_a", &self.top_a)?;
+        insert_json_option::<_, S::Error>(&mut map, "transforms", &self.transforms)?;
+        insert_json_option::<_, S::Error>(&mut map, "models", &self.models)?;
+        insert_json_option::<_, S::Error>(&mut map, "route", &self.route)?;
+        insert_json_option::<_, S::Error>(&mut map, "user", &self.user)?;
+        insert_json_option::<_, S::Error>(&mut map, "session_id", &self.session_id)?;
+        insert_json_option::<_, S::Error>(&mut map, "cache_control", &self.cache_control)?;
+        insert_json_option::<_, S::Error>(&mut map, "trace", &self.trace)?;
+        insert_json_option::<_, S::Error>(&mut map, "provider", &self.provider)?;
+        insert_json_option::<_, S::Error>(&mut map, "metadata", &self.metadata)?;
+        insert_json_option::<_, S::Error>(&mut map, "plugins", &self.plugins)?;
+        insert_json_option::<_, S::Error>(&mut map, "modalities", &self.modalities)?;
+        insert_json_option::<_, S::Error>(&mut map, "image_config", &self.image_config)?;
+        insert_json_option::<_, S::Error>(&mut map, "response_format", &self.response_format)?;
+        insert_json_option::<_, S::Error>(&mut map, "reasoning", &self.reasoning)?;
+        insert_json_option::<_, S::Error>(&mut map, "include_reasoning", &self.include_reasoning)?;
+        insert_json_option::<_, S::Error>(&mut map, "stop", &self.stop)?;
+        insert_json_option::<_, S::Error>(&mut map, "stream_options", &self.stream_options)?;
+        insert_json_option::<_, S::Error>(&mut map, "debug", &self.debug)?;
+
+        let function_tools = self.tools.as_deref().unwrap_or_default();
+        let server_tools = self.server_tools.as_deref().unwrap_or_default();
+        if !function_tools.is_empty() || !server_tools.is_empty() {
+            let mut tools = Vec::with_capacity(function_tools.len() + server_tools.len());
+            for tool in function_tools {
+                tools.push(serde_json::to_value(tool).map_err(serde::ser::Error::custom)?);
+            }
+            for tool in server_tools {
+                tools.push(serde_json::to_value(tool).map_err(serde::ser::Error::custom)?);
+            }
+            map.insert("tools".to_string(), Value::Array(tools));
+        }
+
+        insert_json_option::<_, S::Error>(&mut map, "tool_choice", &self.tool_choice)?;
+        insert_json_option::<_, S::Error>(
+            &mut map,
+            "parallel_tool_calls",
+            &self.parallel_tool_calls,
+        )?;
+
+        Value::Object(map).serialize(serializer)
+    }
 }
 
 impl ChatCompletionRequestBuilder {
@@ -637,6 +747,7 @@ impl ChatCompletionRequestBuilder {
     strip_option_vec_setter!(plugins, Plugin);
     strip_option_vec_setter!(modalities, Modality);
     strip_option_vec_setter!(tools, crate::types::Tool);
+    strip_option_vec_setter!(server_tools, crate::types::ServerTool);
 
     /// Enable reasoning with default settings (medium effort)
     pub fn enable_reasoning(&mut self) -> &mut Self {
@@ -676,6 +787,16 @@ impl ChatCompletionRequestBuilder {
         self
     }
 
+    /// Add a single OpenRouter server tool to the request.
+    pub fn server_tool(&mut self, tool: crate::types::ServerTool) -> &mut Self {
+        if let Some(Some(ref mut existing_tools)) = self.server_tools {
+            existing_tools.push(tool);
+        } else {
+            self.server_tools = Some(Some(vec![tool]));
+        }
+        self
+    }
+
     /// Set tool choice to auto (model chooses whether to use tools)
     pub fn tool_choice_auto(&mut self) -> &mut Self {
         self.tool_choice = Some(Some(crate::types::ToolChoice::auto()));
@@ -697,6 +818,12 @@ impl ChatCompletionRequestBuilder {
     /// Force the model to use a specific tool
     pub fn force_tool(&mut self, tool_name: &str) -> &mut Self {
         self.tool_choice = Some(Some(crate::types::ToolChoice::force_tool(tool_name)));
+        self
+    }
+
+    /// Force the model to use a specific OpenRouter server tool.
+    pub fn force_server_tool(&mut self, tool_type: impl Into<String>) -> &mut Self {
+        self.tool_choice = Some(Some(crate::types::ToolChoice::force_server_tool(tool_type)));
         self
     }
 
@@ -831,6 +958,11 @@ impl ChatCompletionRequest {
     /// Get the tools defined in this request
     pub fn tools(&self) -> Option<&[crate::types::Tool]> {
         self.tools.as_deref()
+    }
+
+    /// Get the OpenRouter server tools defined in this request.
+    pub fn server_tools(&self) -> Option<&[crate::types::ServerTool]> {
+        self.server_tools.as_deref()
     }
 
     /// Get the tool choice setting

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use futures_util::{StreamExt, stream::BoxStream};
 use reqwest::Client as HttpClient;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use serde_json::Value;
 
 use crate::{
@@ -470,7 +470,7 @@ impl From<Vec<String>> for StopSequence {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Builder)]
+#[derive(Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
 pub struct ChatCompletionRequest {
@@ -480,156 +480,260 @@ pub struct ChatCompletionRequest {
     messages: Vec<Message>,
 
     #[builder(setter(skip), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip)]
     experimental_metadata: Option<OpenRouterExperimentalMetadata>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_completion_tokens: Option<u32>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     seed: Option<u32>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_p: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_k: Option<u32>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     frequency_penalty: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     presence_penalty: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     repetition_penalty: Option<f64>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     logit_bias: Option<HashMap<String, f64>>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     logprobs: Option<bool>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_logprobs: Option<u32>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_p: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_a: Option<f64>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     transforms: Option<Vec<String>>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     models: Option<Vec<String>>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     route: Option<String>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     user: Option<String>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     cache_control: Option<CacheControl>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     trace: Option<TraceOptions>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<ProviderPreferences>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<HashMap<String, String>>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     plugins: Option<Vec<Plugin>>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     modalities: Option<Vec<Modality>>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     image_config: Option<HashMap<String, Value>>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<ResponseFormat>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<ReasoningConfig>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_reasoning: Option<bool>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     stop: Option<StopSequence>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     stream_options: Option<StreamOptions>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     debug: Option<DebugOptions>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<crate::types::Tool>>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip, default)]
     server_tools: Option<Vec<crate::types::ServerTool>>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::types::ToolChoice>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     parallel_tool_calls: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionRequestWire {
+    model: String,
+    messages: Vec<Message>,
+    stream: Option<bool>,
+    #[serde(skip)]
+    experimental_metadata: Option<OpenRouterExperimentalMetadata>,
+    max_tokens: Option<u32>,
+    max_completion_tokens: Option<u32>,
+    temperature: Option<f64>,
+    seed: Option<u32>,
+    top_p: Option<f64>,
+    top_k: Option<u32>,
+    frequency_penalty: Option<f64>,
+    presence_penalty: Option<f64>,
+    repetition_penalty: Option<f64>,
+    logit_bias: Option<HashMap<String, f64>>,
+    logprobs: Option<bool>,
+    top_logprobs: Option<u32>,
+    min_p: Option<f64>,
+    top_a: Option<f64>,
+    transforms: Option<Vec<String>>,
+    models: Option<Vec<String>>,
+    route: Option<String>,
+    user: Option<String>,
+    session_id: Option<String>,
+    cache_control: Option<CacheControl>,
+    trace: Option<TraceOptions>,
+    provider: Option<ProviderPreferences>,
+    metadata: Option<HashMap<String, String>>,
+    plugins: Option<Vec<Plugin>>,
+    modalities: Option<Vec<Modality>>,
+    image_config: Option<HashMap<String, Value>>,
+    response_format: Option<ResponseFormat>,
+    reasoning: Option<ReasoningConfig>,
+    include_reasoning: Option<bool>,
+    stop: Option<StopSequence>,
+    stream_options: Option<StreamOptions>,
+    debug: Option<DebugOptions>,
+    tools: Option<Vec<Value>>,
+    tool_choice: Option<crate::types::ToolChoice>,
+    parallel_tool_calls: Option<bool>,
+}
+
+type SplitChatTools = (
+    Option<Vec<crate::types::Tool>>,
+    Option<Vec<crate::types::ServerTool>>,
+);
+
+impl<'de> Deserialize<'de> for ChatCompletionRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ChatCompletionRequestWire::deserialize(deserializer)?;
+        let (tools, server_tools) = split_chat_request_tools(wire.tools)
+            .map_err(|error| de::Error::custom(format!("invalid chat tools entry: {error}")))?;
+
+        Ok(Self {
+            model: wire.model,
+            messages: wire.messages,
+            stream: wire.stream,
+            experimental_metadata: wire.experimental_metadata,
+            max_tokens: wire.max_tokens,
+            max_completion_tokens: wire.max_completion_tokens,
+            temperature: wire.temperature,
+            seed: wire.seed,
+            top_p: wire.top_p,
+            top_k: wire.top_k,
+            frequency_penalty: wire.frequency_penalty,
+            presence_penalty: wire.presence_penalty,
+            repetition_penalty: wire.repetition_penalty,
+            logit_bias: wire.logit_bias,
+            logprobs: wire.logprobs,
+            top_logprobs: wire.top_logprobs,
+            min_p: wire.min_p,
+            top_a: wire.top_a,
+            transforms: wire.transforms,
+            models: wire.models,
+            route: wire.route,
+            user: wire.user,
+            session_id: wire.session_id,
+            cache_control: wire.cache_control,
+            trace: wire.trace,
+            provider: wire.provider,
+            metadata: wire.metadata,
+            plugins: wire.plugins,
+            modalities: wire.modalities,
+            image_config: wire.image_config,
+            response_format: wire.response_format,
+            reasoning: wire.reasoning,
+            include_reasoning: wire.include_reasoning,
+            stop: wire.stop,
+            stream_options: wire.stream_options,
+            debug: wire.debug,
+            tools,
+            server_tools,
+            tool_choice: wire.tool_choice,
+            parallel_tool_calls: wire.parallel_tool_calls,
+        })
+    }
+}
+
+fn split_chat_request_tools(
+    tools: Option<Vec<Value>>,
+) -> Result<SplitChatTools, serde_json::Error> {
+    let Some(values) = tools else {
+        return Ok((None, None));
+    };
+    let was_empty = values.is_empty();
+    let mut function_tools = Vec::new();
+    let mut server_tools = Vec::new();
+
+    for value in values {
+        let is_function_tool = value.get("function").is_some()
+            || value
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|tool_type| tool_type == "function");
+        if is_function_tool {
+            function_tools.push(serde_json::from_value(value)?);
+        } else if crate::types::ServerTool::is_server_tool_value(&value) {
+            server_tools.push(serde_json::from_value(value)?);
+        } else {
+            function_tools.push(serde_json::from_value(value)?);
+        }
+    }
+
+    let tools = if function_tools.is_empty() && !was_empty {
+        None
+    } else {
+        Some(function_tools)
+    };
+    let server_tools = if server_tools.is_empty() {
+        None
+    } else {
+        Some(server_tools)
+    };
+
+    Ok((tools, server_tools))
 }
 
 fn insert_json_field<T, E>(
@@ -965,6 +1069,12 @@ impl ChatCompletionRequest {
         self.server_tools.as_deref()
     }
 
+    pub(crate) fn requires_openrouter_files_tool_header(&self) -> bool {
+        self.server_tools
+            .as_deref()
+            .is_some_and(|tools| tools.iter().any(crate::types::ServerTool::is_files_tool))
+    }
+
     /// Get the tool choice setting
     pub fn tool_choice(&self) -> Option<&crate::types::ToolChoice> {
         self.tool_choice.as_ref()
@@ -1039,7 +1149,7 @@ pub(crate) async fn send_chat_completion_with_client(
     // Ensure that the request is not streaming to get a single response
     let request = request.stream(false);
 
-    let response = transport_request::with_experimental_metadata_header(
+    let request_builder = transport_request::with_experimental_metadata_header(
         transport_request::with_client_request_headers(
             transport_request::post(http_client, &url),
             api_key,
@@ -1048,10 +1158,13 @@ pub(crate) async fn send_chat_completion_with_client(
             app_categories,
         )?,
         &request.experimental_metadata,
-    )
-    .json(&request)
-    .send()
-    .await?;
+    );
+    let request_builder = transport_request::with_openrouter_files_tool_header(
+        request_builder,
+        request.requires_openrouter_files_tool_header(),
+    );
+
+    let response = request_builder.json(&request).send().await?;
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "chat completion").await
@@ -1107,7 +1220,7 @@ pub(crate) async fn stream_chat_completion_with_client(
     // Ensure that the request is streaming to get a continuous response
     let request = request.stream(true);
 
-    let response = transport_request::with_experimental_metadata_header(
+    let request_builder = transport_request::with_experimental_metadata_header(
         transport_request::with_client_request_headers(
             transport_request::post(http_client, &url),
             api_key,
@@ -1116,10 +1229,13 @@ pub(crate) async fn stream_chat_completion_with_client(
             app_categories,
         )?,
         &request.experimental_metadata,
-    )
-    .json(&request)
-    .send()
-    .await?;
+    );
+    let request_builder = transport_request::with_openrouter_files_tool_header(
+        request_builder,
+        request.requires_openrouter_files_tool_header(),
+    );
+
+    let response = request_builder.json(&request).send().await?;
 
     if response.status().is_success() {
         let lines = parse_sse_frames(response_lines(response))

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -716,7 +716,7 @@ impl Serialize for ChatCompletionRequest {
 
         let function_tools = self.tools.as_deref().unwrap_or_default();
         let server_tools = self.server_tools.as_deref().unwrap_or_default();
-        if !function_tools.is_empty() || !server_tools.is_empty() {
+        if self.tools.is_some() || self.server_tools.is_some() {
             let mut tools = Vec::with_capacity(function_tools.len() + server_tools.len());
             for tool in function_tools {
                 tools.push(serde_json::to_value(tool).map_err(serde::ser::Error::custom)?);

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -460,7 +460,7 @@ impl AnthropicOutputConfig {
 }
 
 /// Request body for `POST /messages`.
-#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[derive(Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
 pub struct AnthropicMessagesRequest {
@@ -507,6 +507,10 @@ pub struct AnthropicMessagesRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<AnthropicTool>>,
 
+    #[builder(setter(custom), default)]
+    #[serde(skip, default)]
+    server_tools: Option<Vec<crate::types::ServerTool>>,
+
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<AnthropicToolChoice>,
@@ -552,9 +556,88 @@ pub struct AnthropicMessagesRequest {
     output_config: Option<AnthropicOutputConfig>,
 }
 
+fn insert_json_field<T, E>(
+    map: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: &T,
+) -> Result<(), E>
+where
+    T: Serialize,
+    E: serde::ser::Error,
+{
+    map.insert(
+        key.to_string(),
+        serde_json::to_value(value).map_err(E::custom)?,
+    );
+    Ok(())
+}
+
+fn insert_json_option<T, E>(
+    map: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: &Option<T>,
+) -> Result<(), E>
+where
+    T: Serialize,
+    E: serde::ser::Error,
+{
+    if let Some(value) = value {
+        insert_json_field::<T, E>(map, key, value)?;
+    }
+    Ok(())
+}
+
+impl Serialize for AnthropicMessagesRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serde_json::Map::new();
+
+        insert_json_field::<_, S::Error>(&mut map, "model", &self.model)?;
+        insert_json_field::<_, S::Error>(&mut map, "max_tokens", &self.max_tokens)?;
+        insert_json_field::<_, S::Error>(&mut map, "messages", &self.messages)?;
+        insert_json_option::<_, S::Error>(&mut map, "system", &self.system)?;
+        insert_json_option::<_, S::Error>(&mut map, "metadata", &self.metadata)?;
+        insert_json_option::<_, S::Error>(&mut map, "stop_sequences", &self.stop_sequences)?;
+        insert_json_option::<_, S::Error>(&mut map, "stream", &self.stream)?;
+        insert_json_option::<_, S::Error>(&mut map, "temperature", &self.temperature)?;
+        insert_json_option::<_, S::Error>(&mut map, "top_p", &self.top_p)?;
+        insert_json_option::<_, S::Error>(&mut map, "top_k", &self.top_k)?;
+
+        let anthropic_tools = self.tools.as_deref().unwrap_or_default();
+        let server_tools = self.server_tools.as_deref().unwrap_or_default();
+        if !anthropic_tools.is_empty() || !server_tools.is_empty() {
+            let mut tools = Vec::with_capacity(anthropic_tools.len() + server_tools.len());
+            for tool in anthropic_tools {
+                tools.push(serde_json::to_value(tool).map_err(serde::ser::Error::custom)?);
+            }
+            for tool in server_tools {
+                tools.push(serde_json::to_value(tool).map_err(serde::ser::Error::custom)?);
+            }
+            map.insert("tools".to_string(), Value::Array(tools));
+        }
+
+        insert_json_option::<_, S::Error>(&mut map, "tool_choice", &self.tool_choice)?;
+        insert_json_option::<_, S::Error>(&mut map, "thinking", &self.thinking)?;
+        insert_json_option::<_, S::Error>(&mut map, "service_tier", &self.service_tier)?;
+        insert_json_option::<_, S::Error>(&mut map, "provider", &self.provider)?;
+        insert_json_option::<_, S::Error>(&mut map, "plugins", &self.plugins)?;
+        insert_json_option::<_, S::Error>(&mut map, "route", &self.route)?;
+        insert_json_option::<_, S::Error>(&mut map, "user", &self.user)?;
+        insert_json_option::<_, S::Error>(&mut map, "session_id", &self.session_id)?;
+        insert_json_option::<_, S::Error>(&mut map, "trace", &self.trace)?;
+        insert_json_option::<_, S::Error>(&mut map, "models", &self.models)?;
+        insert_json_option::<_, S::Error>(&mut map, "output_config", &self.output_config)?;
+
+        Value::Object(map).serialize(serializer)
+    }
+}
+
 impl AnthropicMessagesRequestBuilder {
     strip_option_vec_setter!(stop_sequences, String);
     strip_option_vec_setter!(tools, AnthropicTool);
+    strip_option_vec_setter!(server_tools, crate::types::ServerTool);
     strip_option_vec_setter!(plugins, Plugin);
     strip_option_vec_setter!(models, String);
 
@@ -563,6 +646,15 @@ impl AnthropicMessagesRequestBuilder {
             existing_tools.push(tool);
         } else {
             self.tools = Some(Some(vec![tool]));
+        }
+        self
+    }
+
+    pub fn server_tool(&mut self, tool: crate::types::ServerTool) -> &mut Self {
+        if let Some(Some(ref mut existing_tools)) = self.server_tools {
+            existing_tools.push(tool);
+        } else {
+            self.server_tools = Some(Some(vec![tool]));
         }
         self
     }
@@ -602,6 +694,10 @@ impl AnthropicMessagesRequest {
 
     pub fn tools(&self) -> Option<&[AnthropicTool]> {
         self.tools.as_deref()
+    }
+
+    pub fn server_tools(&self) -> Option<&[crate::types::ServerTool]> {
+        self.server_tools.as_deref()
     }
 
     fn stream(&self, stream: bool) -> Self {

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use derive_builder::Builder;
 use futures_util::{StreamExt, stream::BoxStream};
 use reqwest::Client as HttpClient;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use serde_json::{Value, json};
 
 use crate::{
@@ -460,7 +460,7 @@ impl AnthropicOutputConfig {
 }
 
 /// Request body for `POST /messages`.
-#[derive(Deserialize, Debug, Clone, Builder)]
+#[derive(Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
 pub struct AnthropicMessagesRequest {
@@ -472,88 +472,173 @@ pub struct AnthropicMessagesRequest {
     messages: Vec<AnthropicMessage>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     system: Option<AnthropicSystemPrompt>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<AnthropicMessagesMetadata>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     stop_sequences: Option<Vec<String>>,
 
     #[builder(setter(skip), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip)]
     experimental_metadata: Option<OpenRouterExperimentalMetadata>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_p: Option<f64>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_k: Option<u32>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<AnthropicTool>>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip, default)]
     server_tools: Option<Vec<crate::types::ServerTool>>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<AnthropicToolChoice>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinking>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_tier: Option<String>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<ProviderPreferences>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     plugins: Option<Vec<Plugin>>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     route: Option<String>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     user: Option<String>,
 
     #[builder(setter(into, strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     trace: Option<TraceOptions>,
 
     #[builder(setter(custom), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     models: Option<Vec<String>>,
 
     #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     output_config: Option<AnthropicOutputConfig>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicMessagesRequestWire {
+    model: String,
+    max_tokens: u32,
+    messages: Vec<AnthropicMessage>,
+    system: Option<AnthropicSystemPrompt>,
+    metadata: Option<AnthropicMessagesMetadata>,
+    stop_sequences: Option<Vec<String>>,
+    stream: Option<bool>,
+    #[serde(skip)]
+    experimental_metadata: Option<OpenRouterExperimentalMetadata>,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<u32>,
+    tools: Option<Vec<Value>>,
+    tool_choice: Option<AnthropicToolChoice>,
+    thinking: Option<AnthropicThinking>,
+    service_tier: Option<String>,
+    provider: Option<ProviderPreferences>,
+    plugins: Option<Vec<Plugin>>,
+    route: Option<String>,
+    user: Option<String>,
+    session_id: Option<String>,
+    trace: Option<TraceOptions>,
+    models: Option<Vec<String>>,
+    output_config: Option<AnthropicOutputConfig>,
+}
+
+type SplitAnthropicMessageTools = (
+    Option<Vec<AnthropicTool>>,
+    Option<Vec<crate::types::ServerTool>>,
+);
+
+impl<'de> Deserialize<'de> for AnthropicMessagesRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = AnthropicMessagesRequestWire::deserialize(deserializer)?;
+        let (tools, server_tools) = split_anthropic_message_tools(wire.tools).map_err(|error| {
+            de::Error::custom(format!("invalid Anthropic messages tools entry: {error}"))
+        })?;
+
+        Ok(Self {
+            model: wire.model,
+            max_tokens: wire.max_tokens,
+            messages: wire.messages,
+            system: wire.system,
+            metadata: wire.metadata,
+            stop_sequences: wire.stop_sequences,
+            stream: wire.stream,
+            experimental_metadata: wire.experimental_metadata,
+            temperature: wire.temperature,
+            top_p: wire.top_p,
+            top_k: wire.top_k,
+            tools,
+            server_tools,
+            tool_choice: wire.tool_choice,
+            thinking: wire.thinking,
+            service_tier: wire.service_tier,
+            provider: wire.provider,
+            plugins: wire.plugins,
+            route: wire.route,
+            user: wire.user,
+            session_id: wire.session_id,
+            trace: wire.trace,
+            models: wire.models,
+            output_config: wire.output_config,
+        })
+    }
+}
+
+fn split_anthropic_message_tools(
+    tools: Option<Vec<Value>>,
+) -> Result<SplitAnthropicMessageTools, serde_json::Error> {
+    let Some(values) = tools else {
+        return Ok((None, None));
+    };
+    let was_empty = values.is_empty();
+    let mut anthropic_tools = Vec::new();
+    let mut server_tools = Vec::new();
+
+    for value in values {
+        if value.get("name").is_some() {
+            anthropic_tools.push(serde_json::from_value(value)?);
+        } else if crate::types::ServerTool::is_server_tool_value(&value) {
+            server_tools.push(serde_json::from_value(value)?);
+        } else {
+            anthropic_tools.push(serde_json::from_value(value)?);
+        }
+    }
+
+    let tools = if anthropic_tools.is_empty() && !was_empty {
+        None
+    } else {
+        Some(anthropic_tools)
+    };
+    let server_tools = if server_tools.is_empty() {
+        None
+    } else {
+        Some(server_tools)
+    };
+
+    Ok((tools, server_tools))
 }
 
 fn insert_json_field<T, E>(
@@ -698,6 +783,12 @@ impl AnthropicMessagesRequest {
 
     pub fn server_tools(&self) -> Option<&[crate::types::ServerTool]> {
         self.server_tools.as_deref()
+    }
+
+    pub(crate) fn requires_openrouter_files_tool_header(&self) -> bool {
+        self.server_tools
+            .as_deref()
+            .is_some_and(|tools| tools.iter().any(crate::types::ServerTool::is_files_tool))
     }
 
     fn stream(&self, stream: bool) -> Self {
@@ -845,7 +936,7 @@ pub(crate) async fn create_message_with_client(
     let url = format!("{base_url}/messages");
     let request = request.stream(false);
 
-    let response = transport_request::with_experimental_metadata_header(
+    let request_builder = transport_request::with_experimental_metadata_header(
         transport_request::with_client_request_headers(
             transport_request::post(http_client, &url),
             api_key,
@@ -854,10 +945,13 @@ pub(crate) async fn create_message_with_client(
             app_categories,
         )?,
         &request.experimental_metadata,
-    )
-    .json(&request)
-    .send()
-    .await?;
+    );
+    let request_builder = transport_request::with_openrouter_files_tool_header(
+        request_builder,
+        request.requires_openrouter_files_tool_header(),
+    );
+
+    let response = request_builder.json(&request).send().await?;
 
     if response.status().is_success() {
         let response_data: AnthropicMessagesResponse =
@@ -905,7 +999,7 @@ pub(crate) async fn stream_messages_with_client(
     let url = format!("{base_url}/messages");
     let request = request.stream(true);
 
-    let response = transport_request::with_experimental_metadata_header(
+    let request_builder = transport_request::with_experimental_metadata_header(
         transport_request::with_client_request_headers(
             transport_request::post(http_client, &url),
             api_key,
@@ -914,10 +1008,13 @@ pub(crate) async fn stream_messages_with_client(
             app_categories,
         )?,
         &request.experimental_metadata,
-    )
-    .json(&request)
-    .send()
-    .await?;
+    );
+    let request_builder = transport_request::with_openrouter_files_tool_header(
+        request_builder,
+        request.requires_openrouter_files_tool_header(),
+    );
+
+    let response = request_builder.json(&request).send().await?;
 
     if response.status().is_success() {
         let stream = parse_sse_frames(response_lines(response))

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -607,7 +607,7 @@ impl Serialize for AnthropicMessagesRequest {
 
         let anthropic_tools = self.tools.as_deref().unwrap_or_default();
         let server_tools = self.server_tools.as_deref().unwrap_or_default();
-        if !anthropic_tools.is_empty() || !server_tools.is_empty() {
+        if self.tools.is_some() || self.server_tools.is_some() {
             let mut tools = Vec::with_capacity(anthropic_tools.len() + server_tools.len());
             for tool in anthropic_tools {
                 tools.push(serde_json::to_value(tool).map_err(serde::ser::Error::custom)?);

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -4,7 +4,7 @@ use derive_builder::Builder;
 use futures_util::{StreamExt, stream::BoxStream};
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::{
     api::chat::{CacheControl, DebugOptions, Plugin, TraceOptions},
@@ -187,6 +187,33 @@ impl ResponsesRequestBuilder {
     strip_option_vec_setter!(modalities, String);
     strip_option_vec_setter!(include, String);
     strip_option_vec_setter!(plugins, Plugin);
+
+    /// Add a single OpenRouter server tool to the request.
+    pub fn server_tool(&mut self, tool: crate::types::ServerTool) -> &mut Self {
+        if let Some(Some(ref mut existing_tools)) = self.tools {
+            existing_tools.push(Value::from(tool));
+        } else {
+            self.tools = Some(Some(vec![Value::from(tool)]));
+        }
+        self
+    }
+
+    /// Add multiple OpenRouter server tools to the request.
+    pub fn server_tools<T>(&mut self, tools: T) -> &mut Self
+    where
+        T: IntoIterator<Item = crate::types::ServerTool>,
+    {
+        for tool in tools {
+            self.server_tool(tool);
+        }
+        self
+    }
+
+    /// Force the model to call a specific OpenRouter server tool.
+    pub fn force_server_tool(&mut self, tool_type: impl Into<String>) -> &mut Self {
+        self.tool_choice = Some(Some(json!({ "type": tool_type.into() })));
+        self
+    }
 }
 
 impl ResponsesRequest {

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -251,6 +251,14 @@ impl ResponsesRequest {
     pub fn experimental_metadata(&self) -> Option<OpenRouterExperimentalMetadata> {
         self.experimental_metadata
     }
+
+    pub(crate) fn requires_openrouter_files_tool_header(&self) -> bool {
+        self.tools.as_deref().is_some_and(|tools| {
+            tools
+                .iter()
+                .any(crate::types::ServerTool::is_files_tool_value)
+        })
+    }
 }
 
 /// Non-streaming response payload returned by `POST /responses`.
@@ -317,7 +325,7 @@ pub(crate) async fn create_response_with_client(
     let url = format!("{base_url}/responses");
     let request = request.stream(false);
 
-    let response = transport_request::with_experimental_metadata_header(
+    let request_builder = transport_request::with_experimental_metadata_header(
         transport_request::with_client_request_headers(
             transport_request::post(http_client, &url),
             api_key,
@@ -326,10 +334,13 @@ pub(crate) async fn create_response_with_client(
             app_categories,
         )?,
         &request.experimental_metadata,
-    )
-    .json(&request)
-    .send()
-    .await?;
+    );
+    let request_builder = transport_request::with_openrouter_files_tool_header(
+        request_builder,
+        request.requires_openrouter_files_tool_header(),
+    );
+
+    let response = request_builder.json(&request).send().await?;
 
     if response.status().is_success() {
         let response_data: ResponsesResponse =
@@ -375,7 +386,7 @@ pub(crate) async fn stream_response_with_client(
     let url = format!("{base_url}/responses");
     let request = request.stream(true);
 
-    let response = transport_request::with_experimental_metadata_header(
+    let request_builder = transport_request::with_experimental_metadata_header(
         transport_request::with_client_request_headers(
             transport_request::post(http_client, &url),
             api_key,
@@ -384,10 +395,13 @@ pub(crate) async fn stream_response_with_client(
             app_categories,
         )?,
         &request.experimental_metadata,
-    )
-    .json(&request)
-    .send()
-    .await?;
+    );
+    let request_builder = transport_request::with_openrouter_files_tool_header(
+        request_builder,
+        request.requires_openrouter_files_tool_header(),
+    );
+
+    let response = request_builder.json(&request).send().await?;
 
     if response.status().is_success() {
         let lines = parse_sse_frames(response_lines(response))

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -211,21 +211,24 @@ impl ResponsesRequestBuilder {
 
     /// Force the model to call a specific OpenRouter server tool.
     pub fn force_server_tool(&mut self, tool_type: impl Into<String>) -> &mut Self {
-        self.tool_choice = Some(Some(json!({
-            "type": responses_server_tool_choice_type(tool_type.into())
-        })));
+        self.tool_choice = Some(Some(responses_server_tool_choice(tool_type.into())));
         self
     }
 }
 
-fn responses_server_tool_choice_type(tool_type: String) -> String {
+fn responses_server_tool_choice(tool_type: String) -> Value {
     match tool_type.as_str() {
         "openrouter:web_search" | "web_search" | "web_search_2025_08_26" | "web_search_preview" => {
-            "web_search_preview".to_string()
+            json!({"type": "web_search_preview"})
         }
-        "openrouter:apply_patch" | "apply_patch" => "apply_patch".to_string(),
-        "openrouter:bash" | "openrouter:shell" | "shell" => "shell".to_string(),
-        _ => tool_type,
+        "web_search_preview_2025_03_11" => json!({"type": "web_search_preview_2025_03_11"}),
+        "openrouter:apply_patch" | "apply_patch" => json!({"type": "apply_patch"}),
+        "openrouter:bash" | "openrouter:shell" | "shell" => json!({"type": "shell"}),
+        _ => json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": tool_type}]
+        }),
     }
 }
 

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -218,12 +218,9 @@ impl ResponsesRequestBuilder {
 
 fn responses_server_tool_choice(tool_type: String) -> Value {
     match tool_type.as_str() {
-        "openrouter:web_search" | "web_search" | "web_search_2025_08_26" | "web_search_preview" => {
-            json!({"type": "web_search_preview"})
+        "web_search_preview" | "web_search_preview_2025_03_11" | "apply_patch" | "shell" => {
+            json!({"type": tool_type})
         }
-        "web_search_preview_2025_03_11" => json!({"type": "web_search_preview_2025_03_11"}),
-        "openrouter:apply_patch" | "apply_patch" => json!({"type": "apply_patch"}),
-        "openrouter:bash" | "openrouter:shell" | "shell" => json!({"type": "shell"}),
         _ => json!({
             "type": "allowed_tools",
             "mode": "required",

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -211,8 +211,21 @@ impl ResponsesRequestBuilder {
 
     /// Force the model to call a specific OpenRouter server tool.
     pub fn force_server_tool(&mut self, tool_type: impl Into<String>) -> &mut Self {
-        self.tool_choice = Some(Some(json!({ "type": tool_type.into() })));
+        self.tool_choice = Some(Some(json!({
+            "type": responses_server_tool_choice_type(tool_type.into())
+        })));
         self
+    }
+}
+
+fn responses_server_tool_choice_type(tool_type: String) -> String {
+    match tool_type.as_str() {
+        "openrouter:web_search" | "web_search" | "web_search_2025_08_26" | "web_search_preview" => {
+            "web_search_preview".to_string()
+        }
+        "openrouter:apply_patch" | "apply_patch" => "apply_patch".to_string(),
+        "openrouter:bash" | "openrouter:shell" | "shell" => "shell".to_string(),
+        _ => tool_type,
     }
 }
 

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -210,6 +210,13 @@ pub struct WorkspaceMember {
     pub created_at: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ListWorkspaceMembersResponse {
+    pub data: Vec<WorkspaceMember>,
+    pub total_count: f64,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
@@ -599,6 +606,46 @@ pub(crate) async fn delete_workspace_budget_with_client(
         let payload: DeleteWorkspaceBudgetResponse =
             transport_response::parse_json_response(response, "workspace budget deletion").await?;
         Ok(payload.deleted)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+pub async fn list_workspace_members(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListWorkspaceMembersResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_workspace_members_with_client(&http_client, base_url, management_key, id, pagination).await
+}
+
+pub(crate) async fn list_workspace_members_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListWorkspaceMembersResponse, OpenRouterError> {
+    let url = format!("{base_url}/workspaces/{}/members", encode(id));
+    let query = ListWorkspacesQuery {
+        offset: pagination.and_then(|p| p.offset),
+        limit: pagination.and_then(|p| p.limit),
+    };
+    let req = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &url),
+        management_key,
+    );
+    let response = if query.offset.is_none() && query.limit.is_none() {
+        req.send().await?
+    } else {
+        req.query(&query).send().await?
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "workspace member list").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/client.rs
+++ b/src/client.rs
@@ -2480,6 +2480,26 @@ impl OpenRouterClient {
         }
     }
 
+    /// List organization members assigned to a workspace (`GET /workspaces/{id}/members`).
+    pub async fn list_workspace_members(
+        &self,
+        id: &str,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<workspaces::ListWorkspaceMembersResponse, OpenRouterError> {
+        if let Some(management_key) = &self.management_key {
+            workspaces::list_workspace_members_with_client(
+                self.http_client(),
+                &self.base_url,
+                management_key,
+                id,
+                pagination,
+            )
+            .await
+        } else {
+            Err(OpenRouterError::KeyNotConfigured)
+        }
+    }
+
     /// Add multiple organization members to a workspace (`POST /workspaces/{id}/members/add`).
     pub async fn add_workspace_members(
         &self,
@@ -3490,6 +3510,15 @@ impl<'a> ManagementClient<'a> {
         interval: &str,
     ) -> Result<bool, OpenRouterError> {
         self.client.delete_workspace_budget(id, interval).await
+    }
+
+    /// List workspace members (`GET /workspaces/{id}/members`).
+    pub async fn list_workspace_members(
+        &self,
+        id: &str,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<workspaces::ListWorkspaceMembersResponse, OpenRouterError> {
+        self.client.list_workspace_members(id, pagination).await
     }
 
     /// Add workspace members (`POST /workspaces/{id}/members/add`).

--- a/src/transport/request.rs
+++ b/src/transport/request.rs
@@ -79,6 +79,17 @@ pub(crate) fn with_experimental_metadata_header(
     }
 }
 
+pub(crate) fn with_openrouter_files_tool_header(
+    req: RequestBuilder,
+    include_header: bool,
+) -> RequestBuilder {
+    if include_header {
+        req.header("X-OpenRouter-File-Ids", "openrouter")
+    } else {
+        req
+    }
+}
+
 fn serialize_app_categories(
     app_categories: &[String],
 ) -> Result<String, crate::error::OpenRouterError> {
@@ -126,7 +137,10 @@ mod tests {
 
     use crate::types::OpenRouterExperimentalMetadata;
 
-    use super::{post, with_client_request_headers, with_experimental_metadata_header};
+    use super::{
+        post, with_client_request_headers, with_experimental_metadata_header,
+        with_openrouter_files_tool_header,
+    };
 
     #[test]
     fn test_with_client_request_headers_sets_auth_and_metadata() {
@@ -213,6 +227,23 @@ mod tests {
                 .get("X-OpenRouter-Metadata")
                 .expect("experimental metadata header should exist"),
             "enabled"
+        );
+    }
+
+    #[test]
+    fn test_with_openrouter_files_tool_header_sets_required_value() {
+        let client = reqwest::Client::new();
+        let request =
+            with_openrouter_files_tool_header(post(&client, "http://example.com/test"), true)
+                .build()
+                .expect("request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("X-OpenRouter-File-Ids")
+                .expect("files header should exist"),
+            "openrouter"
         );
     }
 }

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -46,6 +46,8 @@
 //! let specific_choice = ToolChoice::force_tool("get_weather");
 //! ```
 
+use std::collections::HashMap;
+
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -86,6 +88,10 @@ pub struct Tool {
 
     /// Function definition
     pub function: FunctionDefinition,
+
+    /// Optional cache-control directive for provider-side prompt caching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<Value>,
 }
 
 impl Tool {
@@ -102,7 +108,9 @@ impl Tool {
                 name: name.to_string(),
                 description: description.to_string(),
                 parameters,
+                strict: None,
             },
+            cache_control: None,
         }
     }
 }
@@ -113,6 +121,8 @@ pub struct ToolBuilder {
     name: Option<String>,
     description: Option<String>,
     parameters: Option<Value>,
+    strict: Option<bool>,
+    cache_control: Option<Value>,
 }
 
 impl ToolBuilder {
@@ -127,6 +137,7 @@ impl ToolBuilder {
         self.name = Some(function.name);
         self.description = Some(function.description);
         self.parameters = Some(function.parameters);
+        self.strict = function.strict;
         self
     }
 
@@ -146,7 +157,9 @@ impl ToolBuilder {
                 name,
                 description: self.description.clone().unwrap_or_default(),
                 parameters: self.parameters.clone().unwrap_or(Value::Null),
+                strict: self.strict,
             },
+            cache_control: self.cache_control.clone(),
         })
     }
 }
@@ -170,6 +183,11 @@ pub struct FunctionDefinition {
     /// JSON Schema defining the function parameters
     #[builder(setter(custom))]
     pub parameters: Value,
+
+    /// Whether the model must strictly adhere to the parameter schema.
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
 }
 
 impl FunctionDefinition {
@@ -212,6 +230,18 @@ impl ToolBuilder {
         let value: Value = serde_json::from_str(json).map_err(OpenRouterError::Serialization)?;
         Ok(self.parameters(value))
     }
+
+    /// Set the function strict-schema flag.
+    pub fn strict(&mut self, strict: bool) -> &mut Self {
+        self.strict = Some(strict);
+        self
+    }
+
+    /// Set the top-level tool cache-control payload.
+    pub fn cache_control(&mut self, cache_control: impl Into<Value>) -> &mut Self {
+        self.cache_control = Some(cache_control.into());
+        self
+    }
 }
 
 impl FunctionDefinitionBuilder {
@@ -236,6 +266,114 @@ impl FunctionDefinitionBuilder {
         let value: Value = serde_json::from_str(json).map_err(OpenRouterError::Serialization)?;
         self.parameters = Some(value);
         Ok(self)
+    }
+}
+
+/// OpenRouter built-in server tool definition.
+///
+/// Server tools are OpenRouter-hosted capabilities such as web search,
+/// datetime lookup, files, bash, and model search. They share a common wire
+/// shape: a `type`, optional `parameters`, and optional tool-specific
+/// top-level fields.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ServerTool {
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Value>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl ServerTool {
+    pub fn new(tool_type: impl Into<String>) -> Self {
+        Self {
+            tool_type: tool_type.into(),
+            parameters: None,
+            extra: HashMap::new(),
+        }
+    }
+
+    pub fn with_parameters(tool_type: impl Into<String>, parameters: impl Into<Value>) -> Self {
+        Self::new(tool_type).parameters(parameters)
+    }
+
+    pub fn parameters(mut self, parameters: impl Into<Value>) -> Self {
+        self.parameters = Some(parameters.into());
+        self
+    }
+
+    pub fn parameters_from<T: Serialize>(mut self, params: &T) -> Result<Self, OpenRouterError> {
+        self.parameters =
+            Some(serde_json::to_value(params).map_err(OpenRouterError::Serialization)?);
+        Ok(self)
+    }
+
+    pub fn option(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.extra.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn web_search() -> Self {
+        Self::new("openrouter:web_search")
+    }
+
+    pub fn web_search_with_parameters(parameters: impl Into<Value>) -> Self {
+        Self::with_parameters("openrouter:web_search", parameters)
+    }
+
+    pub fn web_search_preview() -> Self {
+        Self::new("web_search_preview")
+    }
+
+    pub fn datetime() -> Self {
+        Self::new("openrouter:datetime")
+    }
+
+    pub fn datetime_with_timezone(timezone: impl Into<String>) -> Self {
+        Self::with_parameters(
+            "openrouter:datetime",
+            serde_json::json!({ "timezone": timezone.into() }),
+        )
+    }
+
+    pub fn files() -> Self {
+        Self::new("openrouter:files")
+    }
+
+    pub fn bash() -> Self {
+        Self::new("openrouter:bash")
+    }
+
+    pub fn web_fetch() -> Self {
+        Self::new("openrouter:web_fetch")
+    }
+
+    pub fn advisor() -> Self {
+        Self::new("openrouter:advisor")
+    }
+
+    pub fn subagent() -> Self {
+        Self::new("openrouter:subagent")
+    }
+
+    pub fn image_generation() -> Self {
+        Self::new("openrouter:image_generation")
+    }
+
+    pub fn search_models() -> Self {
+        Self::new("openrouter:experimental__search_models")
+    }
+
+    pub fn apply_patch() -> Self {
+        Self::new("openrouter:apply_patch")
+    }
+}
+
+impl From<ServerTool> for Value {
+    fn from(tool: ServerTool) -> Self {
+        serde_json::to_value(tool).expect("server tool serialization should not fail")
     }
 }
 
@@ -269,6 +407,8 @@ pub enum ToolChoice {
     String(String),
     /// Force a specific tool to be called
     Specific(SpecificToolChoice),
+    /// Force a specific OpenRouter server tool to be called
+    Server(ServerToolChoice),
 }
 
 impl ToolChoice {
@@ -296,6 +436,13 @@ impl ToolChoice {
             },
         })
     }
+
+    /// Force the model to call a specific OpenRouter server tool.
+    pub fn force_server_tool(tool_type: impl Into<String>) -> Self {
+        Self::Server(ServerToolChoice {
+            tool_type: tool_type.into(),
+        })
+    }
 }
 
 /// Specific tool choice for forcing a particular tool
@@ -312,6 +459,14 @@ pub struct SpecificToolChoice {
 #[non_exhaustive]
 pub struct SpecificToolFunction {
     pub name: String,
+}
+
+/// Specific server-tool choice for forcing an OpenRouter built-in tool.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ServerToolChoice {
+    #[serde(rename = "type")]
+    pub tool_type: String,
 }
 
 /// Helper function to create a tool with common parameter structure

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -369,6 +369,41 @@ impl ServerTool {
     pub fn apply_patch() -> Self {
         Self::new("openrouter:apply_patch")
     }
+
+    pub(crate) fn is_server_tool_type(tool_type: &str) -> bool {
+        tool_type.starts_with("openrouter:")
+            || matches!(
+                tool_type,
+                "web_search"
+                    | "web_search_2025_08_26"
+                    | "web_search_preview"
+                    | "web_search_preview_2025_03_11"
+                    | "apply_patch"
+                    | "shell"
+            )
+    }
+
+    pub(crate) fn is_files_tool_type(tool_type: &str) -> bool {
+        matches!(tool_type, "openrouter:files" | "files")
+    }
+
+    pub(crate) fn is_files_tool(&self) -> bool {
+        Self::is_files_tool_type(&self.tool_type)
+    }
+
+    pub(crate) fn is_server_tool_value(value: &Value) -> bool {
+        value
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(Self::is_server_tool_type)
+    }
+
+    pub(crate) fn is_files_tool_value(value: &Value) -> bool {
+        value
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(Self::is_files_tool_type)
+    }
 }
 
 impl From<ServerTool> for Value {

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -641,6 +641,155 @@ class OpenApiDriftReportTests(unittest.TestCase):
             ["flexible plugin payload"],
         )
 
+    def test_chat_server_tool_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "function": {
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                        },
+                                        "required": ["name"],
+                                        "type": "object",
+                                    },
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "function"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "function": {
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "strict": {"type": "boolean"},
+                                        },
+                                        "required": ["name"],
+                                        "type": "object",
+                                    },
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "function"],
+                                "type": "object",
+                            },
+                            {
+                                "properties": {
+                                    "parameters": {
+                                        "properties": {
+                                            "max_results": {"type": "integer"},
+                                        },
+                                        "type": "object",
+                                    },
+                                    "type": {
+                                        "enum": ["openrouter:web_search"],
+                                        "type": "string",
+                                    },
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            },
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Chat flexible tool payload"],
+        )
+
+    def test_chat_tool_container_type_change_remains_actionable(self):
+        baseline = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "tools": {
+                    "properties": {
+                        "type": {"enum": ["function"], "type": "string"},
+                    },
+                    "type": "object",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Chat flexible tool payload"],
+        )
+
     def test_responses_value_tool_and_output_drift_is_classified_as_already_supported(self):
         baseline = build_spec(
             method="post",
@@ -755,6 +904,81 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertEqual(
             report["changed"][0]["repo_impact"]["schema_rules"],
             ["Responses flexible output payload", "Responses flexible tool payload"],
+        )
+
+    def test_preset_responses_tool_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            method="post",
+            path="/presets/{slug}/responses",
+            operation_id="createResponsesPreset",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/presets/{slug}/responses",
+            operation_id="createResponsesPreset",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "name"],
+                                "type": "object",
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "enum": ["openrouter:datetime"],
+                                        "type": "string",
+                                    },
+                                },
+                                "required": ["type"],
+                                "type": "object",
+                            },
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 0)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["Responses flexible tool payload"],
         )
 
     def test_responses_flexible_container_type_changes_remain_actionable(self):

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -732,8 +732,83 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "already_supported")
         self.assertEqual(
             report["changed"][0]["repo_impact"]["schema_rules"],
-            ["Chat flexible tool payload"],
+            ["Chat server-tool payload", "Chat supported function-tool fields"],
         )
+
+    def test_chat_function_tool_shape_change_remains_actionable(self):
+        baseline = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "function": {
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                        },
+                                        "required": ["name"],
+                                        "type": "object",
+                                    },
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "function"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+        candidate = build_spec(
+            method="post",
+            path="/chat/completions",
+            operation_id="sendChatCompletionRequest",
+            request_properties={
+                "tools": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "function": {
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "new_required": {"type": "string"},
+                                        },
+                                        "required": ["name", "new_required"],
+                                        "type": "object",
+                                    },
+                                    "type": {"enum": ["function"], "type": "string"},
+                                },
+                                "required": ["type", "function"],
+                                "type": "object",
+                            }
+                        ]
+                    },
+                    "type": "array",
+                }
+            },
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertTrue(report["has_drift"])
+        self.assertTrue(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
+        self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
+        self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
+        self.assertEqual(report["changed"][0]["repo_impact"]["schema_rules"], [])
 
     def test_chat_tool_container_type_change_remains_actionable(self):
         baseline = build_spec(
@@ -785,10 +860,7 @@ class OpenApiDriftReportTests(unittest.TestCase):
         self.assertEqual(report["repo_summary"]["already_supported_changed"], 0)
         self.assertEqual(report["repo_summary"]["actionable_changed"], 1)
         self.assertEqual(report["changed"][0]["repo_impact"]["category"], "actionable")
-        self.assertEqual(
-            report["changed"][0]["repo_impact"]["schema_rules"],
-            ["Chat flexible tool payload"],
-        )
+        self.assertEqual(report["changed"][0]["repo_impact"]["schema_rules"], [])
 
     def test_responses_value_tool_and_output_drift_is_classified_as_already_supported(self):
         baseline = build_spec(

--- a/tests/unit/chat_api.rs
+++ b/tests/unit/chat_api.rs
@@ -11,7 +11,7 @@ use openrouter_rs::{
     api::chat::{
         ChatCompletionRequestBuilder, Message, send_chat_completion, stream_chat_completion,
     },
-    types::{OpenRouterExperimentalMetadata, Role, completion::CompletionsResponse},
+    types::{OpenRouterExperimentalMetadata, Role, ServerTool, completion::CompletionsResponse},
 };
 
 struct CapturedRequest {
@@ -185,6 +185,42 @@ async fn test_send_chat_completion_sets_stream_false_and_headers() {
     assert_eq!(request_json["stream"], false);
     assert_eq!(request_json["model"], "openai/gpt-4o-mini");
     assert!(request_json.get("experimental_metadata").is_none());
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_send_chat_completion_sets_files_tool_header() {
+    let (base_url, rx, server) = spawn_server(
+        r#"{"id":"gen-files","choices":[{"message":{"role":"assistant","content":"ok"}}],"created":1700000000,"model":"test-model","object":"chat.completion"}"#,
+        "application/json",
+    );
+
+    let request = ChatCompletionRequestBuilder::default()
+        .model("openai/gpt-4o-mini")
+        .messages(vec![Message::new(Role::User, "inspect uploaded files")])
+        .server_tool(ServerTool::files())
+        .build()
+        .expect("chat request should build");
+
+    send_chat_completion(&base_url, "api-key", &None, &None, &None, &request)
+        .await
+        .expect("send_chat_completion should succeed");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    let headers_lower = captured.header_text.to_ascii_lowercase();
+    assert!(
+        headers_lower.contains("x-openrouter-file-ids: openrouter")
+            || headers_lower.contains("x-openrouter-file-ids:openrouter"),
+        "files tool header should be present, headers:\n{}",
+        captured.header_text
+    );
+
+    let request_json: serde_json::Value =
+        serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
+    assert_eq!(request_json["tools"][0]["type"], "openrouter:files");
 
     server.join().expect("server thread should finish");
 }

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -272,6 +272,55 @@ fn test_chat_request_server_tool_only_serialization() {
 }
 
 #[test]
+fn test_chat_request_deserializes_server_tools_from_merged_tools_array() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "openai/gpt-5",
+        "messages": [{"role": "user", "content": "Search and inspect files"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather by city",
+                    "parameters": {"type": "object"},
+                    "strict": true
+                },
+                "cache_control": {"type": "ephemeral"}
+            },
+            {
+                "type": "openrouter:web_search",
+                "parameters": {"max_results": 3}
+            },
+            {
+                "type": "openrouter:files"
+            }
+        ]
+    }))
+    .expect("chat request should deserialize");
+
+    let function_tools = request.tools().expect("function tools should be preserved");
+    assert_eq!(function_tools.len(), 1);
+    assert_eq!(function_tools[0].function.name, "get_weather");
+    assert_eq!(function_tools[0].function.strict, Some(true));
+
+    let server_tools = request
+        .server_tools()
+        .expect("server tools should be preserved");
+    assert_eq!(server_tools.len(), 2);
+    assert_eq!(server_tools[0].tool_type, "openrouter:web_search");
+    assert_eq!(
+        server_tools[0].parameters.as_ref().unwrap()["max_results"],
+        3
+    );
+    assert_eq!(server_tools[1].tool_type, "openrouter:files");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["tools"][0]["type"], "function");
+    assert_eq!(value["tools"][1]["type"], "openrouter:web_search");
+    assert_eq!(value["tools"][2]["type"], "openrouter:files");
+}
+
+#[test]
 fn test_chat_request_preserves_explicit_empty_tools_array() {
     let request = ChatCompletionRequest::builder()
         .model("openai/gpt-5")

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -272,6 +272,32 @@ fn test_chat_request_server_tool_only_serialization() {
 }
 
 #[test]
+fn test_chat_request_preserves_explicit_empty_tools_array() {
+    let request = ChatCompletionRequest::builder()
+        .model("openai/gpt-5")
+        .messages(vec![Message::new(Role::User, "No tools")])
+        .tools(Vec::<Tool>::new())
+        .build()
+        .expect("request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["tools"], json!([]));
+}
+
+#[test]
+fn test_chat_request_preserves_explicit_empty_server_tools_array() {
+    let request = ChatCompletionRequest::builder()
+        .model("openai/gpt-5")
+        .messages(vec![Message::new(Role::User, "No tools")])
+        .server_tools(Vec::<ServerTool>::new())
+        .build()
+        .expect("request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["tools"], json!([]));
+}
+
+#[test]
 fn test_chat_request_extended_generation_fields_serialize() {
     let request = ChatCompletionRequest::builder()
         .model("openai/gpt-5")

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -3,7 +3,7 @@ use openrouter_rs::{
         CacheControl, CacheControlType, ChatCompletionRequest, ContentPart, DebugOptions, Message,
         Modality, Plugin, StopSequence, StreamOptions, TraceOptions,
     },
-    types::{Effort, Role},
+    types::{Effort, Role, ServerTool, Tool},
 };
 use serde_json::json;
 
@@ -217,6 +217,58 @@ fn test_chat_request_extended_control_fields_serialize() {
     assert_eq!(json["trace"]["team"], "rust-sdk");
     assert_eq!(json["stop"][0], "END");
     assert_eq!(json["stop"][1], "DONE");
+}
+
+#[test]
+fn test_chat_request_merges_function_and_server_tools() {
+    let function_tool = Tool::builder()
+        .name("get_weather")
+        .description("Get weather by city")
+        .parameters(json!({"type": "object"}))
+        .build()
+        .expect("function tool should build");
+
+    let request = ChatCompletionRequest::builder()
+        .model("openai/gpt-5")
+        .messages(vec![Message::new(Role::User, "Search and plan")])
+        .tool(function_tool)
+        .server_tool(ServerTool::web_search_with_parameters(
+            json!({"max_results": 3}),
+        ))
+        .force_server_tool("openrouter:web_search")
+        .build()
+        .expect("request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["tools"][0]["type"], "function");
+    assert_eq!(value["tools"][0]["function"]["name"], "get_weather");
+    assert_eq!(value["tools"][1]["type"], "openrouter:web_search");
+    assert_eq!(value["tools"][1]["parameters"]["max_results"], 3);
+    assert_eq!(
+        value["tool_choice"],
+        json!({"type": "openrouter:web_search"})
+    );
+    assert_eq!(request.tools().map(|tools| tools.len()), Some(1));
+    assert_eq!(request.server_tools().map(|tools| tools.len()), Some(1));
+}
+
+#[test]
+fn test_chat_request_server_tool_only_serialization() {
+    let request = ChatCompletionRequest::builder()
+        .model("openai/gpt-5")
+        .messages(vec![Message::new(Role::User, "What time is it?")])
+        .server_tool(ServerTool::datetime_with_timezone("UTC"))
+        .build()
+        .expect("request should build");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(
+        value["tools"],
+        json!([{
+            "type": "openrouter:datetime",
+            "parameters": {"timezone": "UTC"}
+        }])
+    );
 }
 
 #[test]

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -973,6 +973,13 @@ async fn test_management_domain_remaining_methods_require_configured_key() {
     assert!(matches!(
         client
             .management()
+            .list_workspace_members("ws_123", None)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
             .add_workspace_members("ws_123", &workspace_members_request)
             .await,
         Err(OpenRouterError::KeyNotConfigured)
@@ -1415,6 +1422,48 @@ async fn test_management_domain_list_workspaces_without_pagination_delegates() {
         .recv_timeout(Duration::from_secs(2))
         .expect("should capture request");
     assert_eq!(captured.request_line, "GET /api/v1/workspaces HTTP/1.1");
+    assert!(
+        captured
+            .request_text
+            .to_ascii_lowercase()
+            .contains("authorization: bearer management-key")
+            || captured
+                .request_text
+                .to_ascii_lowercase()
+                .contains("authorization:bearer management-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_management_domain_list_workspace_members_delegates() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"data":[],"total_count":0}"#);
+    let client = OpenRouterClient::builder()
+        .base_url(base_url)
+        .management_key("management-key")
+        .build()
+        .expect("client should build");
+
+    let response = client
+        .management()
+        .list_workspace_members(
+            "team/prod 1",
+            Some(PaginationOptions::with_offset_and_limit(1, 5)),
+        )
+        .await
+        .expect("list_workspace_members should succeed");
+    assert_eq!(response.total_count, 0.0);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces/team%2Fprod%201/members?offset=1&limit=5 HTTP/1.1"
+    );
     assert!(
         captured
             .request_text

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -120,6 +120,54 @@ fn test_anthropic_messages_request_merges_server_tools() {
 }
 
 #[test]
+fn test_anthropic_messages_request_deserializes_server_tools_from_merged_tools_array() {
+    let request: AnthropicMessagesRequest = serde_json::from_value(json!({
+        "model": "anthropic/claude-sonnet-4",
+        "max_tokens": 512,
+        "messages": [{"role": "user", "content": "Search and inspect files"}],
+        "tools": [
+            {
+                "type": "custom",
+                "name": "get_weather",
+                "description": "Get weather by city",
+                "input_schema": {"type": "object"}
+            },
+            {
+                "type": "openrouter:datetime",
+                "parameters": {"timezone": "UTC"}
+            },
+            {
+                "type": "openrouter:files"
+            }
+        ]
+    }))
+    .expect("messages request should deserialize");
+
+    let anthropic_tools = request
+        .tools()
+        .expect("Anthropic tools should be preserved");
+    assert_eq!(anthropic_tools.len(), 1);
+    assert_eq!(anthropic_tools[0].name, "get_weather");
+    assert_eq!(anthropic_tools[0].tool_type.as_deref(), Some("custom"));
+
+    let server_tools = request
+        .server_tools()
+        .expect("server tools should be preserved");
+    assert_eq!(server_tools.len(), 2);
+    assert_eq!(server_tools[0].tool_type, "openrouter:datetime");
+    assert_eq!(
+        server_tools[0].parameters.as_ref().unwrap()["timezone"],
+        "UTC"
+    );
+    assert_eq!(server_tools[1].tool_type, "openrouter:files");
+
+    let value = serde_json::to_value(&request).expect("request should serialize");
+    assert_eq!(value["tools"][0]["name"], "get_weather");
+    assert_eq!(value["tools"][1]["type"], "openrouter:datetime");
+    assert_eq!(value["tools"][2]["type"], "openrouter:files");
+}
+
+#[test]
 fn test_anthropic_messages_request_preserves_explicit_empty_tools_array() {
     let request = AnthropicMessagesRequest::builder()
         .model("anthropic/claude-sonnet-4")
@@ -602,6 +650,7 @@ async fn test_create_message_sets_stream_false_and_headers() {
         .model("anthropic/claude-sonnet-4")
         .max_tokens(128)
         .messages(vec![AnthropicMessage::user("hello")])
+        .server_tool(ServerTool::files())
         .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("messages request should build");
@@ -660,10 +709,16 @@ async fn test_create_message_sets_stream_false_and_headers() {
             || headers_lower.contains("x-openrouter-metadata:enabled"),
         "experimental metadata header should be present, headers:\n{header_text}"
     );
+    assert!(
+        headers_lower.contains("x-openrouter-file-ids: openrouter")
+            || headers_lower.contains("x-openrouter-file-ids:openrouter"),
+        "files tool header should be present, headers:\n{header_text}"
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&request_body).expect("request body should be valid json");
     assert_eq!(request_json["stream"], false);
+    assert_eq!(request_json["tools"][0]["type"], "openrouter:files");
     assert!(request_json.get("experimental_metadata").is_none());
 
     server.join().expect("server thread should finish");

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -120,6 +120,34 @@ fn test_anthropic_messages_request_merges_server_tools() {
 }
 
 #[test]
+fn test_anthropic_messages_request_preserves_explicit_empty_tools_array() {
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(512)
+        .messages(vec![AnthropicMessage::user("No tools")])
+        .tools(Vec::<AnthropicTool>::new())
+        .build()
+        .expect("messages request should build");
+
+    let value = serde_json::to_value(&request).expect("messages request should serialize");
+    assert_eq!(value["tools"], json!([]));
+}
+
+#[test]
+fn test_anthropic_messages_request_preserves_explicit_empty_server_tools_array() {
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(512)
+        .messages(vec![AnthropicMessage::user("No tools")])
+        .server_tools(Vec::<ServerTool>::new())
+        .build()
+        .expect("messages request should build");
+
+    let value = serde_json::to_value(&request).expect("messages request should serialize");
+    assert_eq!(value["tools"], json!([]));
+}
+
+#[test]
 fn test_anthropic_messages_response_deserialization() {
     let raw = r#"{
         "id": "msg_01XFDUDYJgAACzvnptvVoYEL",

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -17,7 +17,7 @@ use openrouter_rs::api::{
         create_message, stream_messages,
     },
 };
-use openrouter_rs::types::OpenRouterExperimentalMetadata;
+use openrouter_rs::types::{OpenRouterExperimentalMetadata, ServerTool};
 use serde_json::json;
 
 #[test]
@@ -94,6 +94,32 @@ fn test_anthropic_messages_request_serialization() {
 }
 
 #[test]
+fn test_anthropic_messages_request_merges_server_tools() {
+    let request = AnthropicMessagesRequest::builder()
+        .model("anthropic/claude-sonnet-4")
+        .max_tokens(512)
+        .messages(vec![AnthropicMessage::user("What time is it?")])
+        .tool(AnthropicTool::custom(
+            "get_weather",
+            "Get weather by city",
+            json!({"type": "object"}),
+        ))
+        .server_tool(ServerTool::datetime_with_timezone("America/New_York"))
+        .build()
+        .expect("messages request should build");
+
+    let value = serde_json::to_value(&request).expect("messages request should serialize");
+    assert_eq!(value["tools"][0]["name"], "get_weather");
+    assert_eq!(value["tools"][1]["type"], "openrouter:datetime");
+    assert_eq!(
+        value["tools"][1]["parameters"]["timezone"],
+        "America/New_York"
+    );
+    assert_eq!(request.tools().map(|tools| tools.len()), Some(1));
+    assert_eq!(request.server_tools().map(|tools| tools.len()), Some(1));
+}
+
+#[test]
 fn test_anthropic_messages_response_deserialization() {
     let raw = r#"{
         "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
@@ -112,7 +138,10 @@ fn test_anthropic_messages_response_deserialization() {
         "usage": {
             "input_tokens": 12,
             "output_tokens": 15,
-            "service_tier": "standard"
+            "service_tier": "standard",
+            "server_tool_use": {
+                "web_search_requests": 1
+            }
         }
     }"#;
 
@@ -129,6 +158,15 @@ fn test_anthropic_messages_response_deserialization() {
             .and_then(|usage| usage.output_tokens)
             .unwrap_or_default(),
         15
+    );
+    assert_eq!(
+        response
+            .usage
+            .as_ref()
+            .and_then(|usage| usage.extra.get("server_tool_use"))
+            .and_then(|value| value.get("web_search_requests"))
+            .and_then(|value| value.as_u64()),
+        Some(1)
     );
     assert_eq!(response.content.len(), 1);
     match &response.content[0] {

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -362,6 +362,7 @@ async fn test_create_response_sets_stream_false_and_headers() {
     let request = ResponsesRequest::builder()
         .model("openai/gpt-5")
         .input(json!([{"role":"user","content":"hello"}]))
+        .server_tool(ServerTool::files())
         .experimental_metadata(OpenRouterExperimentalMetadata::Enabled)
         .build()
         .expect("responses request should build");
@@ -425,11 +426,18 @@ async fn test_create_response_sets_stream_false_and_headers() {
         "experimental metadata header should be present, headers:\n{}",
         captured.header_text
     );
+    assert!(
+        headers_lower.contains("x-openrouter-file-ids: openrouter")
+            || headers_lower.contains("x-openrouter-file-ids:openrouter"),
+        "files tool header should be present, headers:\n{}",
+        captured.header_text
+    );
 
     let request_json: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("request body should be valid JSON");
     assert_eq!(request_json["stream"], false);
     assert_eq!(request_json["model"], "openai/gpt-5");
+    assert_eq!(request_json["tools"][0]["type"], "openrouter:files");
     assert!(request_json.get("experimental_metadata").is_none());
 
     server.join().expect("server thread should finish");

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -13,7 +13,7 @@ use openrouter_rs::api::{
         ResponsesRequest, ResponsesResponse, ResponsesStreamEvent, create_response, stream_response,
     },
 };
-use openrouter_rs::types::OpenRouterExperimentalMetadata;
+use openrouter_rs::types::{OpenRouterExperimentalMetadata, ServerTool};
 use serde_json::json;
 
 struct CapturedRequest {
@@ -179,6 +179,30 @@ fn test_responses_request_serialization() {
 }
 
 #[test]
+fn test_responses_request_server_tool_helpers() {
+    let request = ResponsesRequest::builder()
+        .model("openai/gpt-5")
+        .input(json!("Find current docs"))
+        .server_tool(ServerTool::web_search_with_parameters(
+            json!({"max_results": 2}),
+        ))
+        .server_tool(ServerTool::datetime_with_timezone("UTC"))
+        .force_server_tool("openrouter:web_search")
+        .build()
+        .expect("responses request should build");
+
+    let value = serde_json::to_value(&request).expect("responses request should serialize");
+    assert_eq!(value["tools"][0]["type"], "openrouter:web_search");
+    assert_eq!(value["tools"][0]["parameters"]["max_results"], 2);
+    assert_eq!(value["tools"][1]["type"], "openrouter:datetime");
+    assert_eq!(value["tools"][1]["parameters"]["timezone"], "UTC");
+    assert_eq!(
+        value["tool_choice"],
+        json!({"type": "openrouter:web_search"})
+    );
+}
+
+#[test]
 fn test_responses_response_deserialization() {
     let raw = r#"{
         "id": "resp-abc123",
@@ -211,6 +235,49 @@ fn test_responses_response_deserialization() {
     assert_eq!(response.status.as_deref(), Some("completed"));
     assert!(response.output.is_some());
     assert!(response.usage.is_some());
+}
+
+#[test]
+fn test_responses_server_tool_output_items_preserve_fields() {
+    let raw = r#"{
+        "id": "resp-server-tools",
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {
+                "type": "openrouter:web_search",
+                "id": "ws_tmp_abc123",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "latest AI news",
+                    "sources": [{"type": "url", "url": "https://example.com"}]
+                }
+            },
+            {
+                "type": "openrouter:datetime",
+                "id": "dt_tmp_abc123",
+                "status": "completed",
+                "datetime": "2026-03-12T14:30:00.000Z",
+                "timezone": "UTC"
+            }
+        ]
+    }"#;
+
+    let response: ResponsesResponse =
+        serde_json::from_str(raw).expect("responses payload should deserialize");
+    let output = response.output.expect("output should be present");
+
+    assert_eq!(output[0]["type"], "openrouter:web_search");
+    assert_eq!(output[0]["status"], "completed");
+    assert_eq!(output[0]["action"]["query"], "latest AI news");
+    assert_eq!(
+        output[0]["action"]["sources"][0]["url"],
+        "https://example.com"
+    );
+    assert_eq!(output[1]["type"], "openrouter:datetime");
+    assert_eq!(output[1]["datetime"], "2026-03-12T14:30:00.000Z");
+    assert_eq!(output[1]["timezone"], "UTC");
 }
 
 #[test]

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -196,9 +196,38 @@ fn test_responses_request_server_tool_helpers() {
     assert_eq!(value["tools"][0]["parameters"]["max_results"], 2);
     assert_eq!(value["tools"][1]["type"], "openrouter:datetime");
     assert_eq!(value["tools"][1]["parameters"]["timezone"], "UTC");
+    assert_eq!(value["tool_choice"], json!({"type": "web_search_preview"}));
+}
+
+#[test]
+fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() {
+    let web_search = ResponsesRequest::builder()
+        .input(json!("search"))
+        .force_server_tool("openrouter:web_search")
+        .build()
+        .expect("responses request should build");
+    let apply_patch = ResponsesRequest::builder()
+        .input(json!("patch"))
+        .force_server_tool("openrouter:apply_patch")
+        .build()
+        .expect("responses request should build");
+    let shell = ResponsesRequest::builder()
+        .input(json!("shell"))
+        .force_server_tool("openrouter:shell")
+        .build()
+        .expect("responses request should build");
+
     assert_eq!(
-        value["tool_choice"],
-        json!({"type": "openrouter:web_search"})
+        serde_json::to_value(&web_search).expect("request should serialize")["tool_choice"],
+        json!({"type": "web_search_preview"})
+    );
+    assert_eq!(
+        serde_json::to_value(&apply_patch).expect("request should serialize")["tool_choice"],
+        json!({"type": "apply_patch"})
+    );
+    assert_eq!(
+        serde_json::to_value(&shell).expect("request should serialize")["tool_choice"],
+        json!({"type": "shell"})
     );
 }
 

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -196,11 +196,18 @@ fn test_responses_request_server_tool_helpers() {
     assert_eq!(value["tools"][0]["parameters"]["max_results"], 2);
     assert_eq!(value["tools"][1]["type"], "openrouter:datetime");
     assert_eq!(value["tools"][1]["parameters"]["timezone"], "UTC");
-    assert_eq!(value["tool_choice"], json!({"type": "web_search_preview"}));
+    assert_eq!(
+        value["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:web_search"}]
+        })
+    );
 }
 
 #[test]
-fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() {
+fn test_responses_force_server_tool_preserves_openrouter_types() {
     let web_search = ResponsesRequest::builder()
         .input(json!("search"))
         .force_server_tool("openrouter:web_search")
@@ -216,6 +223,11 @@ fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() 
         .force_server_tool("openrouter:shell")
         .build()
         .expect("responses request should build");
+    let bash = ResponsesRequest::builder()
+        .input(json!("bash"))
+        .force_server_tool("openrouter:bash")
+        .build()
+        .expect("responses request should build");
     let datetime = ResponsesRequest::builder()
         .input(json!("datetime"))
         .force_server_tool("openrouter:datetime")
@@ -224,7 +236,81 @@ fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() 
 
     assert_eq!(
         serde_json::to_value(&web_search).expect("request should serialize")["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:web_search"}]
+        })
+    );
+    assert_eq!(
+        serde_json::to_value(&apply_patch).expect("request should serialize")["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:apply_patch"}]
+        })
+    );
+    assert_eq!(
+        serde_json::to_value(&shell).expect("request should serialize")["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:shell"}]
+        })
+    );
+    assert_eq!(
+        serde_json::to_value(&bash).expect("request should serialize")["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:bash"}]
+        })
+    );
+    assert_eq!(
+        serde_json::to_value(&datetime).expect("request should serialize")["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:datetime"}]
+        })
+    );
+}
+
+#[test]
+fn test_responses_force_server_tool_uses_direct_native_response_choices() {
+    let preview = ResponsesRequest::builder()
+        .input(json!("search"))
+        .force_server_tool("web_search_preview")
+        .build()
+        .expect("responses request should build");
+    let dated_preview = ResponsesRequest::builder()
+        .input(json!("search"))
+        .force_server_tool("web_search_preview_2025_03_11")
+        .build()
+        .expect("responses request should build");
+    let apply_patch = ResponsesRequest::builder()
+        .input(json!("patch"))
+        .force_server_tool("apply_patch")
+        .build()
+        .expect("responses request should build");
+    let shell = ResponsesRequest::builder()
+        .input(json!("shell"))
+        .force_server_tool("shell")
+        .build()
+        .expect("responses request should build");
+    let web_search_alias = ResponsesRequest::builder()
+        .input(json!("search"))
+        .force_server_tool("web_search")
+        .build()
+        .expect("responses request should build");
+
+    assert_eq!(
+        serde_json::to_value(&preview).expect("request should serialize")["tool_choice"],
         json!({"type": "web_search_preview"})
+    );
+    assert_eq!(
+        serde_json::to_value(&dated_preview).expect("request should serialize")["tool_choice"],
+        json!({"type": "web_search_preview_2025_03_11"})
     );
     assert_eq!(
         serde_json::to_value(&apply_patch).expect("request should serialize")["tool_choice"],
@@ -235,11 +321,11 @@ fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() 
         json!({"type": "shell"})
     );
     assert_eq!(
-        serde_json::to_value(&datetime).expect("request should serialize")["tool_choice"],
+        serde_json::to_value(&web_search_alias).expect("request should serialize")["tool_choice"],
         json!({
             "type": "allowed_tools",
             "mode": "required",
-            "tools": [{"type": "openrouter:datetime"}]
+            "tools": [{"type": "web_search"}]
         })
     );
 }

--- a/tests/unit/responses.rs
+++ b/tests/unit/responses.rs
@@ -216,6 +216,11 @@ fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() 
         .force_server_tool("openrouter:shell")
         .build()
         .expect("responses request should build");
+    let datetime = ResponsesRequest::builder()
+        .input(json!("datetime"))
+        .force_server_tool("openrouter:datetime")
+        .build()
+        .expect("responses request should build");
 
     assert_eq!(
         serde_json::to_value(&web_search).expect("request should serialize")["tool_choice"],
@@ -228,6 +233,14 @@ fn test_responses_force_server_tool_maps_openrouter_types_to_response_choices() 
     assert_eq!(
         serde_json::to_value(&shell).expect("request should serialize")["tool_choice"],
         json!({"type": "shell"})
+    );
+    assert_eq!(
+        serde_json::to_value(&datetime).expect("request should serialize")["tool_choice"],
+        json!({
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "openrouter:datetime"}]
+        })
     );
 }
 

--- a/tests/unit/tool_builder.rs
+++ b/tests/unit/tool_builder.rs
@@ -1,4 +1,4 @@
-use openrouter_rs::types::tool::{FunctionDefinition, Tool};
+use openrouter_rs::types::tool::{FunctionDefinition, ServerTool, Tool, ToolChoice};
 use serde_json::json;
 
 #[test]
@@ -63,6 +63,46 @@ fn test_tool_builder_accepts_full_function_definition_override() {
     assert_eq!(tool.function.name, "lookup_user");
     assert_eq!(tool.function.description, "Find a user by id");
     assert_eq!(tool.function.parameters["required"][0], "user_id");
+}
+
+#[test]
+fn test_tool_builder_serializes_strict_and_cache_control() {
+    let tool = Tool::builder()
+        .name("lookup_user")
+        .description("Find a user by id")
+        .parameters(json!({"type": "object"}))
+        .strict(true)
+        .cache_control(json!({"type": "ephemeral", "ttl": "1h"}))
+        .build()
+        .expect("tool should build");
+
+    let value = serde_json::to_value(tool).expect("tool should serialize");
+    assert_eq!(value["type"], "function");
+    assert_eq!(value["function"]["strict"], true);
+    assert_eq!(value["cache_control"]["type"], "ephemeral");
+    assert_eq!(value["cache_control"]["ttl"], "1h");
+}
+
+#[test]
+fn test_server_tool_helpers_serialize_openapi_shape() {
+    let tool = ServerTool::web_search_with_parameters(json!({
+        "max_results": 5,
+        "search_context_size": "high"
+    }))
+    .option("allowed_domains", json!(["example.com"]));
+
+    let value = serde_json::to_value(tool).expect("server tool should serialize");
+    assert_eq!(value["type"], "openrouter:web_search");
+    assert_eq!(value["parameters"]["max_results"], 5);
+    assert_eq!(value["parameters"]["search_context_size"], "high");
+    assert_eq!(value["allowed_domains"][0], "example.com");
+}
+
+#[test]
+fn test_server_tool_choice_serializes_openapi_shape() {
+    let choice = ToolChoice::force_server_tool("openrouter:web_search");
+    let value = serde_json::to_value(choice).expect("tool choice should serialize");
+    assert_eq!(value, json!({"type": "openrouter:web_search"}));
 }
 
 #[test]

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -522,6 +522,41 @@ async fn test_list_workspace_budgets_encodes_id_path() {
 }
 
 #[tokio::test]
+async fn test_list_workspace_members_encodes_id_pagination_and_auth_header() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"wm_1","workspace_id":"ws_123","user_id":"user_123","role":"member","created_at":"2025-01-01T00:00:00.000Z"}],"total_count":1}"#,
+    );
+
+    let members = workspaces::list_workspace_members(
+        &base_url,
+        "mgmt-key",
+        "team/prod 1",
+        Some(PaginationOptions::with_offset_and_limit(2, 10)),
+    )
+    .await
+    .expect("list workspace members should succeed");
+    assert_eq!(members.total_count, 1.0);
+    assert_eq!(members.data[0].user_id, "user_123");
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/workspaces/team%2Fprod%201/members?offset=2&limit=10 HTTP/1.1"
+    );
+    let request_lower = captured.request_text.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("authorization: bearer mgmt-key")
+            || request_lower.contains("authorization:bearer mgmt-key"),
+        "authorization header should include management key, request:\n{}",
+        captured.request_text
+    );
+
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
 async fn test_upsert_workspace_budget_encodes_path_and_body() {
     let (base_url, rx, server) = spawn_json_server(
         r#"{"data":{"id":"770e8400-e29b-41d4-a716-446655440000","workspace_id":"550e8400-e29b-41d4-a716-446655440000","limit_usd":100,"reset_interval":"monthly","created_at":"2025-08-24T10:30:00Z","updated_at":"2025-08-24T15:45:00Z"}}"#,


### PR DESCRIPTION
## Summary

- accept the current OpenAPI drift for server-tool request schemas across chat, Responses, Messages, and preset request bodies
- add `ServerTool` helpers, server-tool tool choice support, and workspace member listing via `client.management().list_workspace_members(...)`
- refresh the tracked OpenAPI baseline to 88 / 88 endpoints and document the OpenSpec change

## Validation

- `just openapi-drift-check`
- `just quality-ci`
- `openspec validate --all --strict --json`
- `git diff --check`

Refs #228