### PR TITLE
feat: accept latest OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added explicit chat prompt-cache breakpoints/options, static predicted output, image provider routing preferences, conditional model pricing overrides, detailed cache-creation usage, and custom guardrail `flag` actions.
+
+### Changed
+- Accepted the 2026-07-22 OpenAPI drift review, including optional prompts for image-only video generation, and refreshed the `89 / 89` official endpoint snapshot.
+
 ## [0.12.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 - multimodal chat content, including image, audio, video, and file parts
 - model discovery, provider discovery, app rankings, task classifications, unified benchmarks, embeddings, and ZDR endpoints
 - typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
+- explicit chat prompt-cache breakpoints and static predictions, image provider routing controls, conditional model pricing, and image-only video generation requests
 - management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace member listing/mutation, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-07-14
+Snapshot date: 2026-07-22
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -14,6 +14,7 @@ Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 Drift review note:
 
+- Upstream added explicit chat prompt-cache controls, static predicted output, image provider routing preferences, conditional pricing overrides, detailed cache-creation usage, custom guardrail `flag` actions, namespace tools, and image-only video generation. The SDK types the stable fields and reuses its existing flexible server-tool, plugin, provider-taxonomy, and Responses payload handling for the remaining schema additions.
 - Upstream added `POST /generation/feedback`, new model/rankings filters, analytics classifier controls, verbose transcription fields, XAI ZDR policy, routed service tiers, server-tool reasoning details, and image text chunks. The SDK exposes stable fields and keeps flexible provider, Responses, and server-tool payloads where the upstream surface remains high-churn.
 - Upstream added OpenRouter server-tool variants to chat completions, Responses API, Anthropic-compatible Messages, and preset creation request schemas. The SDK now exposes `ServerTool` helpers and preserves raw `Value` escape hatches for high-churn server-tool payloads.
 - Upstream added `GET /workspaces/{id}/members`, now exposed as `client.management().list_workspace_members(...)`.

--- a/examples/create_image_generation.rs
+++ b/examples/create_image_generation.rs
@@ -1,4 +1,7 @@
-use openrouter_rs::{OpenRouterClient, api::images::ImageGenerationRequest};
+use openrouter_rs::{
+    OpenRouterClient,
+    api::images::{ImageGenerationRequest, ImageProviderOptions},
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -10,6 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .prompt("A red panda astronaut floating in space, studio lighting")
         .aspect_ratio("16:9")
         .resolution("2K")
+        .provider(ImageProviderOptions::default().allow_fallbacks(true))
         .build()?;
 
     let response = client.images().create(&request).await?;

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -313,6 +313,9 @@
                   "$ref": "#/components/schemas/CustomTool"
                 },
                 {
+                  "$ref": "#/components/schemas/NamespaceTool"
+                },
+                {
                   "$ref": "#/components/schemas/AdvisorServerTool_OpenRouter"
                 },
                 {
@@ -960,7 +963,7 @@
         "type": "object"
       },
       "AnthropicCacheControlDirective": {
-        "description": "Enable automatic prompt caching. When set at the top level, the system automatically applies cache breakpoints to the last cacheable block in the request. Currently supported for Anthropic Claude models.",
+        "description": "Enable automatic prompt caching. When set at the top level, the system automatically applies cache breakpoints to the last cacheable block in the request. When set on an individual content block, it marks an explicit cache breakpoint; block-level markers also work on OpenAI models that support explicit prompt caching \u2014 OpenRouter converts them to the provider's native format.",
         "example": {
           "type": "ephemeral"
         },
@@ -4063,6 +4066,52 @@
         ],
         "type": "object"
       },
