### PR TITLE
feat: accept latest OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added explicit chat prompt-cache breakpoints/options, static predicted output, image provider routing preferences, conditional model pricing overrides, detailed cache-creation usage, and custom guardrail `flag` actions.
+- Added assistant-message model annotations, BYOK budget controls for guardrails and workspace budgets, workspace default guardrail IDs, transcription speaker labels, and Anthropic compaction and dynamic-tool content blocks.
 
 ### Changed
 - Accepted the 2026-07-22 OpenAPI drift review, including optional prompts for image-only video generation, and refreshed the `89 / 89` official endpoint snapshot.
+- Accepted the 2026-07-28 OpenAPI drift review and kept provider/plugin/server-tool/Responses schema growth on the existing flexible payload surfaces.
 
 ## [0.12.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added explicit chat prompt-cache breakpoints/options, static predicted output, image provider routing preferences, conditional model pricing overrides, detailed cache-creation usage, and custom guardrail `flag` actions.
-- Added assistant-message model annotations, BYOK budget controls for guardrails and workspace budgets, workspace default guardrail IDs, transcription speaker labels, and Anthropic compaction and dynamic-tool content blocks.
+- Added assistant-message model annotations, round-tripped BYOK budget controls for guardrails and workspace budgets, workspace default guardrail IDs, transcription speaker labels, and Anthropic compaction and dynamic-tool content blocks.
 
 ### Changed
 - Accepted the 2026-07-22 OpenAPI drift review, including optional prompts for image-only video generation, and refreshed the `89 / 89` official endpoint snapshot.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 - model discovery, provider discovery, app rankings, task classifications, unified benchmarks, embeddings, and ZDR endpoints
 - typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
 - explicit chat prompt-cache breakpoints and static predictions, image provider routing controls, conditional model pricing, and image-only video generation requests
-- assistant-message model annotations, transcription speaker labels, Anthropic compaction/dynamic-tool blocks, and BYOK-aware guardrail/workspace budgets
+- assistant-message model annotations, transcription speaker labels, Anthropic compaction/dynamic-tool blocks, and round-tripped BYOK controls for guardrail/workspace budgets
 - management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace member listing/mutation, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Chat, Responses API, and Anthropic-compatible Messages request builders also exp
 - model discovery, provider discovery, app rankings, task classifications, unified benchmarks, embeddings, and ZDR endpoints
 - typed generation metadata, model voice/benchmark/link metadata, workspace I/O logging controls, video callback URL support, and file upload/download workflows
 - explicit chat prompt-cache breakpoints and static predictions, image provider routing controls, conditional model pricing, and image-only video generation requests
+- assistant-message model annotations, transcription speaker labels, Anthropic compaction/dynamic-tool blocks, and BYOK-aware guardrail/workspace budgets
 - management-key workflows for keys, workspace-scoped keys, preset reads/writes, analytics, BYOK provider credentials, observability destinations, auth codes, organization members, workspaces, workspace budgets, workspace member listing/mutation, guardrails, guardrail content filters, workspace-scoped guardrails, and activity, plus API-key-authenticated credits and generation metadata/content endpoints
 
 For deeper examples, prefer the runnable examples in [`examples/`](examples) over long README snippets.

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,6 +1,6 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-07-22
+Snapshot date: 2026-07-28
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
@@ -14,6 +14,7 @@ Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 Drift review note:
 
+- Upstream added assistant-message model annotations, BYOK-aware guardrail and workspace budget fields, workspace default guardrail IDs, transcription speaker labels, Anthropic compaction and dynamic-tool blocks, and more flexible plugin/server-tool/Responses fields. The SDK types the stable fields and continues to carry provider taxonomy, plugin options, server-tool options, and Responses payload growth through existing flexible representations.
 - Upstream added explicit chat prompt-cache controls, static predicted output, image provider routing preferences, conditional pricing overrides, detailed cache-creation usage, custom guardrail `flag` actions, namespace tools, and image-only video generation. The SDK types the stable fields and reuses its existing flexible server-tool, plugin, provider-taxonomy, and Responses payload handling for the remaining schema additions.
 - Upstream added `POST /generation/feedback`, new model/rankings filters, analytics classifier controls, verbose transcription fields, XAI ZDR policy, routed service tiers, server-tool reasoning details, and image text chunks. The SDK exposes stable fields and keeps flexible provider, Responses, and server-tool payloads where the upstream surface remains high-churn.
 - Upstream added OpenRouter server-tool variants to chat completions, Responses API, Anthropic-compatible Messages, and preset creation request schemas. The SDK now exposes `ServerTool` helpers and preserves raw `Value` escape hatches for high-churn server-tool payloads.

--- a/examples/list_workspaces.rs
+++ b/examples/list_workspaces.rs
@@ -16,7 +16,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("workspace count: {}", workspaces.total_count);
     for workspace in workspaces.data {
-        println!("{} ({})", workspace.name, workspace.slug);
+        println!(
+            "{} ({}) default guardrail: {:?}",
+            workspace.name, workspace.slug, workspace.default_guardrail_id
+        );
     }
 
     Ok(())

--- a/scripts/openapi_drift.py
+++ b/scripts/openapi_drift.py
@@ -18,7 +18,15 @@ UPSTREAM_OPENAPI_URL = "https://openrouter.ai/openapi.json"
 OPENROUTER_EXAMPLE_TOKEN_PATTERN = re.compile(r"sk-or-v1-[A-Za-z0-9_-]{20,}")
 OPENROUTER_EXAMPLE_TOKEN_PLACEHOLDER = "sk-or-v1-[REDACTED]"
 HTTP_METHODS = ("get", "post", "put", "patch", "delete", "options", "head", "trace")
-DOC_ONLY_FIELDS = {"description", "example", "examples", "externalDocs", "summary", "title"}
+DOC_ONLY_FIELDS = {
+    "description",
+    "example",
+    "examples",
+    "externalDocs",
+    "summary",
+    "title",
+    "x-hidden",
+}
 REPO_KNOWN_METADATA_PARAMETERS = frozenset(
     {
         ("header", "HTTP-Referer"),
@@ -59,7 +67,10 @@ REPO_SUPPORTED_METADATA_PARAMETER_SHAPES = {
         "x-speakeasy-name-override": "appTitle",
     },
 }
-REPO_DYNAMIC_PROVIDER_NAME_MARKERS = frozenset({"Anthropic", "Google", "OpenAI"})
+REPO_DYNAMIC_PROVIDER_NAME_MARKER_SETS = (
+    frozenset({"Anthropic", "Google", "OpenAI"}),
+    frozenset({"anthropic", "google-vertex", "openai"}),
+)
 REPO_DYNAMIC_OUTPUT_MODALITY_MARKERS = frozenset({"image", "text", "video"})
 REPO_FLEXIBLE_PROVIDER_OPTION_MARKERS = frozenset({"anthropic", "google-vertex", "openai"})
 REPO_FLEXIBLE_PROVIDER_OPTION_VALUE_SCHEMA = {
@@ -410,7 +421,10 @@ def is_repo_supported_dynamic_provider_name_enum(value: Any) -> bool:
     return (
         value.get("type") == "string"
         and value.get("x-speakeasy-unknown-values") == "allow"
-        and REPO_DYNAMIC_PROVIDER_NAME_MARKERS.issubset(string_values)
+        and any(
+            markers.issubset(string_values)
+            for markers in REPO_DYNAMIC_PROVIDER_NAME_MARKER_SETS
+        )
     )
 
 

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -1731,6 +1731,12 @@
               "null"
             ]
           },
+          "encrypted_content": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "type": {
             "enum": [
               "compaction"
@@ -2968,6 +2974,76 @@
         ],
         "type": "object"
       },
