### PR TITLE
fix: preserve streamed tool-call index and tolerate unknown finish reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Preserved streamed tool-call indices through tool-aware accumulation without inventing index `0` when providers omit the optional field, and preserved unknown finish-reason strings via `FinishReason::Other` instead of rejecting the full response frame.
+
 ## [0.13.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ### Unreleased
 
-- No unreleased changes yet.
+- Tool-aware chat streaming now preserves provider-supplied tool-call indices without inventing missing values, and `FinishReason::Other` keeps unknown provider finish reasons forward-compatible.
 
 ### Version 0.13.0 *(Latest)*
 

--- a/src/types/completion.rs
+++ b/src/types/completion.rs
@@ -509,15 +509,73 @@ impl Choice {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Why the model stopped generating.
+///
+/// OpenRouter's wire schema marks `finish_reason` as allowing unknown values
+/// (`x-speakeasy-unknown-values: allow`), so providers may stream values this
+/// SDK does not model (e.g. a legacy `"function_call"`). Deserializing such a
+/// value into a strict enum would fail the entire SSE frame, dropping its
+/// content — so unrecognized values are captured verbatim in
+/// [`FinishReason::Other`] instead.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-#[serde(rename_all = "snake_case")]
 pub enum FinishReason {
     ToolCalls,
     Stop,
     Length,
     ContentFilter,
     Error,
+    /// An upstream finish-reason value not yet modeled by this SDK.
+    ///
+    /// The raw wire string is preserved exactly as received.
+    Other(String),
+}
+
+impl FinishReason {
+    /// The wire-string form of this finish reason.
+    fn as_str(&self) -> &str {
+        match self {
+            FinishReason::ToolCalls => "tool_calls",
+            FinishReason::Stop => "stop",
+            FinishReason::Length => "length",
+            FinishReason::ContentFilter => "content_filter",
+            FinishReason::Error => "error",
+            FinishReason::Other(value) => value,
+        }
+    }
+}
+
+impl Serialize for FinishReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for FinishReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = FinishReason;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a finish reason string")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                Ok(match value {
+                    "tool_calls" => FinishReason::ToolCalls,
+                    "stop" => FinishReason::Stop,
+                    "length" => FinishReason::Length,
+                    "content_filter" => FinishReason::ContentFilter,
+                    "error" => FinishReason::Error,
+                    other => FinishReason::Other(other.to_string()),
+                })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -110,6 +110,7 @@ pub enum StreamEvent {
 /// streaming fragments.
 #[derive(Debug, Clone, Default)]
 struct ToolCallAccumulator {
+    index: Option<u32>,
     id: Option<String>,
     type_: Option<String>,
     name: Option<String>,
@@ -119,6 +120,9 @@ struct ToolCallAccumulator {
 impl ToolCallAccumulator {
     /// Merge a partial tool call fragment into this accumulator.
     fn merge(&mut self, partial: &PartialToolCall) {
+        if partial.index.is_some() {
+            self.index = partial.index;
+        }
         if let Some(id) = &partial.id {
             self.id = Some(id.clone());
         }
@@ -139,7 +143,7 @@ impl ToolCallAccumulator {
     ///
     /// Returns `None` if required fields (`id`, `name`) are still missing,
     /// which would indicate an incomplete stream.
-    fn into_tool_call(self, index: u32) -> Option<ToolCall> {
+    fn into_tool_call(self) -> Option<ToolCall> {
         Some(ToolCall {
             id: self.id?,
             type_: self.type_.unwrap_or_else(|| "function".to_string()),
@@ -147,7 +151,7 @@ impl ToolCallAccumulator {
                 name: self.name?,
                 arguments: self.arguments,
             },
-            index: Some(index),
+            index: self.index,
         })
     }
 }
@@ -270,11 +274,9 @@ impl ToolAwareStream {
 
     /// Finalize the stream: assemble complete tool calls and emit `Done`.
     fn finalize(&mut self) {
-        // Preserve the accumulation index on each assembled tool call so the
-        // caller can tell parallel tool calls apart after accumulation.
         let tool_calls: Vec<ToolCall> = std::mem::take(&mut self.tool_accumulators)
-            .into_iter()
-            .filter_map(|(index, acc)| acc.into_tool_call(index))
+            .into_values()
+            .filter_map(ToolCallAccumulator::into_tool_call)
             .collect();
 
         self.pending_events.push_back(StreamEvent::Done {

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -139,7 +139,7 @@ impl ToolCallAccumulator {
     ///
     /// Returns `None` if required fields (`id`, `name`) are still missing,
     /// which would indicate an incomplete stream.
-    fn into_tool_call(self) -> Option<ToolCall> {
+    fn into_tool_call(self, index: u32) -> Option<ToolCall> {
         Some(ToolCall {
             id: self.id?,
             type_: self.type_.unwrap_or_else(|| "function".to_string()),
@@ -147,7 +147,7 @@ impl ToolCallAccumulator {
                 name: self.name?,
                 arguments: self.arguments,
             },
-            index: None,
+            index: Some(index),
         })
     }
 }
@@ -270,11 +270,11 @@ impl ToolAwareStream {
 
     /// Finalize the stream: assemble complete tool calls and emit `Done`.
     fn finalize(&mut self) {
-        let tool_calls: Vec<ToolCall> = self
-            .tool_accumulators
-            .values()
-            .cloned()
-            .filter_map(|acc| acc.into_tool_call())
+        // Preserve the accumulation index on each assembled tool call so the
+        // caller can tell parallel tool calls apart after accumulation.
+        let tool_calls: Vec<ToolCall> = std::mem::take(&mut self.tool_accumulators)
+            .into_iter()
+            .filter_map(|(index, acc)| acc.into_tool_call(index))
             .collect();
 
         self.pending_events.push_back(StreamEvent::Done {
@@ -386,13 +386,14 @@ struct StreamMeta {
     usage: Option<Value>,
 }
 
-fn finish_reason_to_string(reason: &FinishReason) -> &'static str {
+fn finish_reason_to_string(reason: &FinishReason) -> String {
     match reason {
-        FinishReason::ToolCalls => "tool_calls",
-        FinishReason::Stop => "stop",
-        FinishReason::Length => "length",
-        FinishReason::ContentFilter => "content_filter",
-        FinishReason::Error => "error",
+        FinishReason::ToolCalls => "tool_calls".to_string(),
+        FinishReason::Stop => "stop".to_string(),
+        FinishReason::Length => "length".to_string(),
+        FinishReason::ContentFilter => "content_filter".to_string(),
+        FinishReason::Error => "error".to_string(),
+        FinishReason::Other(value) => value.clone(),
     }
 }
 
@@ -468,8 +469,7 @@ pub fn adapt_chat_stream(
                         }
 
                         if let Some(reason) = choice.finish_reason() {
-                            state.meta.finish_reason =
-                                Some(finish_reason_to_string(reason).to_string());
+                            state.meta.finish_reason = Some(finish_reason_to_string(reason));
                         }
                     }
                 }

--- a/tests/unit/completion.rs
+++ b/tests/unit/completion.rs
@@ -177,6 +177,62 @@ fn test_streaming_response_deserialization() {
     assert_eq!(choice.index(), Some(0));
 }
 
+/// OpenRouter's schema marks `finish_reason` as allowing unknown values, so a
+/// provider may stream a value this SDK does not model. The whole SSE frame
+/// must still deserialize, capturing the raw value instead of erroring.
+#[test]
+fn test_unknown_finish_reason_does_not_fail_full_frame() {
+    let json = r#"{
+        "id": "gen-stream-002",
+        "choices": [{
+            "finish_reason": "function_call",
+            "index": 0,
+            "delta": {
+                "role": "assistant",
+                "content": null
+            }
+        }],
+        "created": 1700000000,
+        "model": "test-model",
+        "object": "chat.completion.chunk"
+    }"#;
+
+    let response: CompletionsResponse = serde_json::from_str(json).expect("Failed to deserialize");
+
+    assert_eq!(response.choices.len(), 1);
+    let choice = &response.choices[0];
+    assert!(matches!(
+        choice.finish_reason(),
+        Some(openrouter_rs::types::completion::FinishReason::Other(value))
+            if value == "function_call"
+    ));
+}
+
+/// Unknown finish reasons survive a serialize round-trip and known variants
+/// keep their snake_case wire form.
+#[test]
+fn test_finish_reason_round_trip() {
+    use openrouter_rs::types::completion::FinishReason;
+
+    assert_eq!(
+        serde_json::to_string(&FinishReason::ToolCalls).unwrap(),
+        r#""tool_calls""#
+    );
+    assert_eq!(
+        serde_json::to_string(&FinishReason::Stop).unwrap(),
+        r#""stop""#
+    );
+    assert_eq!(
+        serde_json::to_string(&FinishReason::Other("max_tokens".to_string())).unwrap(),
+        r#""max_tokens""#
+    );
+
+    let parsed: FinishReason = serde_json::from_str(r#""function_call""#).unwrap();
+    assert!(matches!(parsed, FinishReason::Other(value) if value == "function_call"));
+    let known: FinishReason = serde_json::from_str(r#""length""#).unwrap();
+    assert!(matches!(known, FinishReason::Length));
+}
+
 /// Test deserialization with refusal field
 #[test]
 fn test_response_with_refusal() {

--- a/tests/unit/stream.rs
+++ b/tests/unit/stream.rs
@@ -195,12 +195,13 @@ fn content_chunk(id: &str, model: &str, content: &str) -> CompletionsResponse {
 fn tool_call_chunk(
     id: &str,
     model: &str,
-    tool_call_index: u32,
+    tool_call_index: impl Into<Option<u32>>,
     tool_id: Option<&str>,
     tool_type: Option<&str>,
     func_name: Option<&str>,
     func_args: Option<&str>,
 ) -> CompletionsResponse {
+    let tool_call_index = tool_call_index.into();
     let function = if func_name.is_some() || func_args.is_some() {
         json!({
             "name": func_name,
@@ -241,6 +242,29 @@ fn tool_call_chunk(
         "usage": null
     }))
     .expect("tool call chunk should deserialize")
+}
+
+#[tokio::test]
+async fn test_tool_aware_stream_preserves_missing_tool_call_index() {
+    let raw_stream = stream::iter(vec![Ok(tool_call_chunk(
+        "gen-1",
+        "gpt-4",
+        None,
+        Some("call_1"),
+        Some("function"),
+        Some("get_weather"),
+        Some("{}"),
+    ))])
+    .boxed();
+    let events: Vec<_> = ToolAwareStream::new(raw_stream).collect().await;
+
+    match &events[0] {
+        StreamEvent::Done { tool_calls, .. } => {
+            assert_eq!(tool_calls.len(), 1);
+            assert_eq!(tool_calls[0].index, None);
+        }
+        other => panic!("Expected Done, got {other:?}"),
+    }
 }
 
 /// Helper: create a final chunk with finish_reason and usage.

--- a/tests/unit/stream.rs
+++ b/tests/unit/stream.rs
@@ -479,10 +479,14 @@ async fn test_tool_aware_stream_parallel_tool_calls() {
             assert_eq!(tool_calls[0].id, "call_1");
             assert_eq!(tool_calls[0].function.name, "get_weather");
             assert_eq!(tool_calls[0].function.arguments, "{\"city\": \"NYC\"}");
+            // The streamed index must survive accumulation so callers can
+            // distinguish parallel tool calls.
+            assert_eq!(tool_calls[0].index, Some(0));
 
             assert_eq!(tool_calls[1].id, "call_2");
             assert_eq!(tool_calls[1].function.name, "get_time");
             assert_eq!(tool_calls[1].function.arguments, "{\"timezone\": \"EST\"}");
+            assert_eq!(tool_calls[1].index, Some(1));
         }
         other => panic!("Expected Done, got {:?}", other),
     }


### PR DESCRIPTION
## Summary

Two closely related issues in streaming/deserialization handling, both previously uncaught by tests:

### 1. `ToolAwareStream` dropped the streamed tool-call `index`
When parallel tool-call fragments were accumulated, `finalize()` iterated the accumulator map by value and `into_tool_call()` hardcoded `index: None` — even though the accumulator key *is* the index. After streaming, callers could not tell parallel tool calls apart by index.

**Fix:** thread each accumulator's index through so the assembled `ToolCall` carries `index: Some(i)`.

### 2. Strict `FinishReason` rejected unknown upstream values, killing the whole SSE frame
OpenRouter's schema lists `finish_reason` as `["tool_calls","stop","length","content_filter","error", null]` **with `x-speakeasy-unknown-values: "allow"`** — providers may legally emit values this SDK doesn't model (e.g. legacy `"function_call"`). The strict enum failed deserialization of the *entire* `CompletionsResponse` frame mid-stream, dropping that chunk's content.

**Fix:** added `FinishReason::Other(String)` with custom `Serialize`/`Deserialize` capturing unknown values verbatim; `finish_reason_to_string` (unified stream) now passes them through unchanged.

## Tests
- `tests/unit/stream.rs`: asserts `tool_calls[0].index == Some(0)` / `tool_calls[1].index == Some(1)` in the parallel-tool-calls test.
- `tests/unit/completion.rs`: a chunk with `"finish_reason":"function_call"` deserializes to `FinishReason::Other("function_call")`; serialize round-trip preserves unknown values and snake_case wire form for known variants.

## Validation
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo check --all-targets --all-features` — clean
- `cargo test --lib`, `cargo test --doc` — pass
- `cargo test --test unit`: 322 passed, 0 failed

---

*Code written by [Clark Code](https://www.clarkchat.com/clark-code).*
