### PR TITLE
chore: prepare 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-28
+
 ### Added
 - Added explicit chat prompt-cache breakpoints/options, static predicted output, image provider routing preferences, conditional model pricing overrides, detailed cache-creation usage, and custom guardrail `flag` actions.
 - Added assistant-message model annotations, round-tripped BYOK budget controls for guardrails and workspace budgets, workspace default guardrail IDs, transcription speaker labels, and Anthropic compaction and dynamic-tool content blocks.
 
 ### Changed
+- **Breaking:** `upsert_workspace_budget(...)` now returns `UpsertWorkspaceBudgetResponse`; read the budget from `.data` and the confirmed BYOK policy from `.include_byok_in_budgets`.
+- **Breaking:** `ContentPart::Text` now carries `prompt_cache_breakpoint`; callers that construct or match the variant directly should use the provided constructors or a `..` pattern.
 - Accepted the 2026-07-22 OpenAPI drift review, including optional prompts for image-only video generation, and refreshed the `89 / 89` official endpoint snapshot.
 - Accepted the 2026-07-28 OpenAPI drift review and kept provider/plugin/server-tool/Responses schema growth on the existing flexible payload surfaces.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,10 +2,29 @@
 
 This document keeps historical migration guides intact because the repo still smoke-tests older domain/naming transitions.
 
-> Latest breaking release target: `0.9.x -> 0.10.0`.
-> `0.10.0` makes high-churn public SDK model types non-exhaustive so additive upstream OpenRouter fields and taxonomy values do not keep causing accidental source breaks.
+> Latest breaking release target: `0.12.x -> 0.13.0`.
+> `0.13.0` preserves the official workspace-budget response wrapper and adds prompt-cache metadata to text content parts.
 
-## Latest: 0.9.x -> 0.10.0
+## Latest: 0.12.x -> 0.13.0
+
+Two public return/type shapes changed to match the upstream OpenRouter schema.
+
+### Quick Checklist For 0.13.0
+
+- Read an upserted workspace budget from `response.data`; the response-level `include_byok_in_budgets` field reports the confirmed BYOK policy.
+- Replace direct `ContentPart::Text` construction with `ContentPart::text(...)`, `ContentPart::cacheable_text(...)`, or `ContentPart::cache_breakpoint_text(...)` when possible.
+- Add `..` when matching `ContentPart::Text` if the new `prompt_cache_breakpoint` field is not needed.
+
+### Breaking-Change Mapping For 0.13.0
+
+| Area | Old Usage (`0.12.x`) | New Usage (`0.13.0`) |
+| --- | --- | --- |
+| Workspace budget upsert | `let budget = client.management().upsert_workspace_budget(...).await?;` | `let response = client.management().upsert_workspace_budget(...).await?; let budget = response.data;` |
+| BYOK budget policy | Not returned by workspace budget upsert | `response.include_byok_in_budgets` |
+| Text content construction | `ContentPart::Text { text, cache_control }` | `ContentPart::text(text)` or include `prompt_cache_breakpoint` |
+| Text content matching | `ContentPart::Text { text, cache_control }` | `ContentPart::Text { text, cache_control, .. }` |
+
+## Previous breaking release: 0.9.x -> 0.10.0
 
 This release intentionally future-proofs public SDK model types that mirror upstream request, response, metadata, usage, pricing, discovery, streaming, and taxonomy shapes. The runtime JSON behavior is unchanged, but Rust source that constructed affected public structs with literals or matched affected public enums exhaustively may need small edits.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The current repo snapshot implements `89 / 89` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.12.0"
+openrouter-rs = "0.13.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -47,7 +47,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.12.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.13.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -357,7 +357,15 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 - No unreleased changes yet.
 
-### Version 0.12.0 *(Latest)*
+### Version 0.13.0 *(Latest)*
+
+- Added explicit prompt-cache controls, static predicted output, image provider routing, conditional pricing overrides, cache-creation usage details, and guardrail `flag` actions.
+- Added assistant-message model annotations, BYOK-aware guardrail/workspace budgets, workspace default guardrail IDs, transcription speaker labels, and Anthropic compaction/dynamic-tool blocks.
+- Enabled image-only video requests and kept the accepted OpenAPI snapshot at `89 / 89` through the 2026-07-28 review.
+- **Breaking:** workspace budget upserts now return `UpsertWorkspaceBudgetResponse`; read the budget from `.data`.
+- **Breaking:** direct construction or matching of `ContentPart::Text` must account for `prompt_cache_breakpoint`; prefer the provided constructors or `..` patterns.
+
+### Version 0.12.0
 
 - Added OpenRouter server-tool request helpers for chat completions, Responses API, Anthropic-compatible Messages, and preset creation request bodies.
 - Added management-key SDK support for generation feedback and workspace member listing.

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.12.0", path = "../.." }
+openrouter-rs = { version = "0.13.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/scripts/check_migration_docs.sh
+++ b/scripts/check_migration_docs.sh
@@ -51,7 +51,10 @@ require_pattern "management().create_api_key_from_auth_code(...)" "$README_PATH"
 # If MIGRATION.md exists (OR-25 and later), validate current and historical key structure.
 if [[ -f "$MIGRATION_PATH" ]]; then
   require_pattern "# Migration Guide" "$MIGRATION_PATH"
-  require_pattern "## Latest: 0.9.x -> 0.10.0" "$MIGRATION_PATH"
+  require_pattern "## Latest: 0.12.x -> 0.13.0" "$MIGRATION_PATH"
+  require_pattern "response.include_byok_in_budgets" "$MIGRATION_PATH"
+  require_pattern "ContentPart::Text { text, cache_control, .. }" "$MIGRATION_PATH"
+  require_pattern "## Previous breaking release: 0.9.x -> 0.10.0" "$MIGRATION_PATH"
   require_pattern "## Previous: 0.8.x -> 0.9.0" "$MIGRATION_PATH"
   require_pattern "## Earlier: 0.7.x -> 0.8.0" "$MIGRATION_PATH"
   require_pattern "## Historical: 0.5.x -> 0.6.0" "$MIGRATION_PATH"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.12.0"
+//! openrouter-rs = "0.13.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary

- bump openrouter-rs from 0.12.0 to 0.13.0 across the SDK release surfaces
- document prompt-cache, prediction, image routing, budget, transcription, Anthropic, video, and OpenAPI updates
- keep openrouter-cli at 0.2.0 while syncing its SDK dependency to 0.13.0

## Breaking changes

- workspace budget upserts now return UpsertWorkspaceBudgetResponse; callers read the budget from .data
- direct ContentPart::Text construction or matching must account for prompt_cache_breakpoint

## Validation

- just quality
- cargo package --locked --allow-dirty
- just quality-ci
- just openapi-drift-check (added=0, removed=0, changed=0)
- verify_release_sync.sh 0.13.0