+      "AnthropicToolSearchToolBm25": {
+        "properties": {
+          "allowed_callers": {
+            "$ref": "#/components/schemas/AnthropicAllowedCallers"
+          },
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "defer_loading": {
+            "type": "boolean"
+          },
+          "name": {
+            "enum": [
+              "tool_search_tool_bm25"
+            ],
+            "type": "string"
+          },
+          "strict": {
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "tool_search_tool_bm25_20251119",
+              "tool_search_tool_bm25"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
+      "AnthropicToolSearchToolRegex": {
+        "properties": {
+          "allowed_callers": {
+            "$ref": "#/components/schemas/AnthropicAllowedCallers"
+          },
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "defer_loading": {
+            "type": "boolean"
+          },
+          "name": {
+            "enum": [
+              "tool_search_tool_regex"
+            ],
+            "type": "string"
+          },
+          "strict": {
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "tool_search_tool_regex_20251119",
+              "tool_search_tool_regex"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
       "AnthropicToolSearchToolResult": {
         "example": {
           "content": {
@@ -4072,7 +4148,7 @@
             "anthropic/*",
             "openai/gpt-4o"
           ],
-          "cost_quality_tradeoff": 7,
+          "cost_quality_tradeoff": 9,
           "enabled": true,
           "id": "auto-beta-router"
         },
@@ -4090,8 +4166,8 @@
             "type": "array"
           },
           "cost_quality_tradeoff": {
-            "description": "Balances routing between cost and quality on a 0-10 scale. The auto-beta-router ranks models for the classified task type by community spend share, then filters candidates by their average cost per generation for that task. Higher values favor cheaper models: 10 keeps only models around the cheapest 10th percentile, while 0 permits models up to the 90th percentile for cost. Defaults to 7.",
-            "example": 7,
+            "description": "Balances routing between cost and quality on a 0-10 scale. The auto-beta-router ranks models for the classified task type by community spend share, then filters candidates by their average cost per generation for that task. Higher values favor cheaper models: 10 keeps only models around the cheapest 10th percentile, while 0 permits models up to the 90th percentile for cost. Defaults to 9.",
+            "example": 9,
             "maximum": 10,
             "minimum": 0,
             "type": "integer"
@@ -4120,7 +4196,8 @@
           ],
           "cost_quality_tradeoff": 7,
           "enabled": true,
-          "id": "auto-router"
+          "id": "auto-router",
+          "pin_model": false
         },
         "properties": {
           "allowed_models": {
@@ -4151,6 +4228,11 @@
               "auto-router"
             ],
             "type": "string"
+          },
+          "pin_model": {
+            "description": "When true, reuses the model from the most recent assistant message's `model` attribute for subsequent turns. Defaults to false.",
+            "example": false,
+            "type": "boolean"
           }
         },
         "required": [
@@ -4301,6 +4383,7 @@
           "clarifai",
           "cloudflare",
           "cohere",
+          "coreweave",
           "crusoe",
           "darkbloom",
           "decart",
@@ -4333,6 +4416,7 @@
           "meta",
           "minimax",
           "mistral",
+          "modal",
           "modelrun",
           "modular",
           "moonshotai",
@@ -4354,8 +4438,10 @@
           "recraft",
           "reka",
           "relace",
+          "runway",
           "sail-research",
           "sakana",
+          "sakana-ai",
           "sambanova",
           "seed",
           "siliconflow",
@@ -4370,6 +4456,7 @@
           "venice",
           "wafer",
           "wandb",
+          "wandb-legacy",
           "xai",
           "xiaomi",
           "z-ai"
@@ -6357,6 +6444,7 @@
         "description": "Assistant message for requests and responses",
         "example": {
           "content": "The capital of France is Paris.",
+          "model": "openai/gpt-4o",
           "role": "assistant"
         },
         "properties": {
@@ -6382,6 +6470,11 @@
           },
           "images": {
             "$ref": "#/components/schemas/ChatAssistantImages"
+          },
+          "model": {
+            "description": "Model that generated this assistant message",
+            "example": "openai/gpt-4o",
+            "type": "string"
           },
           "name": {
             "description": "Optional name for the assistant",
@@ -7679,7 +7772,7 @@
             "$ref": "#/components/schemas/TraceConfig"
           },
           "user": {
-            "description": "Unique user identifier",
+            "description": "Per-end-user identifier for abuse isolation. Use a stable ID, hash, or pseudonym. When a provider requires a user identity, OpenRouter folds it into the hashed identity sent upstream and never forwards it raw. If omitted, requests use an account-level identity, so provider policy blocks can affect the whole account.",
             "example": "user-123",
             "type": "string"
           }
@@ -8620,6 +8713,11 @@
           "max_total_results": {
             "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results. Useful for controlling cost and context size in agentic loops. Defaults to 50 when not specified.",
             "example": 50,
+            "type": "integer"
+          },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
             "type": "integer"
           },
           "parameters": {
@@ -9853,6 +9951,11 @@
               "null"
             ]
           },
+          "include_byok_in_budgets": {
+            "description": "Whether BYOK (bring-your-own-key) inference spend counts toward this guardrail's limit_usd, in addition to OpenRouter credit spend. Defaults to false.",
+            "example": false,
+            "type": "boolean"
+          },
           "limit_usd": {
             "description": "Spending limit in USD",
             "example": 50,
@@ -9912,6 +10015,7 @@
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
+            "include_byok_in_budgets": false,
             "limit_usd": 50,
             "name": "My New Guardrail",
             "reset_interval": "monthly",
@@ -10214,6 +10318,7 @@
           "data": {
             "created_at": "2025-08-24T10:30:00Z",
             "created_by": "user_abc123",
+            "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
             "default_text_model": "openai/gpt-4o",
@@ -13332,6 +13437,7 @@
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
+            "include_byok_in_budgets": false,
             "limit_usd": 100,
             "name": "Production Guardrail",
             "reset_interval": "monthly",
@@ -13466,6 +13572,7 @@
           "data": {
             "created_at": "2025-08-24T10:30:00Z",
             "created_by": "user_abc123",
+            "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
             "default_text_model": "openai/gpt-4o",
@@ -13583,6 +13690,7 @@
           "id": "550e8400-e29b-41d4-a716-446655440000",
           "ignored_models": null,
           "ignored_providers": null,
+          "include_byok_in_budgets": false,
           "limit_usd": 100,
           "name": "Production Guardrail",
           "reset_interval": "monthly",
@@ -13748,6 +13856,11 @@
               "null"
             ]
           },
+          "include_byok_in_budgets": {
+            "description": "Whether BYOK (bring-your-own-key) inference spend counts toward this guardrail's limit_usd, in addition to OpenRouter credit spend.",
+            "example": false,
+            "type": "boolean"
+          },
           "limit_usd": {
             "description": "Spending limit in USD",
             "example": 100,
@@ -13782,6 +13895,7 @@
         "required": [
           "id",
           "name",
+          "include_byok_in_budgets",
           "created_at",
           "workspace_id"
         ],
@@ -16010,6 +16124,11 @@
             "example": 5,
             "type": "integer"
           },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
+            "type": "integer"
+          },
           "search_context_size": {
             "$ref": "#/components/schemas/SearchContextSizeEnum"
           },
@@ -16251,6 +16370,7 @@
               "id": "550e8400-e29b-41d4-a716-446655440000",
               "ignored_models": null,
               "ignored_providers": null,
+              "include_byok_in_budgets": false,
               "limit_usd": 100,
               "name": "Production Guardrail",
               "reset_interval": "monthly",
@@ -16478,7 +16598,8 @@
               "updated_at": "2025-08-24T15:45:00Z",
               "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
             }
-          ]
+          ],
+          "include_byok_in_budgets": false
         },
         "properties": {
           "data": {
@@ -16487,10 +16608,16 @@
               "$ref": "#/components/schemas/WorkspaceBudget"
             },
             "type": "array"
+          },
+          "include_byok_in_budgets": {
+            "description": "Whether BYOK spend is included in the workspace budgets",
+            "example": false,
+            "type": "boolean"
           }
         },
         "required": [
-          "data"
+          "data",
+          "include_byok_in_budgets"
         ],
         "type": "object"
       },