+      "AutoBetaRouterPlugin": {
+        "example": {
+          "allowed_models": [
+            "anthropic/*",
+            "openai/gpt-4o"
+          ],
+          "cost_quality_tradeoff": 7,
+          "enabled": true,
+          "id": "auto-beta-router"
+        },
+        "properties": {
+          "allowed_models": {
+            "description": "List of model patterns to filter which models the auto-beta-router can route between. Supports wildcards (e.g., \"anthropic/*\" matches all Anthropic models). When not specified, uses the default supported models list.",
+            "example": [
+              "anthropic/*",
+              "openai/gpt-4o",
+              "google/*"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cost_quality_tradeoff": {
+            "description": "Balances routing between cost and quality on a 0-10 scale. The auto-beta-router ranks models for the classified task type by community spend share, then filters candidates by their average cost per generation for that task. Higher values favor cheaper models: 10 keeps only models around the cheapest 10th percentile, while 0 permits models up to the 90th percentile for cost. Defaults to 7.",
+            "example": 7,
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "enabled": {
+            "description": "Set to false to disable the auto-beta-router plugin for this request. Defaults to true.",
+            "type": "boolean"
+          },
+          "id": {
+            "enum": [
+              "auto-beta-router"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
       "AutoRouterPlugin": {
         "example": {
           "allowed_models": [
@@ -4262,6 +4311,7 @@
           "digitalocean",
           "featherless",
           "fireworks",
+          "fish-audio",
           "friendli",
           "gmicloud",
           "google-ai-studio",
@@ -4276,6 +4326,7 @@
           "inflection",
           "io-net",
           "ionstream",
+          "krea",
           "liquid",
           "mancer",
           "mara",
@@ -4303,6 +4354,7 @@
           "recraft",
           "reka",
           "relace",
+          "sail-research",
           "sakana",
           "sambanova",
           "seed",
@@ -4311,6 +4363,7 @@
           "stepfun",
           "streamlake",
           "switchpoint",
+          "tencent",
           "tenstorrent",
           "together",
           "upstage",
@@ -5600,6 +5653,9 @@
               "null"
             ]
           },
+          "prompt_cache_options": {
+            "$ref": "#/components/schemas/PromptCacheOptions"
+          },
           "reasoning": {
             "$ref": "#/components/schemas/BaseReasoningConfig",
             "nullable": true
@@ -5711,6 +5767,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/CustomTool"
+                },
+                {
+                  "$ref": "#/components/schemas/NamespaceTool"
                 }
               ]
             },
@@ -6476,7 +6535,7 @@
             "type": "object"
           }
         ],
-        "description": "Cache control for the content part",
+        "description": "Anthropic-style cache breakpoint for the content part. Interchangeable with the OpenAI-style `prompt_cache_breakpoint` marker: OpenRouter converts between the two based on the provider serving the request.",
         "example": {
           "ttl": "5m",
           "type": "ephemeral"
@@ -6615,6 +6674,9 @@
         "properties": {
           "cache_control": {
             "$ref": "#/components/schemas/ChatContentCacheControl"
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpoint"
           },
           "text": {
             "type": "string"
@@ -7320,6 +7382,7 @@
             "items": {
               "discriminator": {
                 "mapping": {
+                  "auto-beta-router": "#/components/schemas/AutoBetaRouterPlugin",
                   "auto-router": "#/components/schemas/AutoRouterPlugin",
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
@@ -7335,6 +7398,9 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/AutoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/AutoBetaRouterPlugin"
                 },
                 {
                   "$ref": "#/components/schemas/ModerationPlugin"
@@ -7364,6 +7430,9 @@
             },
             "type": "array"
           },
+          "prediction": {
+            "$ref": "#/components/schemas/Prediction"
+          },
           "presence_penalty": {
             "description": "Presence penalty (-2.0 to 2.0)",
             "example": 0,
@@ -7372,6 +7441,15 @@
               "number",
               "null"
             ]
+          },
+          "prompt_cache_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "prompt_cache_options": {
+            "$ref": "#/components/schemas/PromptCacheOptions"
           },
           "provider": {
             "$ref": "#/components/schemas/ProviderPreferences"
@@ -8452,34 +8530,7 @@
             ]
           },
           "server_tool_use_details": {
-            "description": "Usage for server-side tool execution (e.g., web search)",
-            "properties": {
-              "tool_calls_executed": {
-                "description": "Number of OpenRouter server tool calls that executed and produced a result",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "tool_calls_requested": {
-                "description": "Total number of OpenRouter server-orchestrated tool calls the model requested, across all tool types. Provider-native tools (e.g. native web search) are not counted here.",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "web_search_requests": {
-                "description": "Number of web searches performed by server-side tools. For server-orchestrated tool calls a web search is also counted in tool_calls_requested; provider-native web search may report web_search_requests only. Do not sum the two.",
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "type": [
-              "object",
-              "null"
-            ]
+            "$ref": "#/components/schemas/ServerToolUseDetails"
           },
           "total_tokens": {
             "description": "Total number of tokens",
@@ -9045,7 +9096,8 @@
         "description": "Action taken when the pattern matches",
         "enum": [
           "redact",
-          "block"
+          "block",
+          "flag"
         ],
         "example": "block",
         "type": "string",
@@ -9642,6 +9694,7 @@
           "enforce_zdr_google": false,
           "enforce_zdr_openai": true,
           "enforce_zdr_other": false,
+          "enforce_zdr_xai": false,
           "ignored_models": null,
           "ignored_providers": null,
           "limit_usd": 50,
@@ -9682,7 +9735,7 @@
             ]
           },
           "content_filter_builtins": {
-            "description": "Builtin content filters to apply. The \"flag\" action is only supported for \"regex-prompt-injection\"; PII slugs (email, phone, ssn, credit-card, ip-address, person-name, address) accept \"block\" or \"redact\" only.",
+            "description": "Builtin content filters to apply. Every builtin slug supports \"block\", \"redact\", and the detect-only \"flag\" action.",
             "example": [
               {
                 "action": "block",
@@ -9725,7 +9778,7 @@
           },
           "enforce_zdr": {
             "deprecated": true,
-            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
+            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, enforce_zdr_xai, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
             "example": false,
             "type": [
               "boolean",
@@ -9757,7 +9810,15 @@
             ]
           },
           "enforce_zdr_other": {
-            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, or Google. Falls back to enforce_zdr when not provided.",
+            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, Google, or xAI. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enforce_zdr_xai": {
+            "description": "Whether to enforce zero data retention for xAI models. Falls back to enforce_zdr when not provided.",
             "example": false,
             "type": [
               "boolean",
@@ -9847,6 +9908,7 @@
             "enforce_zdr_google": false,
             "enforce_zdr_openai": true,
             "enforce_zdr_other": false,
+            "enforce_zdr_xai": false,
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
@@ -12509,7 +12571,7 @@
             "$ref": "#/components/schemas/AnthropicCacheControlDirective"
           },
           "max_completion_tokens": {
-            "description": "Maximum number of output tokens (including reasoning tokens) each panelist and the judge model may produce per inner call. Controls the total output budget so reasoning-heavy models like GPT-5.5 do not exhaust their token allowance before producing visible text. When omitted, panelists default to 32000 and the judge to 50000.",
+            "description": "Maximum number of output tokens (including reasoning tokens) each panelist and the judge model may produce per inner call. Controls the total output budget so reasoning-heavy models like GPT-5.5 do not exhaust their token allowance before producing visible text. When omitted, panelists default to 32000 and the judge to 20000.",
             "example": 16384,
             "type": "integer"
           },
@@ -13266,6 +13328,7 @@
             "enforce_zdr_google": false,
             "enforce_zdr_openai": true,
             "enforce_zdr_other": false,
+            "enforce_zdr_xai": false,
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
@@ -13516,6 +13579,7 @@
           "enforce_zdr_google": false,
           "enforce_zdr_openai": true,
           "enforce_zdr_other": false,
+          "enforce_zdr_xai": false,
           "id": "550e8400-e29b-41d4-a716-446655440000",
           "ignored_models": null,
           "ignored_providers": null,
@@ -13605,7 +13669,7 @@
           },
           "enforce_zdr": {
             "deprecated": true,
-            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
+            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, enforce_zdr_xai, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
             "example": false,
             "type": [
               "boolean",
@@ -13637,7 +13701,15 @@
             ]
           },
           "enforce_zdr_other": {
-            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, or Google. Falls back to enforce_zdr when not provided.",
+            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, Google, or xAI. Falls back to enforce_zdr when not provided.",
+            "example": false,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enforce_zdr_xai": {
+            "description": "Whether to enforce zero data retention for xAI models. Falls back to enforce_zdr when not provided.",
             "example": false,
             "type": [
               "boolean",
@@ -14097,6 +14169,118 @@
         ],
         "type": "object"
       },
+      "ImageGenerationProviderPreferences": {
+        "description": "Provider routing preferences and provider-specific passthrough configuration.",
+        "example": {
+          "allow_fallbacks": false,
+          "only": [
+            "google-ai-studio"
+          ]
+        },
+        "properties": {
+          "allow_fallbacks": {
+            "description": "Whether to allow backup providers to serve requests\n- true: (default) when the primary provider (or your custom providers in \"order\") is unavailable, use the next best provider.\n- false: use only the primary/custom provider, and return the upstream error if it's unavailable.\n",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "ignore": {
+            "description": "List of provider slugs to ignore. If provided, this list is merged with your account-wide ignored provider settings for this request.",
+            "example": [
+              "openai",
+              "anthropic"
+            ],
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderName"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "only": {
+            "description": "List of provider slugs to allow. If provided, this list is merged with your account-wide allowed provider settings for this request.",
+            "example": [
+              "openai",
+              "anthropic"
+            ],
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderName"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProviderOptions"
+              },
+              {
+                "example": {
+                  "black-forest-labs": {
+                    "guidance": 3,
+                    "steps": 40
+                  }
+                }
+              }
+            ]
+          },
+          "order": {
+            "description": "An ordered list of provider slugs. The router will attempt to use the first provider in the subset of this list that supports your requested model, and fall back to the next if it is unavailable. If no providers are available, the request will fail with an error message.",
+            "example": [
+              "openai",
+              "anthropic"
+            ],
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderName"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "sort": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProviderSort"
+              },
+              {
+                "$ref": "#/components/schemas/ProviderSortConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The sorting strategy to use for this request, if \"order\" is not specified. When set, no load balancing is performed.",
+            "example": "price"
+          }
+        },
+        "type": "object"
+      },
       "ImageGenerationRequest": {
         "description": "Image generation request input",
         "example": {
@@ -14187,25 +14371,7 @@
             "type": "string"
           },
           "provider": {
-            "description": "Provider-specific passthrough configuration",
-            "properties": {
-              "options": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ProviderOptions"
-                  },
-                  {
-                    "example": {
-                      "black-forest-labs": {
-                        "guidance": 3,
-                        "steps": 40
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            "type": "object"
+            "$ref": "#/components/schemas/ImageGenerationProviderPreferences"
           },
           "quality": {
             "description": "Rendering quality. Providers without a quality knob ignore this.",
@@ -14471,6 +14637,9 @@
           "total_tokens": 4175
         },
         "properties": {
+          "cache_creation": {
+            "$ref": "#/components/schemas/AnthropicCacheCreation"
+          },
           "completion_tokens": {
             "description": "The tokens generated",
             "type": "integer"
@@ -16078,6 +16247,7 @@
               "enforce_zdr_google": false,
               "enforce_zdr_openai": true,
               "enforce_zdr_other": false,
+              "enforce_zdr_xai": false,
               "id": "550e8400-e29b-41d4-a716-446655440000",
               "ignored_models": null,
               "ignored_providers": null,
@@ -17294,6 +17464,9 @@
           },
           "usage": {
             "properties": {
+              "cache_creation": {
+                "$ref": "#/components/schemas/AnthropicCacheCreation"
+              },
               "cache_creation_input_tokens": {
                 "type": [
                   "integer",
@@ -18100,6 +18273,7 @@
             "items": {
               "discriminator": {
                 "mapping": {
+                  "auto-beta-router": "#/components/schemas/AutoBetaRouterPlugin",
                   "auto-router": "#/components/schemas/AutoRouterPlugin",
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
@@ -18115,6 +18289,9 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/AutoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/AutoBetaRouterPlugin"
                 },
                 {
                   "$ref": "#/components/schemas/ModerationPlugin"
@@ -18841,7 +19018,6 @@
                   "Lynn 2",
                   "Lynn",
                   "Mancer",
-                  "Meta",
                   "Modal",
                   "Nineteen",
                   "OctoAI",
@@ -18887,6 +19063,7 @@
                   "DigitalOcean",
                   "Featherless",
                   "Fireworks",
+                  "Fish Audio",
                   "Friendli",
                   "GMICloud",
                   "Google",
@@ -18904,6 +19081,7 @@
                   "Liquid",
                   "Mara",
                   "Mancer 2",
+                  "Meta",
                   "Minimax",
                   "ModelRun",
                   "Mistral",
@@ -18926,6 +19104,7 @@
                   "Recraft",
                   "Reka",
                   "Relace",
+                  "Sail Research",
                   "Sakana AI",
                   "SambaNova",
                   "Seed",
@@ -18935,6 +19114,7 @@
                   "Stealth",
                   "StreamLake",
                   "Switchpoint",
+                  "Tencent",
                   "Tenstorrent",
                   "Together",
                   "Upstage",
@@ -18942,6 +19122,7 @@
                   "Wafer",
                   "WandB",
                   "Quiver",
+                  "Krea",
                   "Xiaomi",
                   "xAI",
                   "Z.AI",
@@ -19765,6 +19946,120 @@
         },
         "required": [
           "data"
+        ],
+        "type": "object"
+      },
+      "NamespaceFunctionTool": {
+        "description": "A function tool grouped inside a namespace tool",
+        "example": {
+          "name": "spawn_agent",
+          "type": "function"
+        },
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "enum": [
+                "direct",
+                "programmatic"
+              ],
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "defer_loading": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "output_schema": {
+            "additionalProperties": {},
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "parameters": {
+            "additionalProperties": {},
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "strict": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "type": {
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamespaceTool": {
+        "description": "Groups function/custom tools under a shared namespace",
+        "example": {
+          "description": "Tools for spawning and managing sub-agents.",
+          "name": "multi_agent_v1",
+          "tools": [
+            {
+              "name": "spawn_agent",
+              "type": "function"
+            }
+          ],
+          "type": "namespace"
+        },
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tools": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/NamespaceFunctionTool"
+                },
+                {
+                  "$ref": "#/components/schemas/CustomTool"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "namespace"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "description",
+          "tools"
         ],
         "type": "object"
       },
@@ -23676,6 +23971,14 @@
           "type": "openrouter:bash"
         },
         "properties": {
+          "arguments": {
+            "description": "The raw tool-call arguments string as emitted by the model.",
+            "type": "string"
+          },
+          "call_id": {
+            "description": "The model-generated tool call id from the originating turn.",
+            "type": "string"
+          },
           "command": {
             "type": "string"
           },
@@ -25446,8 +25749,18 @@
           "id": {
             "type": "string"
           },
+          "instance_name": {
+            "description": "Provider-safe function name of the specific subagent instance that produced this item (e.g. `openrouter_subagent__1`). Present only on items from non-default instances \u2014 the second and later subagent entries in the request `tools` array. The first (default) instance omits it, even when multiple subagents are configured. When a replayed item echoes this field back, the transcript rehydrates the call under that instance's tool. This identity is positional: it is derived from the index of the subagent entry in the request `tools` array, so keep the order of subagent entries stable across requests in a conversation.",
+            "example": "openrouter_subagent__1",
+            "type": "string"
+          },
           "model": {
             "description": "Slug of the worker model that executed the task.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Configured name of the subagent that executed the task (the `name` on its tool entry). Present only for named subagents; omitted for an unnamed (default) subagent.",
+            "example": "summarizer",
             "type": "string"
           },
           "outcome": {
@@ -25733,6 +26046,7 @@
           "logit_bias",
           "logprobs",
           "top_logprobs",
+          "prediction",
           "seed",
           "response_format",
           "structured_outputs",
@@ -26127,6 +26441,65 @@
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
       },
+      "Prediction": {
+        "description": "Static predicted output content. Supported models can use this to reduce latency when much of the response is known in advance.",
+        "example": {
+          "content": "Expected response",
+          "type": "content"
+        },
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PredictionContentText"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "content"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ],
+        "type": [
+          "object",
+          "null"
+        ]
+      },
+      "PredictionContentText": {
+        "description": "Text content part for a predicted output.",
+        "example": {
+          "text": "Expected response",
+          "type": "text"
+        },
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
       "PreferredMaxLatency": {
         "anyOf": [
           {
@@ -26473,8 +26846,62 @@
           "null"
         ]
       },
+      "PricingOverride": {
+        "description": "A conditional override of the base pricing. An entry applies only when all of its condition fields (e.g. min_prompt_tokens, or the utc_start/utc_end time window) match the request; among applicable entries, later entries win per price key; price keys absent from an entry inherit the base price.",
+        "example": {
+          "completion": "0.00002",
+          "min_prompt_tokens": 200000,
+          "prompt": "0.000005"
+        },
+        "properties": {
+          "audio": {
+            "description": "Overridden price in USD per audio input token",
+            "type": "string"
+          },
+          "completion": {
+            "description": "Overridden price in USD per token for completion (output) generation",
+            "type": "string"
+          },
+          "input_audio_cache": {
+            "description": "Overridden price in USD per cached audio input token",
+            "type": "string"
+          },
+          "input_cache_read": {
+            "description": "Overridden price in USD per cached input token (read)",
+            "type": "string"
+          },
+          "input_cache_write": {
+            "description": "Overridden price in USD per cache-write token",
+            "type": "string"
+          },
+          "input_cache_write_1h": {
+            "description": "Overridden price in USD per 1-hour cache-write token",
+            "type": "string"
+          },
+          "min_prompt_tokens": {
+            "description": "Condition: the entry applies when the total prompt tokens of a request are strictly greater than this threshold",
+            "format": "double",
+            "type": "number"
+          },
+          "prompt": {
+            "description": "Overridden price in USD per token for prompt (input) processing",
+            "type": "string"
+          },
+          "utc_end": {
+            "description": "Condition: exclusive end of a daily UTC time window as an HHMM clock number (e.g. 400 = 04:00)",
+            "format": "double",
+            "type": "number"
+          },
+          "utc_start": {
+            "description": "Condition: inclusive start of a daily UTC time window as an HHMM clock number (e.g. 100 = 01:00, 1030 = 10:30). The entry applies while the current UTC time is inside the half-open window [utc_start, utc_end), which may wrap past midnight (utc_start > utc_end).",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
       "PromptCacheBreakpoint": {
-        "description": "Marks an explicit prompt-cache boundary on this content block. Everything through the block carrying this marker is part of the candidate cached prefix. Only supported by OpenAI GPT-5.6 and newer.",
+        "description": "Marks an explicit prompt-cache boundary on this content block (OpenAI-style). Everything through the block carrying this marker is part of the candidate cached prefix. Supported natively by OpenAI GPT-5.6 and newer; on providers that use Anthropic-style `cache_control`, OpenRouter converts the marker to that format automatically.",
         "example": {
           "mode": "explicit"
         },
@@ -26534,7 +26961,6 @@
       },
       "ProviderName": {
         "enum": [
-          "Meta",
           "AkashML",
           "AI21",
           "AionLabs",
@@ -26568,6 +26994,7 @@
           "DigitalOcean",
           "Featherless",
           "Fireworks",
+          "Fish Audio",
           "Friendli",
           "GMICloud",
           "Google",
@@ -26585,6 +27012,7 @@
           "Liquid",
           "Mara",
           "Mancer 2",
+          "Meta",
           "Minimax",
           "ModelRun",
           "Mistral",
@@ -26607,6 +27035,7 @@
           "Recraft",
           "Reka",
           "Relace",
+          "Sail Research",
           "Sakana AI",
           "SambaNova",
           "Seed",
@@ -26616,6 +27045,7 @@
           "Stealth",
           "StreamLake",
           "Switchpoint",
+          "Tencent",
           "Tenstorrent",
           "Together",
           "Upstage",
@@ -26623,6 +27053,7 @@
           "Wafer",
           "WandB",
           "Quiver",
+          "Krea",
           "Xiaomi",
           "xAI",
           "Z.AI",
@@ -26800,6 +27231,10 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "fish-audio": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "friendli": {
             "additionalProperties": {},
             "type": "object"
@@ -26877,6 +27312,10 @@
             "type": "object"
           },
           "klusterai": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "krea": {
             "additionalProperties": {},
             "type": "object"
           },
@@ -27032,6 +27471,10 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "sail-research": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "sakana": {
             "additionalProperties": {},
             "type": "object"
@@ -27077,6 +27520,10 @@
             "type": "object"
           },
           "targon": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "tencent": {
             "additionalProperties": {},
             "type": "object"
           },
@@ -27419,7 +27866,6 @@
               "Lynn 2",
               "Lynn",
               "Mancer",
-              "Meta",
               "Modal",
               "Nineteen",
               "OctoAI",
@@ -27465,6 +27911,7 @@
               "DigitalOcean",
               "Featherless",
               "Fireworks",
+              "Fish Audio",
               "Friendli",
               "GMICloud",
               "Google",
@@ -27482,6 +27929,7 @@
               "Liquid",
               "Mara",
               "Mancer 2",
+              "Meta",
               "Minimax",
               "ModelRun",
               "Mistral",
@@ -27504,6 +27952,7 @@
               "Recraft",
               "Reka",
               "Relace",
+              "Sail Research",
               "Sakana AI",
               "SambaNova",
               "Seed",
@@ -27513,6 +27962,7 @@
               "Stealth",
               "StreamLake",
               "Switchpoint",
+              "Tencent",
               "Tenstorrent",
               "Together",
               "Upstage",
@@ -27520,6 +27970,7 @@
               "Wafer",
               "WandB",
               "Quiver",
+              "Krea",
               "Xiaomi",
               "xAI",
               "Z.AI",
@@ -27727,6 +28178,13 @@
                 "description": "Price in USD per internal reasoning token",
                 "type": "string"
               },
+              "overrides": {
+                "description": "Conditional overrides of the base pricing (e.g. long-context or time-based pricing). An entry applies when all of its condition fields (e.g. min_prompt_tokens, or the utc_start/utc_end time window) match the request; among applicable entries, later entries win per key; price keys absent from an entry inherit the base price. The top-level pricing keys always reflect the price that applies under default conditions.",
+                "items": {
+                  "$ref": "#/components/schemas/PricingOverride"
+                },
+                "type": "array"
+              },
               "prompt": {
                 "description": "Price in USD per token for prompt (input) processing",
                 "type": "string"
@@ -27886,6 +28344,13 @@
           "internal_reasoning": {
             "description": "Price in USD per internal reasoning token",
             "type": "string"
+          },
+          "overrides": {
+            "description": "Conditional overrides of the base pricing (e.g. long-context or time-based pricing). An entry applies when all of its condition fields (e.g. min_prompt_tokens, or the utc_start/utc_end time window) match the request; among applicable entries, later entries win per key; price keys absent from an entry inherit the base price. The top-level pricing keys always reflect the price that applies under default conditions.",
+            "items": {
+              "$ref": "#/components/schemas/PricingOverride"
+            },
+            "type": "array"
           },
           "prompt": {
             "description": "Price in USD per token for prompt (input) processing",
@@ -28369,6 +28834,7 @@
           "openai-responses-v1",
           "azure-openai-responses-v1",
           "xai-responses-v1",
+          "meta-responses-v1",
           "anthropic-claude-v1",
           "google-gemini-v1",
           null
@@ -28977,6 +29443,7 @@
             "items": {
               "discriminator": {
                 "mapping": {
+                  "auto-beta-router": "#/components/schemas/AutoBetaRouterPlugin",
                   "auto-router": "#/components/schemas/AutoRouterPlugin",
                   "context-compression": "#/components/schemas/ContextCompressionPlugin",
                   "file-parser": "#/components/schemas/FileParserPlugin",
@@ -28992,6 +29459,9 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/AutoRouterPlugin"
+                },
+                {
+                  "$ref": "#/components/schemas/AutoBetaRouterPlugin"
                 },
                 {
                   "$ref": "#/components/schemas/ModerationPlugin"
@@ -29029,10 +29499,7 @@
             ]
           },
           "previous_response_id": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "description": "Not supported. The Responses API is stateless: no responses are stored, so a previous response cannot be referenced. Requests with a non-null value are rejected with a 400 error. Send the full conversation history in `input` instead."
           },
           "prompt": {
             "$ref": "#/components/schemas/StoredPromptTemplate"
@@ -29185,6 +29652,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/CustomTool"
+                },
+                {
+                  "$ref": "#/components/schemas/NamespaceTool"
                 },
                 {
                   "$ref": "#/components/schemas/AdvisorServerTool_OpenRouter"
@@ -29712,6 +30182,41 @@
         "example": "medium",
         "type": "string",
         "x-speakeasy-unknown-values": "allow"
+      },
+      "ServerToolUseDetails": {
+        "description": "Usage for server-side tool execution (e.g., web search)",
+        "example": {
+          "tool_calls_executed": 2,
+          "tool_calls_requested": 2,
+          "web_search_requests": 2
+        },
+        "properties": {
+          "tool_calls_executed": {
+            "description": "Number of OpenRouter server tool calls that executed and produced a result.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "tool_calls_requested": {
+            "description": "Total number of OpenRouter server-orchestrated tool calls the model requested, across all tool types. Provider-native tools (e.g. native web search) are not counted here.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "web_search_requests": {
+            "description": "Number of web searches performed by server-side tools. For server-orchestrated tool calls a web search is also counted in tool_calls_requested; provider-native web search may report web_search_requests only. Do not sum the two.",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": [
+          "object",
+          "null"
+        ]
       },
       "ServiceTier": {
         "enum": [
@@ -30819,9 +31324,10 @@
         "type": "object"
       },
       "SubagentServerToolConfig": {
-        "description": "Configuration for the openrouter:subagent server tool.",
+        "description": "Configuration for one openrouter:subagent server tool entry.",
         "example": {
-          "model": "~anthropic/claude-haiku-latest"
+          "model": "~anthropic/claude-haiku-latest",
+          "name": "summarizer"
         },
         "properties": {
           "instructions": {
@@ -30844,6 +31350,14 @@
           "model": {
             "description": "Slug of the model that executes delegated tasks (any OpenRouter model). Typically a smaller, cheaper, faster model than the one delegating. When omitted, the model from the outer API request is used. The subagent tool itself cannot be the subagent model.",
             "example": "~anthropic/claude-haiku-latest",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional name for this subagent. The model sees one tool per named subagent (and one default for an unnamed entry). Names must be unique across subagent entries. Letters, digits, spaces, underscores, and dashes; trimmed; 1\u201364 chars.",
+            "example": "summarizer",
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9 _-]+$",
             "type": "string"
           },
           "reasoning": {
@@ -32176,7 +32690,7 @@
             ]
           },
           "content_filter_builtins": {
-            "description": "Builtin content filters to apply. Set to null to remove. The \"flag\" action is only supported for \"regex-prompt-injection\"; PII slugs (email, phone, ssn, credit-card, ip-address, person-name, address) accept \"block\" or \"redact\" only.",
+            "description": "Builtin content filters to apply. Set to null to remove. Every builtin slug supports \"block\", \"redact\", and the detect-only \"flag\" action.",
             "example": [
               {
                 "action": "block",
@@ -32213,7 +32727,7 @@
           },
           "enforce_zdr": {
             "deprecated": true,
-            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
+            "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, enforce_zdr_xai, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
             "example": true,
             "type": [
               "boolean",
@@ -32245,7 +32759,15 @@
             ]
           },
           "enforce_zdr_other": {
-            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, or Google. Falls back to enforce_zdr when not provided.",
+            "description": "Whether to enforce zero data retention for models that are not from Anthropic, OpenAI, Google, or xAI. Falls back to enforce_zdr when not provided.",
+            "example": true,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enforce_zdr_xai": {
+            "description": "Whether to enforce zero data retention for xAI models. Falls back to enforce_zdr when not provided.",
             "example": true,
             "type": [
               "boolean",
@@ -32324,6 +32846,7 @@
             "enforce_zdr_google": true,
             "enforce_zdr_openai": true,
             "enforce_zdr_other": true,
+            "enforce_zdr_xai": true,
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
@@ -32666,6 +33189,9 @@
                   "is_byok": {
                     "description": "Whether a request was made using a Bring Your Own Key configuration",
                     "type": "boolean"
+                  },
+                  "server_tool_use_details": {
+                    "$ref": "#/components/schemas/ServerToolUseDetails"
                   }
                 },
                 "type": "object"
@@ -32756,6 +33282,8 @@
             "type": "string"
           },
           "prompt": {
+            "description": "Text prompt describing the video to generate. Optional for models that support generating a video from image input alone; required by all other models.",
+            "example": "A serene mountain landscape at sunset",
             "type": "string"
           },
           "provider": {
@@ -32805,7 +33333,6 @@
           }
         },
         "required": [
-          "prompt",
           "model"
         ],
         "type": "object"
@@ -34688,7 +35215,7 @@
                         "x-speakeasy-unknown-values": "allow"
                       },
                       "field": {
-                        "description": "Field to order by",
+                        "description": "Field to order by: a metric included in `metrics` (or \"request_count\", which may be ordered by without being requested), a requested dimension, or \"date\".",
                         "example": "request_count",
                         "type": "string"
                       }
@@ -36087,6 +36614,7 @@
                 "digitalocean",
                 "featherless",
                 "fireworks",
+                "fish-audio",
                 "friendli",
                 "gmicloud",
                 "google-ai-studio",
@@ -36101,6 +36629,7 @@
                 "inflection",
                 "io-net",
                 "ionstream",
+                "krea",
                 "liquid",
                 "mancer",
                 "mara",
@@ -36128,6 +36657,7 @@
                 "recraft",
                 "reka",
                 "relace",
+                "sail-research",
                 "sakana",
                 "sambanova",
                 "seed",
@@ -36136,6 +36666,7 @@
                 "stepfun",
                 "streamlake",
                 "switchpoint",
+                "tencent",
                 "tenstorrent",
                 "together",
                 "upstage",
@@ -38724,6 +39255,22 @@
             },
             "description": "Returns a list of endpoints"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -40183,6 +40730,7 @@
                 "enforce_zdr_google": false,
                 "enforce_zdr_openai": true,
                 "enforce_zdr_other": false,
+                "enforce_zdr_xai": false,
                 "ignored_models": null,
                 "ignored_providers": null,
                 "limit_usd": 50,
@@ -40215,6 +40763,7 @@
                     "enforce_zdr_google": false,
                     "enforce_zdr_openai": true,
                     "enforce_zdr_other": false,
+                    "enforce_zdr_xai": false,
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
@@ -40815,6 +41364,7 @@
                     "enforce_zdr_google": true,
                     "enforce_zdr_openai": true,
                     "enforce_zdr_other": true,
+                    "enforce_zdr_xai": true,
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
@@ -44570,6 +45120,22 @@
             },
             "description": "Returns the model details"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "404": {
             "content": {
               "application/json": {
@@ -44759,8 +45325,7 @@
             "schema": {
               "description": "Minimum context length (tokens). Models with smaller context are excluded.",
               "example": 128000,
-              "exclusiveMinimum": 0,
-              "minimum": 0,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -45128,6 +45693,22 @@
             },
             "description": "Bad Request - Invalid request parameters or malformed input"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -45228,6 +45809,22 @@
               }
             },
             "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
           },
           "500": {
             "content": {
@@ -45373,6 +45970,22 @@
               }
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
           },
           "404": {
             "content": {
@@ -45573,6 +46186,22 @@
               }
             },
             "description": "Returns a list of endpoints"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
           },
           "404": {
             "content": {
@@ -51004,7 +51633,7 @@
         }
       ],
       "post": {
-        "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Remove multiple members from a workspace. Members with active API keys in the workspace cannot be removed. SCIM-managed members cannot be removed; changes must be made in your identity provider. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "bulkRemoveWorkspaceMembers",
         "parameters": [
           {

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-07-14T03:03:34+00:00",
+  "captured_at": "2026-07-22T06:30:46+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "61cba3c3e44d2bb9",
+      "fingerprint": "df122b4b213e4637",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8d9373b331ca424e",
+      "fingerprint": "c47fe5ab1ab6bc42",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -194,7 +194,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cbaee3a7d93ac554",
+      "fingerprint": "14478b1cc8de7965",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b9ea93c3c4da5390",
+      "fingerprint": "66cd160f5d448ecc",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fb26c835808b2cfa",
+      "fingerprint": "9a9f16bea89b5380",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ae60d38e325e7798",
+      "fingerprint": "e928dfa54aeab2ad",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "17d22d1fc1cacbd6",
+      "fingerprint": "a5b60660f4b866e1",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -392,7 +392,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8c21574fdfc9891f",
+      "fingerprint": "1443103dd307b550",
       "id": "GET /model/{author}/{slug}",
       "method": "GET",
       "operation_id": "getModel",
@@ -403,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f7528f2439c35a6c",
+      "fingerprint": "50b6ac4b9f523291",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -414,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c1697bb0b641e58d",
+      "fingerprint": "2d8082ffad0c8832",
       "id": "GET /models/count",
       "method": "GET",
       "operation_id": "listModelsCount",
@@ -425,7 +425,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a29bccaf6899fc00",
+      "fingerprint": "99d90081047dae88",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2ff2f1fcf2a6db25",
+      "fingerprint": "3275f77d033fe08c",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -612,7 +612,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "540e54cc73eff3c6",
+      "fingerprint": "ddc2d44f89f6b041",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -623,7 +623,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0e3bcef281ad25c1",
+      "fingerprint": "d4fc4ed46a1f8fff",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -678,7 +678,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3ba9a7e0b87623c8",
+      "fingerprint": "a670c86739e7ad4b",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -689,7 +689,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8f7d1125737a0065",
+      "fingerprint": "af75e16929a1c91d",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -722,7 +722,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b4a645f14d1e7eb1",
+      "fingerprint": "152353cc61c62177",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -733,7 +733,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0684fe958cc1afb1",
+      "fingerprint": "40ae1c0d5b3108e1",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -755,7 +755,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "10ebf20212a8a30c",
+      "fingerprint": "27f202a6a227c097",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -788,7 +788,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2e5b8f7b9e765f8b",
+      "fingerprint": "5b22baafaa961b61",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -843,7 +843,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "36974f49309e4ee1",
+      "fingerprint": "b49dfdce1cbe9acd",
       "id": "POST /images",
       "method": "POST",
       "operation_id": "createImages",
@@ -865,7 +865,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c5e52444f3006251",
+      "fingerprint": "c75a2ebf5a2f34c2",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -887,7 +887,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c8714481c8597148",
+      "fingerprint": "ddd6783934ab2365",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -898,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "fa2f0fc2dc9b268d",
+      "fingerprint": "b753b6dd5a3cbc17",
       "id": "POST /presets/{slug}/messages",
       "method": "POST",
       "operation_id": "createPresetsMessages",
@@ -909,7 +909,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8e2de92313203acd",
+      "fingerprint": "1521522461f6c5c5",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -920,7 +920,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3f1c137e3387a50e",
+      "fingerprint": "ecf59cdf39f32b45",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -931,7 +931,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f167606f669ce242",
+      "fingerprint": "e08e2d196fdfa837",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
@@ -942,7 +942,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7c75c9f71a4bb29c",
+      "fingerprint": "1b5d7083c58deb36",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -153,6 +153,54 @@ impl CacheControl {
     }
 }
 
+/// Explicit prompt-cache mode used by OpenAI-style cache controls.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum PromptCacheMode {
+    Explicit,
+}
+
+/// Marks an explicit prompt-cache boundary on a text content part.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct PromptCacheBreakpoint {
+    pub mode: PromptCacheMode,
+}
+
+impl PromptCacheBreakpoint {
+    pub fn explicit() -> Self {
+        Self {
+            mode: PromptCacheMode::Explicit,
+        }
+    }
+}
+
+/// Request-level controls for explicit prompt caching.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct PromptCacheOptions {
+    pub mode: PromptCacheMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+}
+
+impl PromptCacheOptions {
+    pub fn explicit() -> Self {
+        Self {
+            mode: PromptCacheMode::Explicit,
+            ttl: None,
+        }
+    }
+
+    pub fn explicit_with_ttl(ttl: impl Into<String>) -> Self {
+        Self {
+            mode: PromptCacheMode::Explicit,
+            ttl: Some(ttl.into()),
+        }
+    }
+}
+
 /// A content part in a multi-modal message.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
@@ -163,6 +211,8 @@ pub enum ContentPart {
         text: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        prompt_cache_breakpoint: Option<PromptCacheBreakpoint>,
     },
     /// Image URL content
     ImageUrl { image_url: ImageUrl },
@@ -181,6 +231,7 @@ impl ContentPart {
         Self::Text {
             text: text.into(),
             cache_control: None,
+            prompt_cache_breakpoint: None,
         }
     }
 
@@ -188,7 +239,23 @@ impl ContentPart {
         Self::Text {
             text: text.into(),
             cache_control: Some(cache_control),
+            prompt_cache_breakpoint: None,
         }
+    }
+
+    pub fn text_with_prompt_cache_breakpoint(
+        text: impl Into<String>,
+        breakpoint: PromptCacheBreakpoint,
+    ) -> Self {
+        Self::Text {
+            text: text.into(),
+            cache_control: None,
+            prompt_cache_breakpoint: Some(breakpoint),
+        }
+    }
+
+    pub fn cache_breakpoint_text(text: impl Into<String>) -> Self {
+        Self::text_with_prompt_cache_breakpoint(text, PromptCacheBreakpoint::explicit())
     }
 
     pub fn cacheable_text(text: impl Into<String>) -> Self {
@@ -283,6 +350,58 @@ impl From<&str> for Content {
 impl From<Vec<ContentPart>> for Content {
     fn from(parts: Vec<ContentPart>) -> Self {
         Self::Parts(parts)
+    }
+}
+
+/// One text part in a static predicted output.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct PredictionContentText {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+impl PredictionContentText {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            content_type: "text".to_string(),
+            text: text.into(),
+        }
+    }
+}
+
+/// Static predicted output content.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum PredictionContent {
+    Text(String),
+    Parts(Vec<PredictionContentText>),
+}
+
+/// Static predicted output used to reduce latency when most output is known.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct Prediction {
+    #[serde(rename = "type")]
+    pub prediction_type: String,
+    pub content: PredictionContent,
+}
+
+impl Prediction {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            prediction_type: "content".to_string(),
+            content: PredictionContent::Text(text.into()),
+        }
+    }
+
+    pub fn parts(parts: Vec<PredictionContentText>) -> Self {
+        Self {
+            prediction_type: "content".to_string(),
+            content: PredictionContent::Parts(parts),
+        }
     }
 }
 
@@ -545,6 +664,15 @@ pub struct ChatCompletionRequest {
     #[builder(setter(strip_option), default)]
     cache_control: Option<CacheControl>,
 
+    #[builder(setter(into, strip_option), default)]
+    prompt_cache_key: Option<String>,
+
+    #[builder(setter(strip_option), default)]
+    prompt_cache_options: Option<PromptCacheOptions>,
+
+    #[builder(setter(strip_option), default)]
+    prediction: Option<Prediction>,
+
     #[builder(setter(strip_option), default)]
     trace: Option<TraceOptions>,
 
@@ -621,6 +749,9 @@ struct ChatCompletionRequestWire {
     user: Option<String>,
     session_id: Option<String>,
     cache_control: Option<CacheControl>,
+    prompt_cache_key: Option<String>,
+    prompt_cache_options: Option<PromptCacheOptions>,
+    prediction: Option<Prediction>,
     trace: Option<TraceOptions>,
     provider: Option<ProviderPreferences>,
     metadata: Option<HashMap<String, String>>,
@@ -677,6 +808,9 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
             user: wire.user,
             session_id: wire.session_id,
             cache_control: wire.cache_control,
+            prompt_cache_key: wire.prompt_cache_key,
+            prompt_cache_options: wire.prompt_cache_options,
+            prediction: wire.prediction,
             trace: wire.trace,
             provider: wire.provider,
             metadata: wire.metadata,
@@ -805,6 +939,13 @@ impl Serialize for ChatCompletionRequest {
         insert_json_option::<_, S::Error>(&mut map, "user", &self.user)?;
         insert_json_option::<_, S::Error>(&mut map, "session_id", &self.session_id)?;
         insert_json_option::<_, S::Error>(&mut map, "cache_control", &self.cache_control)?;
+        insert_json_option::<_, S::Error>(&mut map, "prompt_cache_key", &self.prompt_cache_key)?;
+        insert_json_option::<_, S::Error>(
+            &mut map,
+            "prompt_cache_options",
+            &self.prompt_cache_options,
+        )?;
+        insert_json_option::<_, S::Error>(&mut map, "prediction", &self.prediction)?;
         insert_json_option::<_, S::Error>(&mut map, "trace", &self.trace)?;
         insert_json_option::<_, S::Error>(&mut map, "provider", &self.provider)?;
         insert_json_option::<_, S::Error>(&mut map, "metadata", &self.metadata)?;

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::{
-    api::models::ModelReasoning,
+    api::models::{ModelReasoning, PricingOverride},
     error::OpenRouterError,
     transport::{request as transport_request, response as transport_response},
     types::ApiResponse,
@@ -66,6 +66,8 @@ pub struct PublicPricing {
     pub input_cache_write: Option<BigNumber>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discount: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<Vec<PricingOverride>>,
 }
 
 /// Model architecture data in model discovery responses.

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -17,6 +17,7 @@ use crate::{
 pub enum ContentFilterAction {
     Redact,
     Block,
+    Flag,
 }
 
 /// Action for a built-in content filter.

--- a/src/api/images.rs
+++ b/src/api/images.rs
@@ -16,6 +16,7 @@ use crate::{
     transport::{
         request as transport_request, response as transport_response, sse::response_lines,
     },
+    types::AnthropicCacheCreation,
     utils::parse_sse_frames,
 };
 
@@ -59,14 +60,62 @@ impl ImageInputReference {
 #[non_exhaustive]
 pub struct ImageProviderOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_fallbacks: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub only: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<Value>,
 }
 
 impl ImageProviderOptions {
     pub fn new(options: HashMap<String, Value>) -> Self {
         Self {
             options: Some(options),
+            ..Self::default()
         }
+    }
+
+    pub fn allow_fallbacks(mut self, allow_fallbacks: bool) -> Self {
+        self.allow_fallbacks = Some(allow_fallbacks);
+        self
+    }
+
+    pub fn ignore<T, S>(mut self, providers: T) -> Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.ignore = Some(providers.into_iter().map(Into::into).collect());
+        self
+    }
+
+    pub fn only<T, S>(mut self, providers: T) -> Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.only = Some(providers.into_iter().map(Into::into).collect());
+        self
+    }
+
+    pub fn order<T, S>(mut self, providers: T) -> Self
+    where
+        T: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.order = Some(providers.into_iter().map(Into::into).collect());
+        self
+    }
+
+    pub fn sort(mut self, sort: impl Into<Value>) -> Self {
+        self.sort = Some(sort.into());
+        self
     }
 }
 
@@ -155,6 +204,8 @@ pub struct ImageGenerationUsage {
     pub cost: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_byok: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation: Option<AnthropicCacheCreation>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -13,7 +13,7 @@ use crate::{
     transport::{
         request as transport_request, response as transport_response, sse::response_lines,
     },
-    types::{OpenRouterExperimentalMetadata, ProviderPreferences},
+    types::{AnthropicCacheCreation, OpenRouterExperimentalMetadata, ProviderPreferences},
     utils::parse_sse_frames,
 };
 
@@ -814,6 +814,8 @@ pub struct AnthropicMessagesUsage {
     pub cache_creation_input_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_read_input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation: Option<AnthropicCacheCreation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
     #[serde(flatten)]

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -88,8 +88,36 @@ pub struct Pricing {
     pub input_cache_write: Option<String>,
     pub web_search: Option<String>,
     pub internal_reasoning: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<Vec<PricingOverride>>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+}
+
+/// Conditional override applied to base model pricing.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct PricingOverride {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_audio_cache: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_cache_read: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_cache_write: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_cache_write_1h: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_prompt_tokens: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub utc_end: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub utc_start: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -172,6 +200,8 @@ pub struct EndpointPricing {
     pub image: Option<String>,
     pub prompt: String,
     pub completion: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<Vec<PricingOverride>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -111,7 +111,8 @@ impl VideoProviderOptions {
 #[builder(build_fn(error = "OpenRouterError"))]
 #[non_exhaustive]
 pub struct VideoGenerationRequest {
-    #[builder(setter(into))]
+    #[builder(setter(into), default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub prompt: String,
     #[builder(setter(into))]
     pub model: String,

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -79,6 +79,14 @@ pub struct ServerToolUseDetails {
     pub web_search_requests: Option<u32>,
 }
 
+/// Anthropic-style prompt-cache creation token breakdown.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct AnthropicCacheCreation {
+    pub ephemeral_5m_input_tokens: u64,
+    pub ephemeral_1h_input_tokens: u64,
+}
+
 /// Token and billing usage reported for chat completion responses.
 ///
 /// Response payloads are intentionally constructed by deserialization rather than

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -380,6 +380,7 @@ impl ServerTool {
                     | "web_search_preview_2025_03_11"
                     | "apply_patch"
                     | "shell"
+                    | "namespace"
             )
     }
 

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -1,7 +1,8 @@
 use openrouter_rs::{
     api::chat::{
         CacheControl, CacheControlType, ChatCompletionRequest, ContentPart, DebugOptions, Message,
-        Modality, Plugin, StopSequence, StreamOptions, TraceOptions,
+        Modality, Plugin, Prediction, PredictionContentText, PromptCacheMode, PromptCacheOptions,
+        StopSequence, StreamOptions, TraceOptions,
     },
     types::{Effort, Role, ServerTool, Tool},
 };
@@ -98,6 +99,7 @@ fn test_text_content_part_cache_control_deserialization() {
         ContentPart::Text {
             text,
             cache_control,
+            ..
         } => {
             assert_eq!(text, "cached");
             let cache_control = cache_control.expect("cache control should be present");
@@ -106,6 +108,42 @@ fn test_text_content_part_cache_control_deserialization() {
         }
         _ => panic!("expected text content part"),
     }
+}
+
+#[test]
+fn test_explicit_prompt_cache_and_prediction_serialize() {
+    let request = ChatCompletionRequest::builder()
+        .model("openai/gpt-5.6")
+        .messages(vec![Message::with_parts(
+            Role::User,
+            vec![ContentPart::cache_breakpoint_text("stable prefix")],
+        )])
+        .prompt_cache_key("docs-v1")
+        .prompt_cache_options(PromptCacheOptions::explicit_with_ttl("30m"))
+        .prediction(Prediction::parts(vec![PredictionContentText::new(
+            "Expected response",
+        )]))
+        .build()
+        .expect("request should build");
+
+    let value = serde_json::to_value(request).expect("request should serialize");
+    assert_eq!(
+        value["messages"][0]["content"][0]["prompt_cache_breakpoint"]["mode"],
+        "explicit"
+    );
+    assert_eq!(value["prompt_cache_key"], "docs-v1");
+    assert_eq!(value["prompt_cache_options"]["mode"], "explicit");
+    assert_eq!(value["prompt_cache_options"]["ttl"], "30m");
+    assert_eq!(value["prediction"]["type"], "content");
+    assert_eq!(value["prediction"]["content"][0]["type"], "text");
+    assert_eq!(
+        value["prediction"]["content"][0]["text"],
+        "Expected response"
+    );
+
+    let options: PromptCacheOptions = serde_json::from_value(value["prompt_cache_options"].clone())
+        .expect("prompt cache options should deserialize");
+    assert!(matches!(options.mode, PromptCacheMode::Explicit));
 }
 
 #[test]
@@ -293,6 +331,12 @@ fn test_chat_request_deserializes_server_tools_from_merged_tools_array() {
             },
             {
                 "type": "openrouter:files"
+            },
+            {
+                "type": "namespace",
+                "name": "tools",
+                "description": "Grouped tools",
+                "tools": []
             }
         ]
     }))
@@ -306,18 +350,20 @@ fn test_chat_request_deserializes_server_tools_from_merged_tools_array() {
     let server_tools = request
         .server_tools()
         .expect("server tools should be preserved");
-    assert_eq!(server_tools.len(), 2);
+    assert_eq!(server_tools.len(), 3);
     assert_eq!(server_tools[0].tool_type, "openrouter:web_search");
     assert_eq!(
         server_tools[0].parameters.as_ref().unwrap()["max_results"],
         3
     );
     assert_eq!(server_tools[1].tool_type, "openrouter:files");
+    assert_eq!(server_tools[2].tool_type, "namespace");
 
     let value = serde_json::to_value(&request).expect("request should serialize");
     assert_eq!(value["tools"][0]["type"], "function");
     assert_eq!(value["tools"][1]["type"], "openrouter:web_search");
     assert_eq!(value["tools"][2]["type"], "openrouter:files");
+    assert_eq!(value["tools"][3]["type"], "namespace");
 }
 
 #[test]

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -108,7 +108,12 @@ fn test_models_for_user_response_deserialization() {
             "description": "Test model",
             "pricing": {
                 "prompt": "0.000002",
-                "completion": 0.000008
+                "completion": 0.000008,
+                "overrides": [{
+                    "completion": "0.000012",
+                    "utc_start": 100,
+                    "utc_end": 400
+                }]
             },
             "context_length": 128000,
             "architecture": {
@@ -155,6 +160,13 @@ fn test_models_for_user_response_deserialization() {
         parsed.data[0].pricing.completion,
         BigNumber::Number(_)
     ));
+    let override_price = &parsed.data[0]
+        .pricing
+        .overrides
+        .as_ref()
+        .expect("pricing overrides should deserialize")[0];
+    assert_eq!(override_price.completion.as_deref(), Some("0.000012"));
+    assert_eq!(override_price.utc_start, Some(100.0));
     let reasoning = parsed.data[0]
         .reasoning
         .as_ref()

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -146,7 +146,7 @@ fn test_create_guardrail_request_serializes_content_filters_and_provider_zdr_fla
         .label("[PROMPT_INJECTION]")])
         .content_filters([ContentFilterEntry::new(
             r"\b(sk-[a-zA-Z0-9]{48})\b",
-            ContentFilterAction::Redact,
+            ContentFilterAction::Flag,
         )
         .label("[API_KEY]")])
         .enforce_zdr_anthropic(true)
@@ -171,7 +171,7 @@ fn test_create_guardrail_request_serializes_content_filters_and_provider_zdr_fla
         value["content_filters"][0]["pattern"],
         r"\b(sk-[a-zA-Z0-9]{48})\b"
     );
-    assert_eq!(value["content_filters"][0]["action"], "redact");
+    assert_eq!(value["content_filters"][0]["action"], "flag");
     assert_eq!(value["content_filters"][0]["label"], "[API_KEY]");
     assert_eq!(value["enforce_zdr_anthropic"], true);
     assert_eq!(value["enforce_zdr_openai"], false);

--- a/tests/unit/images.rs
+++ b/tests/unit/images.rs
@@ -127,7 +127,14 @@ fn test_image_generation_request_serialization() {
         .n(2)
         .output_compression(80)
         .output_format("webp")
-        .provider(ImageProviderOptions::new(provider_options))
+        .provider(
+            ImageProviderOptions::new(provider_options)
+                .allow_fallbacks(false)
+                .only(["Black Forest Labs"])
+                .ignore(["OpenAI"])
+                .order(["Black Forest Labs", "Google"])
+                .sort(serde_json::json!({"by": "price", "partition": "model"})),
+        )
         .quality("high")
         .resolution("2K")
         .seed(42)
@@ -148,6 +155,11 @@ fn test_image_generation_request_serialization() {
         value["provider"]["options"]["black-forest-labs"]["steps"],
         40
     );
+    assert_eq!(value["provider"]["allow_fallbacks"], false);
+    assert_eq!(value["provider"]["only"][0], "Black Forest Labs");
+    assert_eq!(value["provider"]["ignore"][0], "OpenAI");
+    assert_eq!(value["provider"]["order"][1], "Google");
+    assert_eq!(value["provider"]["sort"]["partition"], "model");
     assert!(value.get("stream").is_none());
 }
 
@@ -164,7 +176,11 @@ fn test_image_generation_response_deserialization() {
             "completion_tokens": 4175,
             "total_tokens": 4175,
             "cost": 0.04,
-            "is_byok": false
+            "is_byok": false,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 100,
+                "ephemeral_1h_input_tokens": 20
+            }
         }
     }"#;
 
@@ -173,9 +189,14 @@ fn test_image_generation_response_deserialization() {
     assert_eq!(parsed.created, 1748372400);
     assert_eq!(parsed.data[0].b64_json, "aW1hZ2U=");
     assert_eq!(parsed.data[0].media_type.as_deref(), Some("image/svg+xml"));
+    let usage = parsed.usage.expect("usage should be present");
+    assert_eq!(usage.cost, Some(0.04));
     assert_eq!(
-        parsed.usage.expect("usage should be present").cost,
-        Some(0.04)
+        usage
+            .cache_creation
+            .expect("cache creation should be present")
+            .ephemeral_1h_input_tokens,
+        20
     );
 }
 

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -215,6 +215,10 @@ fn test_anthropic_messages_response_deserialization() {
             "input_tokens": 12,
             "output_tokens": 15,
             "service_tier": "standard",
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 100,
+                "ephemeral_1h_input_tokens": 20
+            },
             "server_tool_use": {
                 "web_search_requests": 1
             }
@@ -243,6 +247,14 @@ fn test_anthropic_messages_response_deserialization() {
             .and_then(|value| value.get("web_search_requests"))
             .and_then(|value| value.as_u64()),
         Some(1)
+    );
+    assert_eq!(
+        response
+            .usage
+            .as_ref()
+            .and_then(|usage| usage.cache_creation.as_ref())
+            .map(|details| details.ephemeral_5m_input_tokens),
+        Some(100)
     );
     assert_eq!(response.content.len(), 1);
     match &response.content[0] {

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -109,6 +109,11 @@ fn test_model_endpoints_pricing_allows_missing_optional_fields() {
                 "pricing": {
                     "prompt": "0.00000025",
                     "completion": "0.000002",
+                    "overrides": [{
+                        "prompt": "0.0000005",
+                        "completion": "0.000004",
+                        "min_prompt_tokens": 200000
+                    }],
                     "discount": 0
                 },
                 "provider_name": "Qwen",
@@ -132,6 +137,9 @@ fn test_model_endpoints_pricing_allows_missing_optional_fields() {
     assert_eq!(pricing.completion, "0.000002");
     assert!(pricing.request.is_none());
     assert!(pricing.image.is_none());
+    let override_price = &pricing.overrides.as_ref().expect("overrides should exist")[0];
+    assert_eq!(override_price.prompt.as_deref(), Some("0.0000005"));
+    assert_eq!(override_price.min_prompt_tokens, Some(200000.0));
 }
 
 #[test]

--- a/tests/unit/videos.rs
+++ b/tests/unit/videos.rs
@@ -70,6 +70,24 @@ fn test_video_generation_request_serialization() {
 }
 
 #[test]
+fn test_video_generation_request_allows_image_only_input() {
+    let request = VideoGenerationRequest::builder()
+        .model("google/veo-3.1")
+        .input_references(vec![VideoInputReference::image(
+            "https://example.com/reference.png",
+        )])
+        .build()
+        .expect("image-only video request should build");
+
+    let value = serde_json::to_value(request).expect("video request should serialize");
+    assert!(value.get("prompt").is_none());
+    assert_eq!(
+        value["input_references"][0]["image_url"]["url"],
+        "https://example.com/reference.png"
+    );
+}
+
+#[test]
 fn test_video_generation_response_deserialization() {
     let raw = r#"{
         "id": "job-abc123",


### PR DESCRIPTION
## Summary

- add typed chat prompt-cache controls and static prediction payloads
- expose image provider routing, conditional pricing overrides, cache-creation usage, guardrail `flag` actions, namespace-tool round trips, and image-only video requests
- refresh the accepted OpenAPI baseline and endpoint matrix for the latest 89-operation upstream spec

## Why

The weekly drift report found new stable request and response fields mixed with provider taxonomy and flexible payload changes that the SDK already supports. This types only the stable gaps and reuses the existing `String`, `Value`, plugin, and server-tool escape hatches for the rest.

Closes #236.

## Validation

- `just quality-ci`
- `just openapi-drift-check` (`added=0, removed=0, changed=0`)
- `cargo check --all-targets`
- `cargo test --test unit videos::`