@@ -16533,6 +16660,7 @@
             {
               "created_at": "2025-08-24T10:30:00Z",
               "created_by": "user_abc123",
+              "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
               "default_image_model": "openai/dall-e-3",
               "default_provider_sort": "price",
               "default_text_model": "openai/gpt-4o",
@@ -17259,6 +17387,12 @@
                       "null"
                     ]
                   },
+                  "encrypted_content": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "type": {
                     "enum": [
                       "compaction_delta"
@@ -17350,6 +17484,12 @@
               {
                 "properties": {
                   "content": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "encrypted_content": {
                     "type": [
                       "string",
                       "null"
@@ -17899,6 +18039,12 @@
                             "null"
                           ]
                         },
+                        "encrypted_content": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "type": {
                           "enum": [
                             "compaction"
@@ -17914,6 +18060,12 @@
                     },
                     {
                       "$ref": "#/components/schemas/MessagesAdvisorToolResultBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessagesToolAdditionBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessagesToolRemovalBlock"
                     }
                   ]
                 },
@@ -18512,6 +18664,9 @@
                     "cache_control": {
                       "$ref": "#/components/schemas/AnthropicCacheControlDirective"
                     },
+                    "defer_loading": {
+                      "type": "boolean"
+                    },
                     "description": {
                       "type": "string"
                     },
@@ -18780,6 +18935,12 @@
                     "type"
                   ],
                   "type": "object"
+                },
+                {
+                  "$ref": "#/components/schemas/AnthropicToolSearchToolBm25"
+                },
+                {
+                  "$ref": "#/components/schemas/AnthropicToolSearchToolRegex"
                 }
               ]
             },
@@ -19049,9 +19210,11 @@
                   "Cerebras",
                   "Chutes",
                   "Cirrascale",
+                  "Claude Platform on AWS",
                   "Clarifai",
                   "Cloudflare",
                   "Cohere",
+                  "CoreWeave",
                   "Crucible",
                   "Crusoe",
                   "Darkbloom",
@@ -19088,6 +19251,7 @@
                   "Modular",
                   "Moonshot AI",
                   "Morph",
+                  "VoyageAI by MongoDB",
                   "NCompass",
                   "Nebius",
                   "Nex AGI",
@@ -19123,6 +19287,7 @@
                   "WandB",
                   "Quiver",
                   "Krea",
+                  "Runway",
                   "Xiaomi",
                   "xAI",
                   "Z.AI",
@@ -19302,6 +19467,182 @@
         "required": [
           "event",
           "data"
+        ],
+        "type": "object"
+      },
+      "MessagesToolAdditionBlock": {
+        "description": "Loads a previously deferred tool (declared in `tools` with `defer_loading: true`) mid-conversation without invalidating the prompt cache. Only valid in `role: \"system\"` messages. Not supported on Claude Sonnet 5 or models older than Claude Opus 4.8.",
+        "example": {
+          "tool": {
+            "name": "get_forecast",
+            "type": "tool_reference"
+          },
+          "type": "tool_addition"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "tool": {
+            "oneOf": [
+              {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "tool_reference"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "server_name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "mcp_tool_reference"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name",
+                  "server_name"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "server_name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "mcp_toolset_reference"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "server_name"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "tool_addition"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool"
+        ],
+        "type": "object"
+      },
+      "MessagesToolRemovalBlock": {
+        "description": "Removes a tool from the conversation mid-conversation without invalidating the prompt cache. Only valid in `role: \"system\"` messages. Not supported on Claude Sonnet 5 or models older than Claude Opus 4.8.",
+        "example": {
+          "tool": {
+            "name": "get_weather",
+            "type": "tool_reference"
+          },
+          "type": "tool_removal"
+        },
+        "properties": {
+          "cache_control": {
+            "$ref": "#/components/schemas/AnthropicCacheControlDirective"
+          },
+          "tool": {
+            "oneOf": [
+              {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "tool_reference"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "server_name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "mcp_tool_reference"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name",
+                  "server_name"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "server_name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "mcp_toolset_reference"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "server_name"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "tool_removal"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool"
         ],
         "type": "object"
       },
@@ -20257,6 +20598,7 @@
         "enum": [
           "end_turn",
           "max_tokens",
+          "model_context_window_exceeded",
           "stop_sequence",
           "tool_use",
           "pause_turn",
@@ -24478,7 +24820,12 @@
             "$ref": "#/components/schemas/OutputItemImageGenerationCall"
           },
           {
-            "properties": {},
+            "properties": {
+              "prompt": {
+                "description": "The prompt (possibly rewritten) that the image was generated from.",
+                "type": "string"
+              }
+            },
             "type": "object"
           }
         ],
@@ -24506,6 +24853,10 @@
             "type": "string"
           },
           "imageUrl": {
+            "type": "string"
+          },
+          "prompt": {
+            "description": "The prompt (possibly rewritten) that the image was generated from.",
             "type": "string"
           },
           "result": {
@@ -26068,7 +26419,7 @@
         "example": {
           "enabled": true,
           "id": "pareto-router",
-          "min_coding_score": 0.8,
+          "max_price": 5,
           "price_source": "prompt"
         },
         "properties": {
@@ -26082,8 +26433,15 @@
             ],
             "type": "string"
           },
+          "max_price": {
+            "description": "Maximum input price in USD per million tokens. When set, quality-tier selection (min_coding_score) is bypassed: the router computes the Pareto frontier over the top coding models and routes to the best-scoring frontier model priced at or below this cap, falling back through cheaper frontier models, then non-frontier models. Enforced against the price source given by price_source. Returns 404 when no candidate satisfies the cap.",
+            "example": 5,
+            "format": "double",
+            "minimum": 0,
+            "type": "number"
+          },
           "min_coding_score": {
-            "description": "Minimum coding quality score between 0 and 1. Maps to internal quality tiers: >= 0.66 \u2192 high (top coding models), >= 0.33 \u2192 medium (strong modern flagships), < 0.33 \u2192 low (capable coders above the median). Omit to default to the highest tier (equivalent to >= 0.66).",
+            "description": "Minimum coding quality score between 0 and 1. Maps to internal quality tiers: >= 0.66 \u2192 high (top coding models), >= 0.33 \u2192 medium (strong modern flagships), < 0.33 \u2192 low (capable coders above the median). Omit to default to the highest tier (equivalent to >= 0.66). Not used when max_price is set (price-based selection takes over).",
             "example": 0.8,
             "format": "double",
             "maximum": 1,
@@ -26091,7 +26449,7 @@
             "type": "number"
           },
           "price_source": {
-            "description": "Price source for the Pareto frontier cost axis. \"prompt\" uses catalog list price (endpoint.pricing.prompt). \"weighted_avg\" uses traffic-weighted effective input price from ClickHouse, falling back to prompt price for models without traffic data. Defaults to \"prompt\".",
+            "description": "Price source for the Pareto frontier cost axis and for enforcing max_price. \"prompt\" uses catalog list price (endpoint.pricing.prompt). \"weighted_avg\" uses traffic-weighted effective input price from ClickHouse, falling back to prompt price for models without traffic data. Defaults to \"prompt\".",
             "enum": [
               "prompt",
               "weighted_avg"
@@ -26745,6 +27103,11 @@
             "example": 5,
             "type": "integer"
           },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
+            "type": "integer"
+          },
           "search_context_size": {
             "$ref": "#/components/schemas/SearchContextSizeEnum"
           },
@@ -26778,6 +27141,11 @@
           "max_results": {
             "description": "Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, Parallel, and Perplexity engines; ignored with native provider search. Perplexity supports a maximum of 20; values above 20 are clamped.",
             "example": 5,
+            "type": "integer"
+          },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
             "type": "integer"
           },
           "search_context_size": {
@@ -26961,6 +27329,7 @@
       },
       "ProviderName": {
         "enum": [
+          "Modal",
           "AkashML",
           "AI21",
           "AionLabs",
@@ -26980,9 +27349,11 @@
           "Cerebras",
           "Chutes",
           "Cirrascale",
+          "Claude Platform on AWS",
           "Clarifai",
           "Cloudflare",
           "Cohere",
+          "CoreWeave",
           "Crucible",
           "Crusoe",
           "Darkbloom",
@@ -27019,6 +27390,7 @@
           "Modular",
           "Moonshot AI",
           "Morph",
+          "VoyageAI by MongoDB",
           "NCompass",
           "Nebius",
           "Nex AGI",
@@ -27054,6 +27426,7 @@
           "WandB",
           "Quiver",
           "Krea",
+          "Runway",
           "Xiaomi",
           "xAI",
           "Z.AI",
@@ -27167,11 +27540,19 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "claude-on-aws": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "cloudflare": {
             "additionalProperties": {},
             "type": "object"
           },
           "cohere": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "coreweave": {
             "additionalProperties": {},
             "type": "object"
           },
@@ -27471,11 +27852,19 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "runway": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "sail-research": {
             "additionalProperties": {},
             "type": "object"
           },
           "sakana": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "sakana-ai": {
             "additionalProperties": {},
             "type": "object"
           },
@@ -27551,11 +27940,19 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "voyageai": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "wafer": {
             "additionalProperties": {},
             "type": "object"
           },
           "wandb": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "wandb-legacy": {
             "additionalProperties": {},
             "type": "object"
           },
@@ -27897,9 +28294,11 @@
               "Cerebras",
               "Chutes",
               "Cirrascale",
+              "Claude Platform on AWS",
               "Clarifai",
               "Cloudflare",
               "Cohere",
+              "CoreWeave",
               "Crucible",
               "Crusoe",
               "Darkbloom",
@@ -27936,6 +28335,7 @@
               "Modular",
               "Moonshot AI",
               "Morph",
+              "VoyageAI by MongoDB",
               "NCompass",
               "Nebius",
               "Nex AGI",
@@ -27971,6 +28371,7 @@
               "WandB",
               "Quiver",
               "Krea",
+              "Runway",
               "Xiaomi",
               "xAI",
               "Z.AI",
@@ -29404,6 +29805,8 @@
             ]
           },
           "max_tool_calls": {
+            "description": "Maximum number of server-tool (e.g. `openrouter:web_search`) agent steps the model may take during a request. Defaults to 30, which is also the maximum. Ignored when `stop_server_tools_when` is set.",
+            "example": 30,
             "type": [
               "integer",
               "null"
@@ -29523,6 +29926,8 @@
             "$ref": "#/components/schemas/DeprecatedRoute"
           },
           "safety_identifier": {
+            "description": "Recommended per-end-user identifier for abuse isolation. Use a stable ID, hash, or pseudonym. When a provider requires a user identity, OpenRouter folds it into the hashed identity sent upstream and never forwards it raw. If omitted, requests use an account-level identity, so provider policy blocks can affect the whole account.",
+            "example": "user-123",
             "type": [
               "string",
               "null"
@@ -29962,6 +30367,7 @@
           "id": 0,
           "no_speech_prob": 0.01,
           "seek": 0,
+          "speaker": 0,
           "start": 0,
           "temperature": 0,
           "text": "Hello there.",
@@ -30000,6 +30406,11 @@
           },
           "seek": {
             "description": "Seek offset of the segment",
+            "example": 0,
+            "type": "integer"
+          },
+          "speaker": {
+            "description": "Speaker index for the segment, present when the provider returns diarization data",
             "example": 0,
             "type": "integer"
           },
@@ -30089,6 +30500,7 @@
         "description": "A timestamped word, returned when the provider includes word-level timestamps",
         "example": {
           "end": 0.4,
+          "speaker": 0,
           "start": 0,
           "word": "Hello"
         },
@@ -30098,6 +30510,11 @@
             "example": 0.4,
             "format": "double",
             "type": "number"
+          },
+          "speaker": {
+            "description": "Speaker index for the word, present when the provider returns diarization data",
+            "example": 0,
+            "type": "integer"
           },
           "start": {
             "description": "Word start time in seconds",
@@ -30615,7 +31032,7 @@
         "type": "object"
       },
       "StopServerToolsWhen": {
-        "description": "Stop conditions for the server-tool agent loop. Any condition firing halts the loop (OR logic). When set, this overrides `max_tool_calls`.",
+        "description": "Stop conditions for the server-tool agent loop. Any condition firing halts the loop (OR logic). When set, this overrides `max_tool_calls`. When a condition fires while the model is still emitting tool calls, the pending tool calls are executed and one final turn is made with tool calls disabled so the response ends with a natural-language answer instead of an unfinished tool call.",
         "example": [
           {
             "step_count": 5,
@@ -32802,6 +33219,11 @@
               "null"
             ]
           },
+          "include_byok_in_budgets": {
+            "description": "Whether BYOK (bring-your-own-key) inference spend counts toward this guardrail's limit_usd, in addition to OpenRouter credit spend. Omit to leave unchanged.",
+            "example": true,
+            "type": "boolean"
+          },
           "limit_usd": {
             "description": "New spending limit in USD",
             "example": 75,
@@ -32850,6 +33272,7 @@
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "ignored_models": null,
             "ignored_providers": null,
+            "include_byok_in_budgets": true,
             "limit_usd": 75,
             "name": "Updated Guardrail Name",
             "reset_interval": "weekly",
@@ -33068,6 +33491,7 @@
           "data": {
             "created_at": "2025-08-24T10:30:00Z",
             "created_by": "user_abc123",
+            "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
             "default_text_model": "openai/gpt-4o",
@@ -33102,9 +33526,15 @@
       },
       "UpsertWorkspaceBudgetRequest": {
         "example": {
+          "include_byok_in_budgets": true,
           "limit_usd": 100
         },
         "properties": {
+          "include_byok_in_budgets": {
+            "description": "Whether to include BYOK spend in the workspace budget",
+            "example": true,
+            "type": "boolean"
+          },
           "limit_usd": {
             "description": "Spending limit in USD. Must be greater than 0.",
             "example": 100,
@@ -33126,7 +33556,8 @@
             "reset_interval": "monthly",
             "updated_at": "2025-08-24T15:45:00Z",
             "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
-          }
+          },
+          "include_byok_in_budgets": true
         },
         "properties": {
           "data": {
@@ -33138,10 +33569,16 @@
                 "description": "The created or updated budget"
               }
             ]
+          },
+          "include_byok_in_budgets": {
+            "description": "Whether BYOK spend is included in the workspace budgets",
+            "example": true,
+            "type": "boolean"
           }
         },
         "required": [
-          "data"
+          "data",
+          "include_byok_in_budgets"
         ],
         "type": "object"
       },
@@ -33888,6 +34325,11 @@
             "example": 50,
             "type": "integer"
           },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
+            "type": "integer"
+          },
           "search_context_size": {
             "$ref": "#/components/schemas/SearchQualityLevel"
           },
@@ -34061,6 +34503,11 @@
             "example": 5,
             "type": "integer"
           },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
+            "type": "integer"
+          },
           "search_context_size": {
             "$ref": "#/components/schemas/SearchContextSizeEnum"
           },
@@ -34116,6 +34563,11 @@
           "max_total_results": {
             "description": "Maximum total number of search results across all search calls in a single request. Once this limit is reached, the tool will stop returning new results. Useful for controlling cost and context size in agentic loops. Defaults to 50 when not specified.",
             "example": 50,
+            "type": "integer"
+          },
+          "max_uses": {
+            "description": "Maximum number of web searches the model may perform in a single request. Once reached, further search calls return an error result instead of executing. Applies to the Exa, Firecrawl, Parallel, and Perplexity engines. With native provider search, forwarded only to Anthropic (as `max_uses`); other native search providers have no equivalent parameter and ignore it.",
+            "example": 3,
             "type": "integer"
           },
           "search_context_size": {
@@ -34277,6 +34729,7 @@
         "example": {
           "created_at": "2025-08-24T10:30:00Z",
           "created_by": "user_abc123",
+          "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
           "default_image_model": "openai/dall-e-3",
           "default_provider_sort": "price",
           "default_text_model": "openai/gpt-4o",
@@ -34304,6 +34757,12 @@
               "string",
               "null"
             ]
+          },
+          "default_guardrail_id": {
+            "description": "Deterministic ID of the workspace's implicitly-created default guardrail",
+            "example": "595d5849-7e86-51fd-a7c0-705c34e4afff",
+            "format": "uuid",
+            "type": "string"
           },
           "default_image_model": {
             "description": "Default image model for this workspace",
@@ -34396,6 +34855,7 @@
         },
         "required": [
           "id",
+          "default_guardrail_id",
           "name",
           "slug",
           "description",
@@ -36604,6 +37064,7 @@
                 "clarifai",
                 "cloudflare",
                 "cohere",
+                "coreweave",
                 "crusoe",
                 "darkbloom",
                 "decart",
@@ -36636,6 +37097,7 @@
                 "meta",
                 "minimax",
                 "mistral",
+                "modal",
                 "modelrun",
                 "modular",
                 "moonshotai",
@@ -36657,8 +37119,10 @@
                 "recraft",
                 "reka",
                 "relace",
+                "runway",
                 "sail-research",
                 "sakana",
+                "sakana-ai",
                 "sambanova",
                 "seed",
                 "siliconflow",
@@ -36673,6 +37137,7 @@
                 "venice",
                 "wafer",
                 "wandb",
+                "wandb-legacy",
                 "xai",
                 "xiaomi",
                 "z-ai"
@@ -36712,6 +37177,22 @@
               }
             },
             "description": "List of BYOK credentials"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
           },
           "401": {
             "content": {
@@ -39445,6 +39926,7 @@
         "tags": [
           "Files"
         ],
+        "x-hidden": true,
         "x-speakeasy-name-override": "list",
         "x-speakeasy-pagination": {
           "inputs": [
@@ -39632,6 +40114,7 @@
         "tags": [
           "Files"
         ],
+        "x-hidden": true,
         "x-speakeasy-name-override": "upload"
       }
     },
@@ -39746,6 +40229,7 @@
         "tags": [
           "Files"
         ],
+        "x-hidden": true,
         "x-speakeasy-name-override": "delete"
       },
       "get": {
@@ -39863,6 +40347,7 @@
         "tags": [
           "Files"
         ],
+        "x-hidden": true,
         "x-speakeasy-name-override": "retrieve"
       },
       "parameters": [
@@ -40002,6 +40487,7 @@
         "tags": [
           "Files"
         ],
+        "x-hidden": true,
         "x-speakeasy-name-override": "download"
       },
       "parameters": [
@@ -40628,6 +41114,7 @@
                       "id": "550e8400-e29b-41d4-a716-446655440000",
                       "ignored_models": null,
                       "ignored_providers": null,
+                      "include_byok_in_budgets": false,
                       "limit_usd": 100,
                       "name": "Production Guardrail",
                       "reset_interval": "monthly",
@@ -40643,6 +41130,22 @@
               }
             },
             "description": "List of guardrails"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
           },
           "401": {
             "content": {
@@ -40767,6 +41270,7 @@
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
+                    "include_byok_in_budgets": false,
                     "limit_usd": 50,
                     "name": "My New Guardrail",
                     "reset_interval": "monthly",
@@ -41234,6 +41738,7 @@
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
+                    "include_byok_in_budgets": false,
                     "limit_usd": 100,
                     "name": "Production Guardrail",
                     "reset_interval": "monthly",
@@ -41368,6 +41873,7 @@
                     "id": "550e8400-e29b-41d4-a716-446655440000",
                     "ignored_models": null,
                     "ignored_providers": null,
+                    "include_byok_in_budgets": true,
                     "limit_usd": 75,
                     "name": "Updated Guardrail Name",
                     "reset_interval": "weekly",
@@ -43342,6 +43848,22 @@
               }
             },
             "description": "List of API keys"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
           },
           "401": {
             "content": {
@@ -46335,6 +46857,22 @@
               }
             },
             "description": "List of observability destinations"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
           },
           "401": {
             "content": {
@@ -49798,6 +50336,7 @@
         },
         "summary": "Create a response",
         "tags": [
+          "responses",
           "beta.responses"
         ],
         "x-speakeasy-name-override": "send",
@@ -50347,6 +50886,7 @@
                     {
                       "created_at": "2025-08-24T10:30:00Z",
                       "created_by": "user_abc123",
+                      "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
                       "default_image_model": "openai/dall-e-3",
                       "default_provider_sort": "price",
                       "default_text_model": "openai/gpt-4o",
@@ -50468,6 +51008,7 @@
                   "data": {
                     "created_at": "2025-08-24T10:30:00Z",
                     "created_by": "user_abc123",
+                    "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
                     "default_image_model": "openai/dall-e-3",
                     "default_provider_sort": "price",
                     "default_text_model": "openai/gpt-4o",
@@ -50706,6 +51247,7 @@
                   "data": {
                     "created_at": "2025-08-24T10:30:00Z",
                     "created_by": "user_abc123",
+                    "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
                     "default_image_model": "openai/dall-e-3",
                     "default_provider_sort": "price",
                     "default_text_model": "openai/gpt-4o",
@@ -50833,6 +51375,7 @@
                   "data": {
                     "created_at": "2025-08-24T10:30:00Z",
                     "created_by": "user_abc123",
+                    "default_guardrail_id": "595d5849-7e86-51fd-a7c0-705c34e4afff",
                     "default_image_model": "openai/dall-e-3",
                     "default_provider_sort": "price",
                     "default_text_model": "openai/gpt-4o",
@@ -50975,7 +51518,8 @@
                       "updated_at": "2025-08-24T15:45:00Z",
                       "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
                     }
-                  ]
+                  ],
+                  "include_byok_in_budgets": false
                 },
                 "schema": {
                   "$ref": "#/components/schemas/ListWorkspaceBudgetsResponse"
@@ -51190,6 +51734,7 @@
           "content": {
             "application/json": {
               "example": {
+                "include_byok_in_budgets": true,
                 "limit_usd": 100
               },
               "schema": {
@@ -51211,7 +51756,8 @@
                     "reset_interval": "monthly",
                     "updated_at": "2025-08-24T15:45:00Z",
                     "workspace_id": "550e8400-e29b-41d4-a716-446655440000"
-                  }
+                  },
+                  "include_byok_in_budgets": true
                 },
                 "schema": {
                   "$ref": "#/components/schemas/UpsertWorkspaceBudgetResponse"
@@ -51892,7 +52438,11 @@
       "name": "beta.Analytics"
     },
     {
-      "description": "beta.responses endpoints",
+      "description": "responses endpoints",
+      "name": "responses"
+    },
+    {
+      "description": "Deprecated alias of responses. Use responses instead; scheduled for removal (sunset date TBD).",
       "name": "beta.responses"
     }
   ]

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-07-22T06:30:46+00:00",
+  "captured_at": "2026-07-28T01:40:56+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -128,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "df122b4b213e4637",
+      "fingerprint": "f9ffe89bf3759343",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -139,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c47fe5ab1ab6bc42",
+      "fingerprint": "0c72446afeeb6d46",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -205,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "66cd160f5d448ecc",
+      "fingerprint": "7183c24c3524d1d0",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -249,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "9a9f16bea89b5380",
+      "fingerprint": "185f4431c8460e10",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -271,7 +271,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e928dfa54aeab2ad",
+      "fingerprint": "0bf80e949ce80c57",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -304,7 +304,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a5b60660f4b866e1",
+      "fingerprint": "c0b10709c316fe7f",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -370,7 +370,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c3838b7c14319e24",
+      "fingerprint": "7d89ca7293034a15",
       "id": "GET /keys",
       "method": "GET",
       "operation_id": "list",
@@ -436,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "3275f77d033fe08c",
+      "fingerprint": "f4c01c2b71667e8d",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -447,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6ce39387b0783cb5",
+      "fingerprint": "2a704ea0d5988457",
       "id": "GET /observability/destinations",
       "method": "GET",
       "operation_id": "listObservabilityDestinations",
@@ -568,7 +568,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ec05cc681420a18b",
+      "fingerprint": "2ce1418cb2a5b1a4",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -579,7 +579,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d2ad106ff85fa1a3",
+      "fingerprint": "1daf328bed1552fc",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -590,7 +590,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6aa66e743313d6f3",
+      "fingerprint": "579f46650ccfe84c",
       "id": "GET /workspaces/{id}/budgets",
       "method": "GET",
       "operation_id": "listWorkspaceBudgets",
@@ -612,7 +612,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ddc2d44f89f6b041",
+      "fingerprint": "d1f3be28321c474c",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -623,7 +623,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d4fc4ed46a1f8fff",
+      "fingerprint": "1a8b03bcdd3d470e",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -656,7 +656,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d7421b389ed752bd",
+      "fingerprint": "789f097907b8479b",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -678,7 +678,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a670c86739e7ad4b",
+      "fingerprint": "4474f16b77c44bfb",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -689,7 +689,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "af75e16929a1c91d",
+      "fingerprint": "37bc291d4719c045",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -722,7 +722,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "152353cc61c62177",
+      "fingerprint": "e7c7ff195a04d7a9",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -733,7 +733,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "40ae1c0d5b3108e1",
+      "fingerprint": "574ff5ba68164e62",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -755,7 +755,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "27f202a6a227c097",
+      "fingerprint": "2d1b0304b523a473",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -788,7 +788,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5b22baafaa961b61",
+      "fingerprint": "f3795b1b801f3bcf",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -843,7 +843,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b49dfdce1cbe9acd",
+      "fingerprint": "312e001d1b64cfc4",
       "id": "POST /images",
       "method": "POST",
       "operation_id": "createImages",
@@ -865,7 +865,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c75a2ebf5a2f34c2",
+      "fingerprint": "bd2a664b308335d4",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -887,7 +887,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ddd6783934ab2365",
+      "fingerprint": "5f0e41417312d4e8",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -898,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b753b6dd5a3cbc17",
+      "fingerprint": "eaf8bdacd098ea32",
       "id": "POST /presets/{slug}/messages",
       "method": "POST",
       "operation_id": "createPresetsMessages",
@@ -909,7 +909,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1521522461f6c5c5",
+      "fingerprint": "c053f41120e25f22",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -920,7 +920,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ecf59cdf39f32b45",
+      "fingerprint": "dd7fdd75710d43d1",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -931,18 +931,19 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e08e2d196fdfa837",
+      "fingerprint": "6649cc0e5f208525",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
       "path": "/responses",
       "tags": [
+        "responses",
         "beta.responses"
       ]
     },
     {
       "deprecated": false,
-      "fingerprint": "1b5d7083c58deb36",
+      "fingerprint": "cd6f7076c7ce8cc5",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -953,7 +954,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "a9e2f3c55d4ab377",
+      "fingerprint": "09fa7c795c50f15a",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -986,7 +987,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "ba4cbe8acd8755a0",
+      "fingerprint": "b30971a50e5b4e36",
       "id": "PUT /workspaces/{id}/budgets/{interval}",
       "method": "PUT",
       "operation_id": "upsertWorkspaceBudget",

--- a/src/api/audio.rs
+++ b/src/api/audio.rs
@@ -174,6 +174,8 @@ pub struct TranscriptionSegment {
     pub start: f64,
     pub end: f64,
     pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<i64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tokens: Vec<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -194,6 +196,8 @@ pub struct TranscriptionWord {
     pub word: String,
     pub start: f64,
     pub end: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<i64>,
 }
 
 /// Usage metadata for audio transcription requests.

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -410,6 +410,9 @@ impl Prediction {
 pub struct Message {
     pub role: Role,
     pub content: Content,
+    /// Model that generated an assistant message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     /// Optional name for tool messages or function calls
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -426,6 +429,7 @@ impl Message {
         Self {
             role,
             content: content.into(),
+            model: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -437,6 +441,7 @@ impl Message {
         Self {
             role,
             content: Content::Parts(parts),
+            model: None,
             name: None,
             tool_call_id: None,
             tool_calls: None,
@@ -448,6 +453,7 @@ impl Message {
         Self {
             role: Role::Tool,
             content: content.into(),
+            model: None,
             name: None,
             tool_call_id: Some(tool_call_id.to_string()),
             tool_calls: None,
@@ -463,6 +469,7 @@ impl Message {
         Self {
             role: Role::Tool,
             content: content.into(),
+            model: None,
             name: Some(tool_name.to_string()),
             tool_call_id: Some(tool_call_id.to_string()),
             tool_calls: None,
@@ -474,6 +481,7 @@ impl Message {
         Self {
             role,
             content: content.into(),
+            model: None,
             name: Some(name.to_string()),
             tool_call_id: None,
             tool_calls: None,
@@ -488,10 +496,16 @@ impl Message {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            model: None,
             name: None,
             tool_call_id: None,
             tool_calls: Some(tool_calls),
         }
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
     }
 }
 

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -105,6 +105,8 @@ pub struct Guardrail {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit_usd: Option<f64>,
+    #[serde(default)]
+    pub include_byok_in_budgets: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reset_interval: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,6 +157,9 @@ pub struct CreateGuardrailRequest {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     limit_usd: Option<f64>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include_byok_in_budgets: Option<bool>,
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     reset_interval: Option<String>,
@@ -217,6 +222,8 @@ pub struct UpdateGuardrailRequest {
     description: Option<String>,
     #[builder(setter(strip_option), default)]
     limit_usd: Option<f64>,
+    #[builder(setter(strip_option), default)]
+    include_byok_in_budgets: Option<bool>,
     #[builder(setter(into, strip_option), default)]
     reset_interval: Option<String>,
     #[builder(setter(custom), default)]
@@ -267,6 +274,9 @@ impl Serialize for UpdateGuardrailRequest {
         }
         if let Some(value) = &self.limit_usd {
             map.serialize_entry("limit_usd", value)?;
+        }
+        if let Some(value) = &self.include_byok_in_budgets {
+            map.serialize_entry("include_byok_in_budgets", value)?;
         }
         if let Some(value) = &self.reset_interval {
             map.serialize_entry("reset_interval", value)?;

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -173,6 +173,28 @@ pub enum AnthropicContentPart {
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
+    Compaction {
+        content: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        encrypted_content: Option<String>,
+    },
+    AdvisorToolResult {
+        tool_use_id: String,
+        content: Value,
+    },
+    ToolReference {
+        tool_name: String,
+    },
+    ToolAddition {
+        tool: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    ToolRemoval {
+        tool: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
 }
 
 impl AnthropicContentPart {

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -283,6 +283,13 @@ impl UpsertWorkspaceBudgetRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct UpsertWorkspaceBudgetResponse {
+    pub data: WorkspaceBudget,
+    pub include_byok_in_budgets: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct DeleteWorkspaceBudgetResponse {
     deleted: bool,
 }
@@ -536,7 +543,7 @@ pub async fn upsert_workspace_budget(
     id: &str,
     interval: &str,
     request: &UpsertWorkspaceBudgetRequest,
-) -> Result<WorkspaceBudget, OpenRouterError> {
+) -> Result<UpsertWorkspaceBudgetResponse, OpenRouterError> {
     let http_client = crate::transport::new_client()?;
     upsert_workspace_budget_with_client(
         &http_client,
@@ -556,7 +563,7 @@ pub(crate) async fn upsert_workspace_budget_with_client(
     id: &str,
     interval: &str,
     request: &UpsertWorkspaceBudgetRequest,
-) -> Result<WorkspaceBudget, OpenRouterError> {
+) -> Result<UpsertWorkspaceBudgetResponse, OpenRouterError> {
     let url = format!(
         "{base_url}/workspaces/{}/budgets/{}",
         encode(id),
@@ -571,9 +578,7 @@ pub(crate) async fn upsert_workspace_budget_with_client(
     .await?;
 
     if response.status().is_success() {
-        let payload: ApiResponse<WorkspaceBudget> =
-            transport_response::parse_json_response(response, "workspace budget upsert").await?;
-        Ok(payload.data)
+        transport_response::parse_json_response(response, "workspace budget upsert").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -29,6 +29,8 @@ pub struct Workspace {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_guardrail_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_text_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_image_model: Option<String>,
@@ -260,6 +262,8 @@ pub struct WorkspaceBudget {
 #[non_exhaustive]
 pub struct ListWorkspaceBudgetsResponse {
     pub data: Vec<WorkspaceBudget>,
+    #[serde(default)]
+    pub include_byok_in_budgets: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -267,6 +271,9 @@ pub struct ListWorkspaceBudgetsResponse {
 #[non_exhaustive]
 pub struct UpsertWorkspaceBudgetRequest {
     pub limit_usd: f64,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_byok_in_budgets: Option<bool>,
 }
 
 impl UpsertWorkspaceBudgetRequest {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2480,7 +2480,7 @@ impl OpenRouterClient {
         id: &str,
         interval: &str,
         request: &workspaces::UpsertWorkspaceBudgetRequest,
-    ) -> Result<workspaces::WorkspaceBudget, OpenRouterError> {
+    ) -> Result<workspaces::UpsertWorkspaceBudgetResponse, OpenRouterError> {
         if let Some(management_key) = &self.management_key {
             workspaces::upsert_workspace_budget_with_client(
                 self.http_client(),
@@ -3549,7 +3549,7 @@ impl<'a> ManagementClient<'a> {
         id: &str,
         interval: &str,
         request: &workspaces::UpsertWorkspaceBudgetRequest,
-    ) -> Result<workspaces::WorkspaceBudget, OpenRouterError> {
+    ) -> Result<workspaces::UpsertWorkspaceBudgetResponse, OpenRouterError> {
         self.client
             .upsert_workspace_budget(id, interval, request)
             .await

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -557,6 +557,8 @@ pub struct StreamingChoice {
 pub struct Message {
     #[serde(default, deserialize_with = "deserialize_optional_text_content")]
     pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/tests/test_openapi_drift.py
+++ b/tests/test_openapi_drift.py
@@ -323,6 +323,58 @@ class OpenApiDriftReportTests(unittest.TestCase):
             ["dynamic provider name enum"],
         )
 
+    def test_dynamic_provider_slug_drift_is_classified_as_already_supported(self):
+        baseline = build_spec(
+            response_properties={
+                "provider": {
+                    "enum": ["anthropic", "google-vertex", "openai"],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow",
+                }
+            }
+        )
+        candidate = build_spec(
+            response_properties={
+                "provider": {
+                    "enum": ["anthropic", "coreweave", "google-vertex", "openai"],
+                    "type": "string",
+                    "x-speakeasy-unknown-values": "allow",
+                }
+            }
+        )
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertFalse(report["has_actionable_drift"])
+        self.assertEqual(report["repo_summary"]["already_supported_changed"], 1)
+        self.assertEqual(
+            report["changed"][0]["repo_impact"]["schema_rules"],
+            ["dynamic provider name enum"],
+        )
+
+    def test_hidden_operation_metadata_is_not_reported_as_drift(self):
+        baseline = build_spec()
+        candidate = build_spec()
+        candidate["paths"]["/models"]["get"]["x-hidden"] = True
+
+        report = openapi_drift.build_report(
+            baseline_spec=baseline,
+            candidate_spec=candidate,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            source_url="https://example.com/openapi.json",
+            max_diff_lines=20,
+        )
+
+        self.assertFalse(report["has_drift"])
+
     def test_dynamic_enum_with_object_members_does_not_crash(self):
         baseline = build_spec(
             response_properties={

--- a/tests/unit/audio.rs
+++ b/tests/unit/audio.rs
@@ -80,6 +80,30 @@ fn test_transcription_request_serialization() {
     );
 }
 
+#[test]
+fn test_transcription_speaker_labels_deserialize() {
+    let response: audio::TranscriptionResponse = serde_json::from_value(serde_json::json!({
+        "text": "Hello",
+        "segments": [{
+            "id": 0,
+            "start": 0.0,
+            "end": 0.5,
+            "text": "Hello",
+            "speaker": 1
+        }],
+        "words": [{
+            "word": "Hello",
+            "start": 0.0,
+            "end": 0.5,
+            "speaker": 1
+        }]
+    }))
+    .expect("speaker labels should deserialize");
+
+    assert_eq!(response.segments.unwrap()[0].speaker, Some(1));
+    assert_eq!(response.words.unwrap()[0].speaker, Some(1));
+}
+
 #[tokio::test]
 async fn test_create_transcription_path_body_headers_and_response() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");

--- a/tests/unit/chat_request.rs
+++ b/tests/unit/chat_request.rs
@@ -147,6 +147,16 @@ fn test_explicit_prompt_cache_and_prediction_serialize() {
 }
 
 #[test]
+fn test_assistant_message_model_roundtrip() {
+    let message = Message::new(Role::Assistant, "Hello").with_model("openai/gpt-5.6");
+    let value = serde_json::to_value(&message).expect("message should serialize");
+    assert_eq!(value["model"], "openai/gpt-5.6");
+
+    let parsed: Message = serde_json::from_value(value).expect("message should deserialize");
+    assert_eq!(parsed.model.as_deref(), Some("openai/gpt-5.6"));
+}
+
+#[test]
 fn test_multimodal_content_parts_serialize() {
     let request = ChatCompletionRequest::builder()
         .model("openai/gpt-5")

--- a/tests/unit/completion.rs
+++ b/tests/unit/completion.rs
@@ -1,4 +1,4 @@
-use openrouter_rs::types::completion::CompletionsResponse;
+use openrouter_rs::types::completion::{Choice, CompletionsResponse};
 
 /// Test deserialization of a standard non-streaming response
 #[test]
@@ -10,7 +10,8 @@ fn test_non_streaming_response_deserialization() {
             "index": 0,
             "message": {
                 "role": "assistant",
-                "content": "Hello from Rust!"
+                "content": "Hello from Rust!",
+                "model": "openai/gpt-4o"
             }
         }],
         "created": 1700000000,
@@ -28,6 +29,10 @@ fn test_non_streaming_response_deserialization() {
     assert_eq!(choice.content(), Some("Hello from Rust!"));
     assert_eq!(choice.role(), Some("assistant"));
     assert_eq!(choice.index(), Some(0));
+    let Choice::NonStreaming(choice) = choice else {
+        panic!("expected non-streaming choice");
+    };
+    assert_eq!(choice.message.model.as_deref(), Some("openai/gpt-4o"));
 }
 
 /// Test deserialization of response with index field (Grok model format)

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -113,6 +113,7 @@ fn test_create_guardrail_request_serialization() {
         .name("Production")
         .description("Production guardrail")
         .limit_usd(100.0)
+        .include_byok_in_budgets(true)
         .reset_interval("monthly")
         .allowed_providers(vec!["openai".to_string(), "anthropic".to_string()])
         .allowed_models(vec![
@@ -128,6 +129,7 @@ fn test_create_guardrail_request_serialization() {
     assert_eq!(value["name"], "Production");
     assert_eq!(value["description"], "Production guardrail");
     assert_eq!(value["limit_usd"], 100.0);
+    assert_eq!(value["include_byok_in_budgets"], true);
     assert_eq!(value["reset_interval"], "monthly");
     assert_eq!(value["allowed_providers"][0], "openai");
     assert_eq!(value["allowed_models"][1], "anthropic/claude-sonnet-4");
@@ -184,12 +186,14 @@ fn test_create_guardrail_request_serializes_content_filters_and_provider_zdr_fla
 fn test_update_guardrail_request_serialization() {
     let request = UpdateGuardrailRequest::builder()
         .name("Updated")
+        .include_byok_in_budgets(false)
         .enforce_zdr(false)
         .build()
         .expect("update guardrail request should build");
 
     let value = serde_json::to_value(&request).expect("request should serialize");
     assert_eq!(value["name"], "Updated");
+    assert_eq!(value["include_byok_in_budgets"], false);
     assert_eq!(value["enforce_zdr"], false);
     assert!(value.get("description").is_none());
     assert!(value.get("allowed_models").is_none());
@@ -315,6 +319,7 @@ fn test_guardrail_response_deserialization() {
             "name": "Production Guardrail",
             "description": "Guardrail for production traffic",
             "limit_usd": 100,
+            "include_byok_in_budgets": true,
             "reset_interval": "monthly",
             "allowed_providers": ["openai"],
             "allowed_models": ["openai/gpt-4.1"],
@@ -349,6 +354,7 @@ fn test_guardrail_response_deserialization() {
     assert_eq!(parsed.data.enforce_zdr_openai, Some(false));
     assert_eq!(parsed.data.enforce_zdr_google, Some(true));
     assert_eq!(parsed.data.enforce_zdr_other, Some(false));
+    assert!(parsed.data.include_byok_in_budgets);
     assert_eq!(
         parsed.data.content_filter_builtins.unwrap_or_default()[0].slug,
         ContentFilterBuiltinSlug::RegexPromptInjection

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -279,6 +279,52 @@ fn test_anthropic_document_file_id_part_serializes() {
 }
 
 #[test]
+fn test_anthropic_compaction_and_dynamic_tool_blocks_roundtrip() {
+    let message: AnthropicMessage = serde_json::from_value(json!({
+        "role": "system",
+        "content": [
+            {
+                "type": "compaction",
+                "content": null,
+                "encrypted_content": "enc_123"
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srvtoolu_123",
+                "content": {"type": "advisor_result", "text": "Use option A"}
+            },
+            {
+                "type": "tool_reference",
+                "tool_name": "get_weather"
+            },
+            {
+                "type": "tool_addition",
+                "tool": {
+                    "type": "mcp_tool_reference",
+                    "name": "search",
+                    "server_name": "docs"
+                }
+            },
+            {
+                "type": "tool_removal",
+                "tool": {
+                    "type": "tool_reference",
+                    "name": "get_weather"
+                }
+            }
+        ]
+    }))
+    .expect("new content blocks should deserialize");
+
+    let value = serde_json::to_value(message).expect("content blocks should serialize");
+    assert_eq!(value["content"][0]["encrypted_content"], "enc_123");
+    assert_eq!(value["content"][1]["tool_use_id"], "srvtoolu_123");
+    assert_eq!(value["content"][2]["tool_name"], "get_weather");
+    assert_eq!(value["content"][3]["tool"]["server_name"], "docs");
+    assert_eq!(value["content"][4]["type"], "tool_removal");
+}
+
+#[test]
 fn test_anthropic_messages_system_role_roundtrip() {
     let message = AnthropicMessage::system("Follow the policy.");
     let value = serde_json::to_value(&message).expect("system message should serialize");

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -226,6 +226,7 @@ fn test_workspace_response_deserialization() {
             "name": "Production",
             "slug": "production",
             "description": "Production environment",
+            "default_guardrail_id": "gr_default",
             "default_text_model": "openai/gpt-4o",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
@@ -244,6 +245,10 @@ fn test_workspace_response_deserialization() {
         serde_json::from_str(raw).expect("workspace response should deserialize");
     assert_eq!(parsed.data.id, "ws_123");
     assert_eq!(parsed.data.slug, "production");
+    assert_eq!(
+        parsed.data.default_guardrail_id.as_deref(),
+        Some("gr_default")
+    );
     assert_eq!(parsed.data.created_by.as_deref(), Some("user_123"));
     assert_eq!(parsed.data.io_logging_api_key_ids, Some(vec![101, 202]));
     assert_eq!(parsed.data.io_logging_sampling_rate, 0.5);
@@ -310,12 +315,14 @@ fn test_workspace_budget_response_deserialization() {
             "reset_interval": "monthly",
             "created_at": "2025-08-24T10:30:00Z",
             "updated_at": "2025-08-24T15:45:00Z"
-        }]
+        }],
+        "include_byok_in_budgets": true
     }"#;
 
     let parsed: workspaces::ListWorkspaceBudgetsResponse =
         serde_json::from_str(raw).expect("workspace budget list should deserialize");
     assert_eq!(parsed.data.len(), 1);
+    assert!(parsed.include_byok_in_budgets);
     assert_eq!(parsed.data[0].limit_usd, 100.0);
     assert_eq!(parsed.data[0].reset_interval.as_deref(), Some("monthly"));
 
@@ -563,6 +570,7 @@ async fn test_upsert_workspace_budget_encodes_path_and_body() {
     );
     let request = UpsertWorkspaceBudgetRequest::builder()
         .limit_usd(100.0)
+        .include_byok_in_budgets(true)
         .build()
         .expect("budget request should build");
 
@@ -587,6 +595,7 @@ async fn test_upsert_workspace_budget_encodes_path_and_body() {
     let body: serde_json::Value =
         serde_json::from_str(&captured.body_text).expect("body should be valid json");
     assert_eq!(body["limit_usd"], 100.0);
+    assert_eq!(body["include_byok_in_budgets"], true);
 
     server.join().expect("server thread should finish");
 }

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -566,7 +566,7 @@ async fn test_list_workspace_members_encodes_id_pagination_and_auth_header() {
 #[tokio::test]
 async fn test_upsert_workspace_budget_encodes_path_and_body() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"770e8400-e29b-41d4-a716-446655440000","workspace_id":"550e8400-e29b-41d4-a716-446655440000","limit_usd":100,"reset_interval":"monthly","created_at":"2025-08-24T10:30:00Z","updated_at":"2025-08-24T15:45:00Z"}}"#,
+        r#"{"data":{"id":"770e8400-e29b-41d4-a716-446655440000","workspace_id":"550e8400-e29b-41d4-a716-446655440000","limit_usd":100,"reset_interval":"monthly","created_at":"2025-08-24T10:30:00Z","updated_at":"2025-08-24T15:45:00Z"},"include_byok_in_budgets":true}"#,
     );
     let request = UpsertWorkspaceBudgetRequest::builder()
         .limit_usd(100.0)
@@ -574,7 +574,7 @@ async fn test_upsert_workspace_budget_encodes_path_and_body() {
         .build()
         .expect("budget request should build");
 
-    let budget = workspaces::upsert_workspace_budget(
+    let response = workspaces::upsert_workspace_budget(
         &base_url,
         "mgmt-key",
         "team/prod 1",
@@ -583,7 +583,8 @@ async fn test_upsert_workspace_budget_encodes_path_and_body() {
     )
     .await
     .expect("upsert workspace budget should succeed");
-    assert_eq!(budget.limit_usd, 100.0);
+    assert_eq!(response.data.limit_usd, 100.0);
+    assert!(response.include_byok_in_budgets);
 
     let captured = rx
         .recv_timeout(Duration::from_secs(2))


### PR DESCRIPTION
## Summary

- expose assistant-message model annotations, transcription speaker labels, BYOK-aware guardrail/workspace budgets, and workspace default guardrail IDs
- support Anthropic compaction, advisor results, tool references, and dynamic tool addition/removal content blocks
- treat hidden-operation metadata and extensible provider slug enums as already supported drift, then refresh the accepted 89-operation OpenAPI baseline

## Why

Issue #238 reported stable SDK fields mixed with provider taxonomy, plugin, server-tool, Responses payload, error-schema, and generator-metadata changes. This types the stable gaps while reusing the existing `String`, `Value`, flattened plugin/server-tool, and generic error handling for the rest.

The live upstream spec also added the same BYOK budget control to workspace budget responses and upsert requests after the issue artifact was captured, so that compatible follow-up is included.

Closes #238.

## Validation

- `just quality-ci`
- `python3 tests/test_openapi_drift.py`
- `just openapi-drift-check` (`added=0, removed=0, changed=0`)
