### PR TITLE
feat: accept latest OpenAPI drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added management-key support for SCIM group discovery and group-role mappings through `client.management()`.
+- Added provider-aware Files queries and response types for OpenAI and Anthropic-backed file storage.
+
+### Changed
+- Accepted the 2026-08-03 OpenAPI drift review, including OpenRouter benchmark rows, optional speech voices, model alias targets, guardrail publication/training controls, and workspace BYOK budget defaults, restoring the official endpoint snapshot to `95 / 95`.
+
 ### Fixed
 - Preserved streamed tool-call indices through tool-aware accumulation without inventing index `0` when providers omit the optional field, and preserved unknown finish-reason strings via `FinishReason::Other` instead of rejecting the full response frame.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Type-safe, async Rust SDK for the OpenRouter API.
 
 `openrouter-rs` is a community-maintained Rust SDK for OpenRouter. It exposes a domain-oriented client for chat, responses, messages, rerank, audio speech/transcription, image generation, video generation, models, embeddings, files, presets, analytics, and management APIs, plus a companion CLI in the same repository.
 
-The current repo snapshot implements `89 / 89` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
+The current repo snapshot implements `95 / 95` official OpenAPI method/path entries, with published live integration coverage tracked in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md).
 
 ## Why `openrouter-rs`
 
@@ -32,7 +32,7 @@ The current repo snapshot implements `89 / 89` official OpenAPI method/path entr
 - Typed tools, manual JSON-schema tools, OpenRouter server tools, and multimodal chat content
 - Typed chat usage metadata for token counts, OpenRouter cost, provider cost breakdowns, and BYOK status
 - Opt-in OpenRouter response metadata for chat, Responses API, and Anthropic-compatible Messages requests
-- Discovery, rankings and benchmark datasets, task classifications, rerank, audio speech/transcription, image generation, video generation, files, embeddings, API-key management, preset creation/readback/versioning, analytics, BYOK provider credentials, observability destinations, workspace management, organization members, guardrails, activity, credits, and generation metadata/content coverage
+- Discovery, rankings and benchmark datasets, task classifications, rerank, audio speech/transcription, image generation, video generation, provider-backed files, embeddings, API-key management, preset creation/readback/versioning, analytics, BYOK provider credentials, observability destinations, workspace management, SCIM group mappings, organization members, guardrails, activity, credits, and generation metadata/content coverage
 - A companion CLI for profile resolution, discovery, management, and billing/usage workflows
 
 ## Installation
@@ -252,7 +252,7 @@ For copy-paste shell/CI recipes, see [`docs/operations/cli-automation-workflows.
 
 - Community-maintained third-party SDK; not affiliated with OpenRouter
 - Canonical docs and examples prefer the domain clients over older flat helpers
-- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`89 / 89`)
+- Accepted endpoint coverage is tracked against the current OpenAPI snapshot, and the current baseline is fully implemented at the SDK surface (`95 / 95`)
 - Live integration coverage and gaps are published in [`docs/operations/official-endpoint-test-matrix.md`](docs/operations/official-endpoint-test-matrix.md)
 - Migration guidance for the `0.9.x -> 0.10.0` public-model future-proofing release, the `0.8.x -> 0.9.0` audio speech release, the `0.7.x -> 0.8.0` transport/error-surface release, and the archived `0.5.x -> 0.6.x` naming guide lives in [`MIGRATION.md`](MIGRATION.md)
 - Legacy `POST /completions` support remains available behind the `legacy-completions` feature
@@ -356,6 +356,8 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 ### Unreleased
 
 - Tool-aware chat streaming now preserves provider-supplied tool-call indices without inventing missing values, and `FinishReason::Other` keeps unknown provider finish reasons forward-compatible.
+- Added SCIM group and group-role mapping management plus provider-aware Files API support.
+- Accepted the 2026-08-03 OpenAPI drift review and restored tracked endpoint coverage to `95 / 95`.
 
 ### Version 0.13.0 *(Latest)*
 

--- a/docs/operations/official-endpoint-test-matrix.md
+++ b/docs/operations/official-endpoint-test-matrix.md
@@ -1,19 +1,20 @@
 # Official Endpoint Test Matrix
 
-Snapshot date: 2026-07-28
+Snapshot date: 2026-08-03
 Source of truth: `https://openrouter.ai/openapi.json` (method+path extracted from latest spec)  
 Tracked baseline: `specs/openrouter/openapi-baseline.json`  
 Weekly drift workflow: `.github/workflows/openapi-drift.yml`
 
 ## Coverage Summary
 
-- Official OpenAPI endpoints: `89` method+path entries.
-- SDK implementation coverage (`src/api` + domain client): `89 / 89` (`100.0%`).
-- Live integration coverage (`tests/integration`): `24 / 89` endpoints currently exercised.
+- Official OpenAPI endpoints: `95` method+path entries.
+- SDK implementation coverage (`src/api` + domain client): `95 / 95` (`100.0%`).
+- Live integration coverage (`tests/integration`): `24 / 95` endpoints currently exercised.
   - Covered live now: `POST /chat/completions`, `POST /messages`, `POST /responses`, `POST /embeddings`, `POST /rerank`, `GET /key`, `GET /models`, `GET /models/user`, `GET /models/count`, `GET /models/{author}/{slug}/endpoints`, `GET /providers`, `GET /endpoints/zdr`, `GET /embeddings/models`, `GET /keys`, `POST /keys`, `GET /keys/{hash}`, `PATCH /keys/{hash}`, `DELETE /keys/{hash}`, `GET /guardrails`, `POST /guardrails`, `GET /guardrails/{id}`, `PATCH /guardrails/{id}`, `DELETE /guardrails/{id}`, `GET /organization/members`
 
 Drift review note:
 
+- Upstream added six SCIM group and group-role mapping endpoints plus provider-native Files shapes and pagination. The SDK exposes SCIM through `client.management()`, provider-backed storage through `client.files().*_for_provider(...)`, and types the stable benchmark, audio, model, guardrail, and workspace fields. High-churn provider/plugin/Responses additions continue through existing flexible representations.
 - Upstream added assistant-message model annotations, BYOK-aware guardrail and workspace budget fields, workspace default guardrail IDs, transcription speaker labels, Anthropic compaction and dynamic-tool blocks, and more flexible plugin/server-tool/Responses fields. The SDK types the stable fields and continues to carry provider taxonomy, plugin options, server-tool options, and Responses payload growth through existing flexible representations.
 - Upstream added explicit chat prompt-cache controls, static predicted output, image provider routing preferences, conditional pricing overrides, detailed cache-creation usage, custom guardrail `flag` actions, namespace tools, and image-only video generation. The SDK types the stable fields and reuses its existing flexible server-tool, plugin, provider-taxonomy, and Responses payload handling for the remaining schema additions.
 - Upstream added `POST /generation/feedback`, new model/rankings filters, analytics classifier controls, verbose transcription fields, XAI ZDR policy, routed service tiers, server-tool reasoning details, and image text chunks. The SDK exposes stable fields and keeps flexible provider, Responses, and server-tool payloads where the upstream surface remains high-churn.
@@ -78,11 +79,11 @@ Legend:
 | `POST /embeddings` | `client.create_embedding(...)` / `client.models().create_embedding(...)` | Yes | Contract | Yes | Keep |
 | `GET /embeddings/models` | `client.list_embedding_models()` / `client.models().list_embedding_models()` | Yes | Path | Yes | Keep |
 | `GET /endpoints/zdr` | `client.models().list_zdr_endpoints(...)` | Yes | Contract | Yes | Keep |
-| `GET /files` | `client.files().list(...)` | Yes | Path | No | P1 |
-| `POST /files` | `client.files().upload(...)` | Yes | Path | No | P1 |
-| `GET /files/{file_id}` | `client.files().get_metadata(...)` | Yes | Path | No | P1 |
-| `DELETE /files/{file_id}` | `client.files().delete(...)` | Yes | Path | No | P1 |
-| `GET /files/{file_id}/content` | `client.files().download_content(...)` | Yes | Path | No | P1 |
+| `GET /files` | `client.files().list(...)` / `list_for_provider(...)` | Yes | Path | No | P1 |
+| `POST /files` | `client.files().upload(...)` / `upload_for_provider(...)` | Yes | Path | No | P1 |
+| `GET /files/{file_id}` | `client.files().get_metadata(...)` / `get_metadata_for_provider(...)` | Yes | Path | No | P1 |
+| `DELETE /files/{file_id}` | `client.files().delete(...)` / `delete_for_provider(...)` | Yes | Path | No | P1 |
+| `GET /files/{file_id}/content` | `client.files().download_content(...)` / `download_content_for_provider(...)` | Yes | Path | No | P1 |
 | `GET /generation` | `client.get_generation(...)` / `client.management().get_generation(...)` | Yes | Path | No | P2 |
 | `GET /generation/content` | `client.get_generation_content(...)` / `client.management().get_generation_content(...)` | Yes | Path | No | P2 |
 | `POST /generation/feedback` | `client.management().submit_generation_feedback(...)` | Yes | Path | No | P1 |
@@ -127,6 +128,12 @@ Legend:
 | `GET /presets/{slug}/versions` | `client.management().list_preset_versions(...)` | Yes | Path | No | P2 |
 | `GET /presets/{slug}/versions/{version}` | `client.management().get_preset_version(...)` | Yes | Path | No | P2 |
 | `GET /providers` | `client.list_providers()` / `client.models().list_providers()` | Yes | Contract | Yes | Keep |
+| `GET /scim/groups` | `client.management().list_scim_groups(...)` | Yes | Path | No | P1 |
+| `GET /scim/group-mappings` | `client.management().list_scim_group_mappings(...)` | Yes | Path | No | P1 |
+| `POST /scim/group-mappings` | `client.management().create_scim_group_mapping(...)` | Yes | Path | No | P1 |
+| `GET /scim/group-mappings/{id}` | `client.management().get_scim_group_mapping(...)` | Yes | Path | No | P1 |
+| `PATCH /scim/group-mappings/{id}` | `client.management().update_scim_group_mapping(...)` | Yes | Path | No | P1 |
+| `DELETE /scim/group-mappings/{id}` | `client.management().delete_scim_group_mapping(...)` | Yes | Path | No | P1 |
 | `GET /workspaces` | `client.management().list_workspaces(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}` | `client.management().get_workspace(...)` | Yes | Path | No | P1 |
 | `GET /workspaces/{id}/budgets` | `client.management().list_workspace_budgets(...)` | Yes | Path | No | P1 |
@@ -167,7 +174,7 @@ The endpoints below are intentionally kept as legacy compatibility and are not p
 4. P2: keep `/credits`, `/credits/coinbase`, `/generation`, `/generation/content`, `/datasets*`, `/benchmarks`, `/model/{author}/{slug}`, `/presets*`, and `/auth/keys*` as controlled scenarios (manual or mocked contract-first) due rate limits, cost, or side effects.
 5. P1/P2: add low-cost live or smoke coverage for `/audio/speech`, `/audio/transcriptions`, `/images*`, and `/videos*` once stable fixtures and cost controls are defined.
 6. P1: add management-key live validation for `/workspaces*`, plus targeted workspace-scoped read/write coverage for `/keys` and `/guardrails`.
-7. P1: add management-key live validation for `/byok*` and `/observability/destinations*` once safe test credentials and destination fixtures are defined.
+7. P1: add management-key live validation for `/byok*`, `/observability/destinations*`, and `/scim*` once safe credentials and fixtures are defined.
 
 ## Reproduce Snapshot
 

--- a/examples/list_scim_groups.rs
+++ b/examples/list_scim_groups.rs
@@ -1,0 +1,14 @@
+use openrouter_rs::OpenRouterClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = OpenRouterClient::builder()
+        .management_key(std::env::var("OPENROUTER_MANAGEMENT_KEY")?)
+        .build()?;
+
+    for group in client.management().list_scim_groups(None).await?.data {
+        println!("{}\t{}", group.id, group.display_name);
+    }
+
+    Ok(())
+}

--- a/specs/openrouter/openapi-baseline.json
+++ b/specs/openrouter/openapi-baseline.json
@@ -2032,9 +2032,96 @@
         ],
         "type": "object"
       },
+      "AnthropicFile": {
+        "description": "A stored file in Anthropic's Files API shape.",
+        "example": {
+          "_shape": "anthropic",
+          "created_at": "2025-01-01T00:00:00Z",
+          "downloadable": false,
+          "filename": "document.pdf",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "mime_type": "application/pdf",
+          "size_bytes": 1024000,
+          "type": "file"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "anthropic"
+            ],
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "downloadable": {
+            "type": "boolean"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "size_bytes": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "id",
+          "type",
+          "filename",
+          "mime_type",
+          "size_bytes",
+          "created_at",
+          "downloadable"
+        ],
+        "type": "object"
+      },
+      "AnthropicFileDeleted": {
+        "description": "Deletion result in Anthropic's shape.",
+        "example": {
+          "_shape": "anthropic",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "type": "file_deleted"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "anthropic"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file_deleted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
       "AnthropicFileDocumentSource": {
         "example": {
-          "file_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "file_id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
           "type": "file"
         },
         "properties": {
@@ -2051,6 +2138,53 @@
         "required": [
           "type",
           "file_id"
+        ],
+        "type": "object"
+      },
+      "AnthropicFileList": {
+        "description": "A page of files in Anthropic's shape.",
+        "example": {
+          "_shape": "anthropic",
+          "data": [],
+          "first_id": null,
+          "has_more": false,
+          "last_id": null
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "anthropic"
+            ],
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AnthropicFile"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "last_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "_shape",
+          "data",
+          "has_more",
+          "first_id",
+          "last_id"
         ],
         "type": "object"
       },
@@ -4146,10 +4280,13 @@
         "example": {
           "allowed_models": [
             "anthropic/*",
+            "openai/*"
+          ],
+          "cost_tier": "low",
+          "enabled": true,
+          "excluded_models": [
             "openai/gpt-4o"
           ],
-          "cost_quality_tradeoff": 9,
-          "enabled": true,
           "id": "auto-beta-router"
         },
         "properties": {
@@ -4166,15 +4303,40 @@
             "type": "array"
           },
           "cost_quality_tradeoff": {
-            "description": "Balances routing between cost and quality on a 0-10 scale. The auto-beta-router ranks models for the classified task type by community spend share, then filters candidates by their average cost per generation for that task. Higher values favor cheaper models: 10 keeps only models around the cheapest 10th percentile, while 0 permits models up to the 90th percentile for cost. Defaults to 9.",
+            "deprecated": true,
+            "description": "Deprecated: Use cost_tier instead. Balances routing between cost and quality on a 0-10 scale. The auto-beta-router ranks models for the classified task type by community spend share, then filters candidates by their average cost per generation for that task. Higher values favor cheaper models: 10 keeps only models around the cheapest 10th percentile, while 0 permits models up to the 90th percentile for cost. Defaults to 9. Numeric cost_quality_tradeoff remains supported, retains ceiling behavior, and takes precedence over cost_tier when both are provided.",
             "example": 9,
             "maximum": 10,
             "minimum": 0,
             "type": "integer"
           },
+          "cost_tier": {
+            "description": "Named cost/quality setting. For auto-beta-router, tiers select cost-percentile bands: low = [0, 20), medium = [20, 40), high = [40, 60), xhigh = [60, 80), and max = [80, 100]. Numeric cost_quality_tradeoff takes precedence and retains ceiling behavior.",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "example": "low",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
           "enabled": {
             "description": "Set to false to disable the auto-beta-router plugin for this request. Defaults to true.",
             "type": "boolean"
+          },
+          "excluded_models": {
+            "description": "List of model patterns to exclude from auto-beta-router selection. Supports wildcards (e.g., \"meta-llama/*\" excludes all Llama models). Applied after allowed_models, so an excluded pattern always wins over an allowed one.",
+            "example": [
+              "openai/gpt-4o",
+              "meta-llama/*"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "id": {
             "enum": [
@@ -4192,10 +4354,13 @@
         "example": {
           "allowed_models": [
             "anthropic/*",
+            "openai/*"
+          ],
+          "cost_tier": "medium",
+          "enabled": true,
+          "excluded_models": [
             "openai/gpt-4o"
           ],
-          "cost_quality_tradeoff": 7,
-          "enabled": true,
           "id": "auto-router",
           "pin_model": false
         },
@@ -4213,15 +4378,40 @@
             "type": "array"
           },
           "cost_quality_tradeoff": {
-            "description": "Controls cost vs. quality routing tradeoff (0\u201310). 0 = pure quality (best model regardless of cost), 10 = maximize for cost (cheapest model wins). Intermediate values blend quality and cost signals continuously. Defaults to 7.",
+            "deprecated": true,
+            "description": "Deprecated: Use cost_tier instead. Controls cost vs. quality routing tradeoff (0\u201310). 0 = pure quality (best model regardless of cost), 10 = maximize for cost (cheapest model wins). Intermediate values blend quality and cost signals continuously. Defaults to 7. Numeric cost_quality_tradeoff remains supported and takes precedence over cost_tier when both are provided.",
             "example": 7,
             "maximum": 10,
             "minimum": 0,
             "type": "integer"
           },
+          "cost_tier": {
+            "description": "Shorthand for cost_quality_tradeoff. Higher tiers spend more on better models: low = 9, medium = 7, high = 5, xhigh = 3, and max = 1. Numeric cost_quality_tradeoff takes precedence when both are provided.",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "example": "medium",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
           "enabled": {
             "description": "Set to false to disable the auto-router plugin for this request. Defaults to true.",
             "type": "boolean"
+          },
+          "excluded_models": {
+            "description": "List of model patterns to exclude from auto-router selection. Supports wildcards (e.g., \"meta-llama/*\" excludes all Llama models). Applied after allowed_models, so an excluded pattern always wins over an allowed one.",
+            "example": [
+              "openai/gpt-4o",
+              "meta-llama/*"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "id": {
             "enum": [
@@ -4451,6 +4641,7 @@
           "switchpoint",
           "tencent",
           "tenstorrent",
+          "thinkingmachines",
           "together",
           "upstage",
           "venice",
@@ -7652,10 +7843,11 @@
             ]
           },
           "service_tier": {
-            "description": "The service tier to use for processing this request.",
+            "description": "The service tier to use for processing this request. `fast` is accepted as an alias for `priority`.",
             "enum": [
               "auto",
               "default",
+              "fast",
               "flex",
               "priority",
               "scale",
@@ -8694,7 +8886,7 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, and xAI. Not supported with OpenAI (silently ignored). Cannot be used with allowed_domains.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, OpenAI, and xAI. Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
@@ -9874,6 +10066,30 @@
               "null"
             ]
           },
+          "enable_free_model_publication": {
+            "description": "Whether this guardrail allows free endpoints that publish prompts.",
+            "example": false,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_free_model_training": {
+            "description": "Whether this guardrail allows free endpoints that train on request data.",
+            "example": true,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_paid_model_training": {
+            "description": "Whether this guardrail allows paid endpoints that train on request data.",
+            "example": true,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "enforce_zdr": {
             "deprecated": true,
             "description": "Deprecated. Use enforce_zdr_anthropic, enforce_zdr_openai, enforce_zdr_google, enforce_zdr_xai, and enforce_zdr_other instead. When provided, its value is copied into any of those per-provider fields that are not explicitly specified on the request.",
@@ -10216,6 +10432,43 @@
         ],
         "type": "object"
       },
+      "CreateScimGroupMappingRequest": {
+        "properties": {
+          "role": {
+            "enum": [
+              "admin",
+              "member"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "scim_group_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "workspace_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scim_group_id",
+          "workspace_id",
+          "role"
+        ],
+        "type": "object"
+      },
+      "CreateScimGroupMappingResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ScimGroupMapping"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "CreateWorkspaceRequest": {
         "example": {
           "default_image_model": "openai/dall-e-3",
@@ -10324,6 +10577,7 @@
             "default_text_model": "openai/gpt-4o",
             "description": "Production environment workspace",
             "id": "550e8400-e29b-41d4-a716-446655440000",
+            "include_byok_in_budgets": false,
             "io_logging_api_key_ids": null,
             "io_logging_sampling_rate": 1,
             "is_data_discount_logging_enabled": true,
@@ -10869,6 +11123,18 @@
         ],
         "type": "object"
       },
+      "DeleteScimGroupMappingResponse": {
+        "properties": {
+          "deleted": {
+            "const": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
       "DeleteWorkspaceBudgetResponse": {
         "example": {
           "deleted": true
@@ -11287,133 +11553,61 @@
         "type": "object"
       },
       "FileDeleteResponse": {
-        "description": "Confirmation that a file was deleted.",
+        "description": "Confirmation that a file was deleted, in the negotiated shape.",
+        "discriminator": {
+          "mapping": {
+            "anthropic": "#/components/schemas/AnthropicFileDeleted",
+            "openai": "#/components/schemas/OpenAIFileDeleted",
+            "openrouter": "#/components/schemas/OpenRouterFileDeleted"
+          },
+          "propertyName": "_shape"
+        },
         "example": {
-          "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "_shape": "openrouter",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
           "type": "file_deleted"
         },
-        "properties": {
-          "id": {
-            "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenRouterFileDeleted"
           },
-          "type": {
-            "enum": [
-              "file_deleted"
-            ],
-            "type": "string"
+          {
+            "$ref": "#/components/schemas/OpenAIFileDeleted"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicFileDeleted"
           }
-        },
-        "required": [
-          "id",
-          "type"
-        ],
-        "type": "object"
+        ]
       },
       "FileListResponse": {
-        "description": "A page of files belonging to the requesting workspace.",
+        "description": "A page of files, in the negotiated shape.",
+        "discriminator": {
+          "mapping": {
+            "anthropic": "#/components/schemas/AnthropicFileList",
+            "openai": "#/components/schemas/OpenAIFileList",
+            "openrouter": "#/components/schemas/OpenRouterFileList"
+          },
+          "propertyName": "_shape"
+        },
         "example": {
+          "_shape": "openrouter",
           "cursor": null,
-          "data": [
-            {
-              "created_at": "2025-01-01T00:00:00Z",
-              "downloadable": false,
-              "filename": "document.pdf",
-              "id": "file_011CNha8iCJcU1wXNR6q4V8w",
-              "mime_type": "application/pdf",
-              "size_bytes": 1024000,
-              "type": "file"
-            }
-          ],
-          "first_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "data": [],
+          "first_id": null,
           "has_more": false,
-          "last_id": "file_011CNha8iCJcU1wXNR6q4V8w"
+          "last_id": null
         },
-        "properties": {
-          "cursor": {
-            "description": "Opaque cursor for the next page; null when there are no more results.",
-            "type": [
-              "string",
-              "null"
-            ]
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenRouterFileList"
           },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/FileMetadata"
-            },
-            "type": "array"
+          {
+            "$ref": "#/components/schemas/OpenAIFileList"
           },
-          "first_id": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "has_more": {
-            "type": "boolean"
-          },
-          "last_id": {
-            "type": [
-              "string",
-              "null"
-            ]
+          {
+            "$ref": "#/components/schemas/AnthropicFileList"
           }
-        },
-        "required": [
-          "data",
-          "has_more",
-          "first_id",
-          "last_id",
-          "cursor"
-        ],
-        "type": "object"
-      },
-      "FileMetadata": {
-        "description": "Metadata describing a stored file.",
-        "example": {
-          "created_at": "2025-01-01T00:00:00Z",
-          "downloadable": false,
-          "filename": "document.pdf",
-          "id": "file_011CNha8iCJcU1wXNR6q4V8w",
-          "mime_type": "application/pdf",
-          "size_bytes": 1024000,
-          "type": "file"
-        },
-        "properties": {
-          "created_at": {
-            "type": "string"
-          },
-          "downloadable": {
-            "type": "boolean"
-          },
-          "filename": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "mime_type": {
-            "type": "string"
-          },
-          "size_bytes": {
-            "type": "integer"
-          },
-          "type": {
-            "enum": [
-              "file"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "type",
-          "filename",
-          "mime_type",
-          "size_bytes",
-          "created_at",
-          "downloadable"
-        ],
-        "type": "object"
+        ]
       },
       "FileParserPlugin": {
         "example": {
@@ -11469,6 +11663,48 @@
           "index"
         ],
         "type": "object"
+      },
+      "FileProvider": {
+        "description": "Store or read this file on the named provider using your own API key for it. Omit to use OpenRouter storage.",
+        "enum": [
+          "openai",
+          "anthropic"
+        ],
+        "example": "openai",
+        "type": "string",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "FileResponse": {
+        "description": "A stored file. The shape is negotiated per request \u2014 see the endpoint description.",
+        "discriminator": {
+          "mapping": {
+            "anthropic": "#/components/schemas/AnthropicFile",
+            "openai": "#/components/schemas/OpenAIFile",
+            "openrouter": "#/components/schemas/OpenRouterFile"
+          },
+          "propertyName": "_shape"
+        },
+        "example": {
+          "_shape": "openrouter",
+          "created_at": "2025-01-01T00:00:00Z",
+          "downloadable": false,
+          "filename": "document.pdf",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "mime_type": "application/pdf",
+          "size_bytes": 1024000,
+          "type": "file"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenRouterFile"
+          },
+          {
+            "$ref": "#/components/schemas/OpenAIFile"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicFile"
+          }
+        ]
       },
       "FileSearchServerTool": {
         "description": "File search tool configuration",
@@ -11988,7 +12224,7 @@
         "type": "object"
       },
       "FusionAnalysisResult": {
-        "description": "Structured analysis produced by the fusion judge model.",
+        "description": "Structured analysis produced by the fusion analyst model.",
         "example": {
           "blind_spots": [
             "No model considered the impact on existing API consumers."
@@ -12122,7 +12358,7 @@
         "type": "object"
       },
       "FusionCallAnalysisCompletedEvent": {
-        "description": "Emitted when the fusion judge completes with the structured analysis.",
+        "description": "Emitted when the fusion analyst completes with the structured analysis.",
         "example": {
           "analysis": {
             "blind_spots": [],
@@ -12166,8 +12402,9 @@
         "type": "object"
       },
       "FusionCallAnalysisInProgressEvent": {
-        "description": "Emitted when the fusion judge starts producing the structured analysis.",
+        "description": "Emitted when the fusion analyst starts producing the structured analysis.",
         "example": {
+          "analyst_model": "openai/gpt-5",
           "item_id": "st_fusion_abc",
           "judge_model": "openai/gpt-5",
           "output_index": 0,
@@ -12175,10 +12412,16 @@
           "type": "response.fusion_call.analysis.in_progress"
         },
         "properties": {
+          "analyst_model": {
+            "description": "Slug of the model producing the structured analysis.",
+            "type": "string"
+          },
           "item_id": {
             "type": "string"
           },
           "judge_model": {
+            "deprecated": true,
+            "description": "Deprecated alias of `analyst_model`, kept so existing consumers keep working. Always carries the same value. Use `analyst_model`.",
             "type": "string"
           },
           "output_index": {
@@ -12196,6 +12439,7 @@
         },
         "required": [
           "type",
+          "analyst_model",
           "judge_model",
           "output_index",
           "item_id",
@@ -12496,7 +12740,7 @@
         },
         "properties": {
           "analysis_models": {
-            "description": "Slugs of models to run in parallel as the \"expert panel\" the judge analyzes. Each model receives the same user prompt with web_search + web_fetch enabled. Capped at 8 models to bound cost amplification. When omitted, defaults to the Quality preset from the /labs/fusion UI (~anthropic/claude-opus-latest, ~openai/gpt-latest, ~google/gemini-pro-latest).",
+            "description": "Slugs of models to run in parallel as the \"expert panel\" the analyst analyzes. Each model receives the same user prompt with web_search + web_fetch enabled. Capped at 8 models to bound cost amplification. When omitted, defaults to the Quality preset from the /labs/fusion UI (~anthropic/claude-opus-latest, ~openai/gpt-latest, ~google/gemini-pro-latest).",
             "example": [
               "~anthropic/claude-opus-latest",
               "~openai/gpt-latest",
@@ -12520,19 +12764,19 @@
             "type": "string"
           },
           "max_tool_calls": {
-            "description": "Maximum number of tool-calling steps each panelist (analysis model) and the judge model may take during their agentic web-research loop. Models with web_search/web_fetch enabled iterate until they produce a text response or hit this ceiling. Defaults to 8. Capped at 16.",
+            "description": "Maximum number of tool-calling steps each panelist (analysis model) and the analyst model may take during their agentic web-research loop. Models with web_search/web_fetch enabled iterate until they produce a text response or hit this ceiling. Defaults to 8. Capped at 16.",
             "example": 12,
             "maximum": 16,
             "minimum": 1,
             "type": "integer"
           },
           "model": {
-            "description": "Slug of the model that performs both the judge step (with web_search + web_fetch) and the final synthesis. When omitted, defaults to the first model in the Quality preset.",
+            "description": "Slug of the model that performs both the analyst step (with web_search + web_fetch) and the final synthesis. When omitted, defaults to the first model in the Quality preset.",
             "example": "~anthropic/claude-opus-latest",
             "type": "string"
           },
           "preset": {
-            "description": "A curated OpenRouter fusion preset (slugs follow `<task>-<tier>`, e.g. `general-high`). Expands server-side into the preset's analysis_models panel and judge model, so callers never name individual models. Explicitly provided `analysis_models` / `model` take precedence.",
+            "description": "A curated OpenRouter fusion preset (slugs follow `<task>-<tier>`, e.g. `general-high`). Expands server-side into the preset's analysis_models panel and analyst model, so callers never name individual models. Explicitly provided `analysis_models` / `model` take precedence.",
             "enum": [
               "general-high",
               "general-budget",
@@ -12543,7 +12787,7 @@
             "x-speakeasy-unknown-values": "allow"
           },
           "tools": {
-            "description": "Server tools available to panelist and judge inner calls. Each entry uses the same `{ type, parameters? }` shorthand as the outer Chat Completions request. When omitted, defaults to `[{ type: \"openrouter:web_search\" }, { type: \"openrouter:web_fetch\" }]`. Pass an empty array to disable tools entirely (panelists answer from parametric knowledge only).",
+            "description": "Server tools available to panelist and analyst inner calls. Each entry uses the same `{ type, parameters? }` shorthand as the outer Chat Completions request. When omitted, defaults to `[{ type: \"openrouter:web_search\" }, { type: \"openrouter:web_fetch\" }]`. Pass an empty array to disable tools entirely (panelists answer from parametric knowledge only).",
             "example": [
               {
                 "parameters": {
@@ -12659,7 +12903,7 @@
         },
         "properties": {
           "analysis_models": {
-            "description": "Slugs of models to run in parallel as the analysis panel. Each model receives the user prompt with openrouter:web_search and openrouter:web_fetch enabled, then a judge model summarizes the collective output into structured analysis JSON. Capped at 8 models to bound cost amplification. Defaults to the Quality preset from /labs/fusion.",
+            "description": "Slugs of models to run in parallel as the analysis panel. Each model receives the user prompt with openrouter:web_search and openrouter:web_fetch enabled, then an analyst model summarizes the collective output into structured analysis JSON. Capped at 8 models to bound cost amplification. Defaults to the Quality preset from /labs/fusion.",
             "example": [
               "~anthropic/claude-opus-latest",
               "~openai/gpt-latest",
@@ -12676,27 +12920,27 @@
             "$ref": "#/components/schemas/AnthropicCacheControlDirective"
           },
           "max_completion_tokens": {
-            "description": "Maximum number of output tokens (including reasoning tokens) each panelist and the judge model may produce per inner call. Controls the total output budget so reasoning-heavy models like GPT-5.5 do not exhaust their token allowance before producing visible text. When omitted, panelists default to 32000 and the judge to 20000.",
+            "description": "Maximum number of output tokens (including reasoning tokens) each panelist and the analyst model may produce per inner call. Controls the total output budget so reasoning-heavy models like GPT-5.5 do not exhaust their token allowance before producing visible text. When omitted, panelists default to 32000 and the analyst to 20000.",
             "example": 16384,
             "type": "integer"
           },
           "max_tool_calls": {
-            "description": "Maximum number of tool-calling steps each panelist (analysis model) and the judge model may take during their agentic web-research loop. Models with web_search/web_fetch enabled iterate until they produce a text response or hit this ceiling. Defaults to 8. Capped at 16.",
+            "description": "Maximum number of tool-calling steps each panelist (analysis model) and the analyst model may take during their agentic web-research loop. Models with web_search/web_fetch enabled iterate until they produce a text response or hit this ceiling. Defaults to 8. Capped at 16.",
             "example": 12,
             "maximum": 16,
             "minimum": 1,
             "type": "integer"
           },
           "model": {
-            "description": "Slug of the judge model that produces the structured analysis JSON. Defaults to the model used in the outer API request.",
+            "description": "Slug of the analyst model that produces the structured analysis JSON. Defaults to the model used in the outer API request.",
             "example": "~anthropic/claude-opus-latest",
             "type": "string"
           },
           "reasoning": {
-            "description": "Reasoning configuration forwarded to panelist and judge inner calls. Use this to control reasoning effort and token budget for models that support extended thinking.",
+            "description": "Reasoning configuration forwarded to panelist and analyst inner calls. Use this to control reasoning effort and token budget for models that support extended thinking.",
             "properties": {
               "effort": {
-                "description": "Reasoning effort level for panelist and judge inner calls.",
+                "description": "Reasoning effort level for panelist and analyst inner calls.",
                 "enum": [
                   "max",
                   "xhigh",
@@ -12710,20 +12954,20 @@
                 "x-speakeasy-unknown-values": "allow"
               },
               "max_tokens": {
-                "description": "Maximum number of reasoning tokens each panelist and judge model may use. Helps bound cost when models allocate too much budget to chain-of-thought.",
+                "description": "Maximum number of reasoning tokens each panelist and analyst model may use. Helps bound cost when models allocate too much budget to chain-of-thought.",
                 "type": "integer"
               }
             },
             "type": "object"
           },
           "temperature": {
-            "description": "Temperature forwarded to panelist inner calls. The judge always runs at temperature 0 regardless of this value. When omitted, the provider's default applies.",
+            "description": "Temperature forwarded to panelist inner calls. The analyst always runs at temperature 0 regardless of this value. When omitted, the provider's default applies.",
             "example": 0.7,
             "format": "double",
             "type": "number"
           },
           "tools": {
-            "description": "Server tools available to panelist and judge inner calls. Each entry uses the same `{ type, parameters? }` shorthand as the outer Chat Completions request. When omitted, defaults to `[{ type: \"openrouter:web_search\" }, { type: \"openrouter:web_fetch\" }]`. Pass an empty array to disable tools entirely (panelists answer from parametric knowledge only).",
+            "description": "Server tools available to panelist and analyst inner calls. Each entry uses the same `{ type, parameters? }` shorthand as the outer Chat Completions request. When omitted, defaults to `[{ type: \"openrouter:web_search\" }, { type: \"openrouter:web_fetch\" }]`. Pass an empty array to disable tools entirely (panelists answer from parametric knowledge only).",
             "example": [
               {
                 "parameters": {
@@ -12761,7 +13005,7 @@
         "type": "object"
       },
       "FusionServerTool_OpenRouter": {
-        "description": "OpenRouter built-in server tool: fans out the user prompt to a panel of analysis models, then asks a judge model to summarize their collective output as structured JSON the outer model can synthesize from.",
+        "description": "OpenRouter built-in server tool: fans out the user prompt to a panel of analysis models, then asks an analyst model to summarize their collective output as structured JSON the outer model can synthesize from.",
         "example": {
           "parameters": {
             "analysis_models": [
@@ -12799,7 +13043,7 @@
             "type": "string"
           },
           "url": {
-            "description": "URL of the web page a panel or the judge retrieved during the run.",
+            "description": "URL of the web page a panel or the analyst retrieved during the run.",
             "type": "string"
           }
         },
@@ -13024,10 +13268,11 @@
                 "type": "string"
               },
               "data_region": {
-                "description": "The data region this generation was routed through. 'europe' for EU-routed requests, 'global' otherwise.",
+                "description": "The data region this generation was routed through: 'global', 'europe', or 'us'.",
                 "enum": [
                   "global",
-                  "europe"
+                  "europe",
+                  "us"
                 ],
                 "example": "global",
                 "type": "string",
@@ -13567,6 +13812,17 @@
         ],
         "type": "object"
       },
+      "GetScimGroupMappingResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ScimGroupMapping"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "GetWorkspaceResponse": {
         "example": {
           "data": {
@@ -13578,6 +13834,7 @@
             "default_text_model": "openai/gpt-4o",
             "description": "Production environment workspace",
             "id": "550e8400-e29b-41d4-a716-446655440000",
+            "include_byok_in_budgets": false,
             "io_logging_api_key_ids": null,
             "io_logging_sampling_rate": 1,
             "is_data_discount_logging_enabled": true,
@@ -13681,6 +13938,9 @@
           "content_filters": null,
           "created_at": "2025-08-24T10:30:00Z",
           "description": "Guardrail for production environment",
+          "enable_free_model_publication": false,
+          "enable_free_model_training": true,
+          "enable_paid_model_training": true,
           "enforce_zdr": null,
           "enforce_zdr_anthropic": true,
           "enforce_zdr_google": false,
@@ -13772,6 +14032,30 @@
             "example": "Guardrail for production environment",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "enable_free_model_publication": {
+            "description": "Whether this guardrail allows free endpoints that publish prompts.",
+            "example": false,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_free_model_training": {
+            "description": "Whether this guardrail allows free endpoints that train on request data.",
+            "example": true,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_paid_model_training": {
+            "description": "Whether this guardrail allows paid endpoints that train on request data.",
+            "example": true,
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -15687,6 +15971,13 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "type": {
+                          "default": "message",
+                          "enum": [
+                            "message"
+                          ],
+                          "type": "string"
                         }
                       },
                       "type": "object"
@@ -16587,6 +16878,42 @@
         ],
         "type": "object"
       },
+      "ListScimGroupMappingsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ScimGroupMapping"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
+      "ListScimGroupsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ScimGroup"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "type": "object"
+      },
       "ListWorkspaceBudgetsResponse": {
         "example": {
           "data": [
@@ -16610,14 +16937,13 @@
             "type": "array"
           },
           "include_byok_in_budgets": {
-            "description": "Whether BYOK spend is included in the workspace budgets",
+            "description": "Whether BYOK (bring-your-own-key) spend is included when enforcing the workspace's budgets. This is a workspace-wide setting that applies to all budget intervals (daily, weekly, monthly, and lifetime).",
             "example": false,
             "type": "boolean"
           }
         },
         "required": [
-          "data",
-          "include_byok_in_budgets"
+          "data"
         ],
         "type": "object"
       },
@@ -16666,6 +16992,7 @@
               "default_text_model": "openai/gpt-4o",
               "description": "Production environment workspace",
               "id": "550e8400-e29b-41d4-a716-446655440000",
+              "include_byok_in_budgets": false,
               "io_logging_api_key_ids": null,
               "io_logging_sampling_rate": 1,
               "is_data_discount_logging_enabled": true,
@@ -19280,6 +19607,7 @@
                   "Switchpoint",
                   "Tencent",
                   "Tenstorrent",
+                  "Thinking Machines",
                   "Together",
                   "Upstage",
                   "Venice",
@@ -19713,6 +20041,9 @@
           }
         },
         "properties": {
+          "alias_target": {
+            "$ref": "#/components/schemas/ModelAliasTarget"
+          },
           "architecture": {
             "$ref": "#/components/schemas/ModelArchitecture"
           },
@@ -19827,6 +20158,28 @@
           "default_parameters",
           "supported_voices",
           "links"
+        ],
+        "type": "object"
+      },
+      "ModelAliasTarget": {
+        "description": "Concrete model targeted by this tilde-latest alias, when applicable",
+        "example": {
+          "name": "Claude Sonnet 4.5",
+          "slug": "anthropic/claude-sonnet-4.5"
+        },
+        "properties": {
+          "name": {
+            "description": "Human-readable name of the concrete model targeted by this alias",
+            "type": "string"
+          },
+          "slug": {
+            "description": "Routable model ID of the concrete target, matching that model row's id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug",
+          "name"
         ],
         "type": "object"
       },
@@ -23101,6 +23454,169 @@
         ],
         "type": "object"
       },
+      "OpenAIFile": {
+        "description": "A stored file in OpenAI's Files API shape.",
+        "example": {
+          "_shape": "openai",
+          "bytes": 1024000,
+          "created_at": 1735689600,
+          "filename": "document.pdf",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "object": "file",
+          "purpose": "user_data",
+          "status": "processed"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "openai"
+            ],
+            "type": "string"
+          },
+          "bytes": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "integer"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          },
+          "purpose": {
+            "enum": [
+              "assistants",
+              "batch",
+              "fine-tune",
+              "vision",
+              "user_data",
+              "evals",
+              "assistants_output",
+              "batch_output",
+              "fine-tune-results"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "status": {
+            "enum": [
+              "processed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "id",
+          "object",
+          "bytes",
+          "created_at",
+          "filename",
+          "purpose",
+          "status"
+        ],
+        "type": "object"
+      },
+      "OpenAIFileDeleted": {
+        "description": "Deletion result in OpenAI's shape.",
+        "example": {
+          "_shape": "openai",
+          "deleted": true,
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "object": "file"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "openai"
+            ],
+            "type": "string"
+          },
+          "deleted": {
+            "const": true,
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "id",
+          "object",
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "OpenAIFileList": {
+        "description": "A page of files in OpenAI's shape.",
+        "example": {
+          "_shape": "openai",
+          "data": [],
+          "first_id": null,
+          "has_more": false,
+          "last_id": null,
+          "object": "list"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "openai"
+            ],
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OpenAIFile"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "last_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "object": {
+            "enum": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "object",
+          "data",
+          "has_more",
+          "first_id",
+          "last_id"
+        ],
+        "type": "object"
+      },
       "OpenAIResponseCustomToolCall": {
         "example": {
           "call_id": "call-abc123",
@@ -24078,6 +24594,149 @@
         },
         "type": "object"
       },
+      "OpenRouterFile": {
+        "description": "A stored file in the OpenRouter superset shape: Anthropic-shaped, plus OpenRouter-only fields.",
+        "example": {
+          "_shape": "openrouter",
+          "created_at": "2025-01-01T00:00:00Z",
+          "downloadable": false,
+          "filename": "document.pdf",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "mime_type": "application/pdf",
+          "size_bytes": 1024000,
+          "type": "file"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "openrouter"
+            ],
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "downloadable": {
+            "type": "boolean"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "size_bytes": {
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "id",
+          "type",
+          "filename",
+          "mime_type",
+          "size_bytes",
+          "created_at",
+          "downloadable"
+        ],
+        "type": "object"
+      },
+      "OpenRouterFileDeleted": {
+        "description": "Deletion result in the OpenRouter shape.",
+        "example": {
+          "_shape": "openrouter",
+          "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+          "type": "file_deleted"
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "openrouter"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file_deleted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_shape",
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OpenRouterFileList": {
+        "description": "A page of files in the OpenRouter shape.",
+        "example": {
+          "_shape": "openrouter",
+          "cursor": null,
+          "data": [],
+          "first_id": null,
+          "has_more": false,
+          "last_id": null
+        },
+        "properties": {
+          "_shape": {
+            "enum": [
+              "openrouter"
+            ],
+            "type": "string"
+          },
+          "cursor": {
+            "description": "Opaque cursor for the next page; null when there are no more results.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OpenRouterFile"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "last_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "_shape",
+          "data",
+          "has_more",
+          "first_id",
+          "last_id",
+          "cursor"
+        ],
+        "type": "object"
+      },
       "OpenRouterMetadata": {
         "example": {
           "attempt": 1,
@@ -24767,7 +25426,7 @@
             "type": "array"
           },
           "failure_reason": {
-            "description": "Typed failure reason when the fusion run failed. Possible values include: all_panels_failed, insufficient_credits, rate_limited, judge_not_valid_json, judge_schema_mismatch, judge_upstream_error, judge_empty_completion.",
+            "description": "Typed failure reason when the fusion run failed. Possible values include: all_panels_failed, insufficient_credits, rate_limited, judge_not_valid_json, judge_schema_mismatch, judge_upstream_error, judge_empty_completion. The four analysis-stage codes keep their pre-rename `judge_` spelling so existing consumers keep matching.",
             "type": "string"
           },
           "id": {
@@ -24792,7 +25451,7 @@
             "type": "array"
           },
           "sources": {
-            "description": "Web pages the analysis panels and judge retrieved via web search during this fusion run, deduplicated by URL across the whole run. Present when at least one model cited a source.",
+            "description": "Web pages the analysis panels and analyst retrieved via web search during this fusion run, deduplicated by URL across the whole run. Present when at least one model cited a source.",
             "items": {
               "$ref": "#/components/schemas/FusionSource"
             },
@@ -27419,6 +28078,7 @@
           "Switchpoint",
           "Tencent",
           "Tenstorrent",
+          "Thinking Machines",
           "Together",
           "Upstage",
           "Venice",
@@ -27920,6 +28580,10 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "thinkingmachines": {
+            "additionalProperties": {},
+            "type": "object"
+          },
           "together": {
             "additionalProperties": {},
             "type": "object"
@@ -28364,6 +29028,7 @@
               "Switchpoint",
               "Tencent",
               "Tenstorrent",
+              "Thinking Machines",
               "Together",
               "Upstage",
               "Venice",
@@ -28777,8 +29442,11 @@
           "int4",
           "int8",
           "fp4",
+          "mxfp4",
+          "nvfp4",
           "fp6",
           "fp8",
+          "mxfp8",
           "fp16",
           "bf16",
           "fp32",
@@ -29234,6 +29902,7 @@
           "unknown",
           "openai-responses-v1",
           "azure-openai-responses-v1",
+          "bedrock-openai-responses-v1",
           "xai-responses-v1",
           "meta-responses-v1",
           "anthropic-claude-v1",
@@ -29710,7 +30379,8 @@
               "empty_image_file",
               "failed_to_download_image",
               "image_file_not_found",
-              "bio_policy"
+              "bio_policy",
+              "data_residency_mismatch"
             ],
             "type": "string",
             "x-speakeasy-unknown-values": "allow"
@@ -29935,9 +30605,11 @@
           },
           "service_tier": {
             "default": "auto",
+            "description": "The service tier to use for processing this request. `fast` is accepted as an alias for `priority`.",
             "enum": [
               "auto",
               "default",
+              "fast",
               "flex",
               "priority",
               "scale",
@@ -30540,6 +31212,101 @@
         "example": 900,
         "type": "integer"
       },
+      "ScimGroup": {
+        "example": {
+          "created_at": "2025-08-24T10:30:00.000Z",
+          "display_name": "Engineering",
+          "external_id": "group-external-id",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "organization_id": "org_123456",
+          "updated_at": "2025-08-24T10:30:00.000Z"
+        },
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "external_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "organization_id",
+          "external_id",
+          "display_name",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "ScimGroupMapping": {
+        "example": {
+          "created_at": "2025-08-24T10:30:00.000Z",
+          "id": "770e8400-e29b-41d4-a716-446655440000",
+          "organization_id": "org_123456",
+          "role": "member",
+          "scim_group_id": "550e8400-e29b-41d4-a716-446655440000",
+          "updated_at": "2025-08-24T10:30:00.000Z",
+          "workspace_id": "660e8400-e29b-41d4-a716-446655440000"
+        },
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "admin",
+              "member"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "scim_group_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "organization_id",
+          "scim_group_id",
+          "workspace_id",
+          "role",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
       "SearchContextSizeEnum": {
         "description": "Size of the search context for web search tools",
         "enum": [
@@ -31021,13 +31788,13 @@
           "voice": {
             "description": "Voice identifier (provider-specific).",
             "example": "en_paul_neutral",
+            "minLength": 1,
             "type": "string"
           }
         },
         "required": [
           "model",
-          "input",
-          "voice"
+          "input"
         ],
         "type": "object"
       },
@@ -32818,6 +33585,7 @@
             "enum": [
               "artificial-analysis",
               "design-arena",
+              "openrouter",
               null
             ],
             "example": "artificial-analysis",
@@ -32861,6 +33629,94 @@
         ],
         "type": "object"
       },
+      "UnifiedBenchmarksORItem": {
+        "example": {
+          "accuracy": 0.72,
+          "accuracy_stddev": 0.03,
+          "avg_cost_per_task": 0.002,
+          "benchmark_type": "gpqa_diamond",
+          "display_name": "GPT-4o",
+          "last_run_timestamp": "2026-06-03T12:00:00Z",
+          "model_permaslug": "openai/gpt-4o",
+          "source": "openrouter",
+          "total_tasks": 300
+        },
+        "properties": {
+          "accuracy": {
+            "description": "Aggregate accuracy score from 0 to 1. Higher is better.",
+            "example": 0.72,
+            "format": "double",
+            "type": "number"
+          },
+          "accuracy_stddev": {
+            "description": "Standard deviation of run accuracy, or null for a single run.",
+            "example": 0.03,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "avg_cost_per_task": {
+            "description": "Average cost per task in USD, or null if unavailable.",
+            "example": 0.002,
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "benchmark_type": {
+            "description": "OpenRouter benchmark evaluation type.",
+            "enum": [
+              "gpqa_diamond",
+              "tau_bench_verified_airline"
+            ],
+            "example": "gpqa_diamond",
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          },
+          "display_name": {
+            "description": "Human-readable model name.",
+            "example": "GPT-4o",
+            "type": "string"
+          },
+          "last_run_timestamp": {
+            "description": "Timestamp of the most recent public benchmark run.",
+            "example": "2026-06-03T12:00:00Z",
+            "type": "string"
+          },
+          "model_permaslug": {
+            "description": "Stable OpenRouter model identifier.",
+            "example": "openai/gpt-4o",
+            "type": "string"
+          },
+          "source": {
+            "description": "Benchmark source discriminator.",
+            "enum": [
+              "openrouter"
+            ],
+            "type": "string"
+          },
+          "total_tasks": {
+            "description": "Total benchmark tasks across runs.",
+            "example": 300,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "source",
+          "model_permaslug",
+          "display_name",
+          "benchmark_type",
+          "accuracy",
+          "accuracy_stddev",
+          "avg_cost_per_task",
+          "total_tasks",
+          "last_run_timestamp"
+        ],
+        "type": "object"
+      },
       "UnifiedBenchmarksResponse": {
         "example": {
           "data": [
@@ -32875,6 +33731,17 @@
                 "prompt": "0.0000025"
               },
               "source": "artificial-analysis"
+            },
+            {
+              "accuracy": 0.72,
+              "accuracy_stddev": 0.03,
+              "avg_cost_per_task": 0.002,
+              "benchmark_type": "gpqa_diamond",
+              "display_name": "GPT-4o",
+              "last_run_timestamp": "2026-06-03T12:00:00Z",
+              "model_permaslug": "openai/gpt-4o",
+              "source": "openrouter",
+              "total_tasks": 300
             }
           ],
           "meta": {
@@ -32893,7 +33760,8 @@
               "discriminator": {
                 "mapping": {
                   "artificial-analysis": "#/components/schemas/UnifiedBenchmarksAAItem",
-                  "design-arena": "#/components/schemas/UnifiedBenchmarksDAItem"
+                  "design-arena": "#/components/schemas/UnifiedBenchmarksDAItem",
+                  "openrouter": "#/components/schemas/UnifiedBenchmarksORItem"
                 },
                 "propertyName": "source"
               },
@@ -32903,6 +33771,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/UnifiedBenchmarksDAItem"
+                },
+                {
+                  "$ref": "#/components/schemas/UnifiedBenchmarksORItem"
                 }
               ]
             },
@@ -33139,6 +34010,30 @@
             "maxLength": 1000,
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "enable_free_model_publication": {
+            "description": "Whether this guardrail allows free endpoints that publish prompts.",
+            "example": false,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_free_model_training": {
+            "description": "Whether this guardrail allows free endpoints that train on request data.",
+            "example": true,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "enable_paid_model_training": {
+            "description": "Whether this guardrail allows paid endpoints that train on request data.",
+            "example": true,
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -33397,6 +34292,33 @@
         ],
         "type": "object"
       },
+      "UpdateScimGroupMappingRequest": {
+        "properties": {
+          "role": {
+            "enum": [
+              "admin",
+              "member"
+            ],
+            "type": "string",
+            "x-speakeasy-unknown-values": "allow"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "type": "object"
+      },
+      "UpdateScimGroupMappingResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ScimGroupMapping"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "UpdateWorkspaceRequest": {
         "example": {
           "name": "Updated Workspace",
@@ -33497,6 +34419,7 @@
             "default_text_model": "openai/gpt-4o",
             "description": "Production environment workspace",
             "id": "550e8400-e29b-41d4-a716-446655440000",
+            "include_byok_in_budgets": false,
             "io_logging_api_key_ids": null,
             "io_logging_sampling_rate": 1,
             "is_data_discount_logging_enabled": true,
@@ -33531,7 +34454,7 @@
         },
         "properties": {
           "include_byok_in_budgets": {
-            "description": "Whether to include BYOK spend in the workspace budget",
+            "description": "Whether to include BYOK (bring-your-own-key) spend when enforcing the workspace's budgets. This is a workspace-wide setting: it applies to every budget interval (daily, weekly, monthly, and lifetime), not just the interval being upserted in this request. Omit to leave the current setting unchanged.",
             "example": true,
             "type": "boolean"
           },
@@ -33571,14 +34494,13 @@
             ]
           },
           "include_byok_in_budgets": {
-            "description": "Whether BYOK spend is included in the workspace budgets",
+            "description": "Whether BYOK (bring-your-own-key) spend is included when enforcing the workspace's budgets. This is a workspace-wide setting that applies to all budget intervals (daily, weekly, monthly, and lifetime).",
             "example": true,
             "type": "boolean"
           }
         },
         "required": [
-          "data",
-          "include_byok_in_budgets"
+          "data"
         ],
         "type": "object"
       },
@@ -33750,6 +34672,7 @@
             "enum": [
               "480p",
               "720p",
+              "768p",
               "1080p",
               "1K",
               "2K",
@@ -33993,6 +34916,7 @@
               "enum": [
                 "480p",
                 "720p",
+                "768p",
                 "1080p",
                 "1K",
                 "2K",
@@ -34022,8 +34946,14 @@
                 "720x1080",
                 "720x1280",
                 "720x1680",
+                "768x768",
+                "768x1024",
+                "768x1152",
+                "768x1366",
+                "768x1792",
                 "854x480",
                 "960x720",
+                "1024x768",
                 "1080x720",
                 "1080x1080",
                 "1080x1440",
@@ -34031,19 +34961,31 @@
                 "1080x1920",
                 "1080x2520",
                 "1120x480",
+                "1152x768",
                 "1280x720",
+                "1366x768",
                 "1440x1080",
+                "1440x1440",
+                "1440x1920",
+                "1440x2160",
+                "1440x2560",
+                "1440x3360",
                 "1620x1080",
                 "1680x720",
+                "1792x768",
                 "1920x1080",
+                "1920x1440",
+                "2160x1440",
                 "2160x2160",
                 "2160x2880",
                 "2160x3240",
                 "2160x3840",
                 "2160x5040",
                 "2520x1080",
+                "2560x1440",
                 "2880x2160",
                 "3240x2160",
+                "3360x1440",
                 "3840x2160",
                 "5040x2160"
               ],
@@ -34304,7 +35246,7 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, and xAI. Not supported with OpenAI (silently ignored). Cannot be used with allowed_domains.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, OpenAI, and xAI. Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
@@ -34344,12 +35286,24 @@
           "allowed_domains": [
             "example.com"
           ],
+          "blocked_domains": [
+            "spam.com"
+          ],
           "excluded_domains": [
             "spam.com"
           ]
         },
         "properties": {
           "allowed_domains": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "blocked_domains": {
             "items": {
               "type": "string"
             },
@@ -34544,7 +35498,7 @@
             "$ref": "#/components/schemas/WebSearchEngineEnum"
           },
           "excluded_domains": {
-            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, and xAI. Not supported with OpenAI (silently ignored). Cannot be used with allowed_domains.",
+            "description": "Exclude search results from these domains. Supported by Exa, Firecrawl, Parallel, Perplexity, Anthropic, OpenAI, and xAI. Cannot be used with allowed_domains.",
             "items": {
               "type": "string"
             },
@@ -34735,6 +35689,7 @@
           "default_text_model": "openai/gpt-4o",
           "description": "Production environment workspace",
           "id": "550e8400-e29b-41d4-a716-446655440000",
+          "include_byok_in_budgets": false,
           "io_logging_api_key_ids": null,
           "io_logging_sampling_rate": 1,
           "is_data_discount_logging_enabled": true,
@@ -34759,7 +35714,7 @@
             ]
           },
           "default_guardrail_id": {
-            "description": "Deterministic ID of the workspace's implicitly-created default guardrail",
+            "description": "Deterministic ID derived from the workspace ID. The default guardrail is materialized when its configuration is first written.",
             "example": "595d5849-7e86-51fd-a7c0-705c34e4afff",
             "format": "uuid",
             "type": "string"
@@ -34801,6 +35756,11 @@
             "example": "550e8400-e29b-41d4-a716-446655440000",
             "format": "uuid",
             "type": "string"
+          },
+          "include_byok_in_budgets": {
+            "description": "Whether BYOK (bring-your-own-key) spend counts toward this workspace's budgets. Set it via the workspace budget endpoints.",
+            "example": false,
+            "type": "boolean"
           },
           "io_logging_api_key_ids": {
             "description": "Optional array of API key IDs to filter I/O logging. Null means all keys are logged.",
@@ -36792,7 +37752,7 @@
     },
     "/benchmarks": {
       "get": {
-        "description": "Unified benchmark endpoint that aggregates scores from multiple benchmark sources (Artificial Analysis, Design Arena). Filter by source to reproduce the exact shapes from the legacy per-source endpoints, or use task_type to find models suited for specific workloads. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
+        "description": "Unified benchmark endpoint that aggregates scores from multiple benchmark sources (Artificial Analysis, Design Arena, and OpenRouter's own tau-bench and GPQA evals). Filter by source to reproduce the exact shapes from the legacy per-source endpoints, or use task_type to find models suited for specific workloads. Authenticate with any valid OpenRouter API key. Rate-limited to 30 requests/minute per key and 500 requests/day per account.",
         "operationId": "getBenchmarks",
         "parameters": [
           {
@@ -36804,7 +37764,8 @@
               "description": "Benchmark source to query. Determines the shape of the returned items. When omitted, returns results from all sources.",
               "enum": [
                 "artificial-analysis",
-                "design-arena"
+                "design-arena",
+                "openrouter"
               ],
               "example": "artificial-analysis",
               "type": "string",
@@ -36886,6 +37847,17 @@
                         "prompt": "0.0000025"
                       },
                       "source": "artificial-analysis"
+                    },
+                    {
+                      "accuracy": 0.72,
+                      "accuracy_stddev": 0.03,
+                      "avg_cost_per_task": 0.002,
+                      "benchmark_type": "gpqa_diamond",
+                      "display_name": "GPT-4o",
+                      "last_run_timestamp": "2026-06-03T12:00:00Z",
+                      "model_permaslug": "openai/gpt-4o",
+                      "source": "openrouter",
+                      "total_tasks": 300
                     }
                   ],
                   "meta": {
@@ -37132,6 +38104,7 @@
                 "switchpoint",
                 "tencent",
                 "tenstorrent",
+                "thinkingmachines",
                 "together",
                 "upstage",
                 "venice",
@@ -38973,10 +39946,12 @@
                   "input": {
                     "anyOf": [
                       {
+                        "minLength": 1,
                         "type": "string"
                       },
                       {
                         "items": {
+                          "minLength": 1,
                           "type": "string"
                         },
                         "type": "array"
@@ -39005,6 +39980,7 @@
                                   {
                                     "properties": {
                                       "text": {
+                                        "minLength": 1,
                                         "type": "string"
                                       },
                                       "type": {
@@ -39057,6 +40033,7 @@
                                   }
                                 ]
                               },
+                              "minItems": 1,
                               "type": "array"
                             }
                           },
@@ -39812,7 +40789,7 @@
             "required": false,
             "schema": {
               "description": "Opaque pagination cursor from a previous response.",
-              "example": "eyJjdXJzb3IiOiJmaWxlXzAxMUNOaGE4aUNKY1Uxd1hOUjZxNFY4dyJ9",
+              "example": "eyJjdXJzb3IiOiJvcl9maWxlXzAxMUNOaGE4aUNKY1Uxd1hOUjZxNFY4dyJ9",
               "type": "string"
             }
           },
@@ -39827,6 +40804,65 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "description": "Store or read this file on the named provider using your own API key for it. Omit to use OpenRouter storage.",
+            "example": "openai",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/FileProvider"
+            }
+          },
+          {
+            "description": "OpenAI-style forward cursor: the id to list after.",
+            "in": "query",
+            "name": "after",
+            "required": false,
+            "schema": {
+              "description": "OpenAI-style forward cursor: the id to list after.",
+              "example": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Anthropic-style forward cursor: the id to list after.",
+            "in": "query",
+            "name": "after_id",
+            "required": false,
+            "schema": {
+              "description": "Anthropic-style forward cursor: the id to list after.",
+              "example": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Anthropic-style reverse cursor. Not supported by OpenRouter storage.",
+            "in": "query",
+            "name": "before_id",
+            "required": false,
+            "schema": {
+              "description": "Anthropic-style reverse cursor. Not supported by OpenRouter storage.",
+              "example": "or_file_011CNha8iCJcU1wXNR6q4V8w",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction. Only `asc` is supported by OpenRouter storage.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "description": "Sort direction. Only `asc` is supported by OpenRouter storage.",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "example": "asc",
+              "type": "string",
+              "x-speakeasy-unknown-values": "allow"
+            }
           }
         ],
         "responses": {
@@ -39840,15 +40876,15 @@
                       "created_at": "2025-01-01T00:00:00Z",
                       "downloadable": false,
                       "filename": "document.pdf",
-                      "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                      "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
                       "mime_type": "application/pdf",
                       "size_bytes": 1024000,
                       "type": "file"
                     }
                   ],
-                  "first_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "first_id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
                   "has_more": false,
-                  "last_id": "file_011CNha8iCJcU1wXNR6q4V8w"
+                  "last_id": "or_file_011CNha8iCJcU1wXNR6q4V8w"
                 },
                 "schema": {
                   "$ref": "#/components/schemas/FileListResponse"
@@ -39889,6 +40925,22 @@
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "429": {
             "content": {
               "application/json": {
@@ -39920,6 +40972,38 @@
               }
             },
             "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
           }
         },
         "summary": "List files",
@@ -39969,6 +41053,16 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "description": "Store or read this file on the named provider using your own API key for it. Omit to use OpenRouter storage.",
+            "example": "openai",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/FileProvider"
+            }
           }
         ],
         "requestBody": {
@@ -40001,13 +41095,13 @@
                   "created_at": "2025-01-01T00:00:00Z",
                   "downloadable": false,
                   "filename": "document.pdf",
-                  "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
                   "mime_type": "application/pdf",
                   "size_bytes": 1024000,
                   "type": "file"
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/FileMetadata"
+                  "$ref": "#/components/schemas/FileResponse"
                 }
               }
             },
@@ -40108,6 +41202,38 @@
               }
             },
             "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
           }
         },
         "summary": "Upload a file",
@@ -40128,7 +41254,7 @@
             "name": "file_id",
             "required": true,
             "schema": {
-              "example": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "example": "or_file_011CNha8iCJcU1wXNR6q4V8w",
               "type": "string"
             }
           },
@@ -40143,6 +41269,16 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "description": "Store or read this file on the named provider using your own API key for it. Omit to use OpenRouter storage.",
+            "example": "openai",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/FileProvider"
+            }
           }
         ],
         "responses": {
@@ -40150,7 +41286,7 @@
             "content": {
               "application/json": {
                 "example": {
-                  "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
                   "type": "file_deleted"
                 },
                 "schema": {
@@ -40176,6 +41312,22 @@
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "404": {
             "content": {
               "application/json": {
@@ -40223,6 +41375,38 @@
               }
             },
             "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
           }
         },
         "summary": "Delete a file",
@@ -40241,7 +41425,7 @@
             "name": "file_id",
             "required": true,
             "schema": {
-              "example": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "example": "or_file_011CNha8iCJcU1wXNR6q4V8w",
               "type": "string"
             }
           },
@@ -40256,6 +41440,16 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "description": "Store or read this file on the named provider using your own API key for it. Omit to use OpenRouter storage.",
+            "example": "openai",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/FileProvider"
+            }
           }
         ],
         "responses": {
@@ -40266,13 +41460,13 @@
                   "created_at": "2025-01-01T00:00:00Z",
                   "downloadable": false,
                   "filename": "document.pdf",
-                  "id": "file_011CNha8iCJcU1wXNR6q4V8w",
+                  "id": "or_file_011CNha8iCJcU1wXNR6q4V8w",
                   "mime_type": "application/pdf",
                   "size_bytes": 1024000,
                   "type": "file"
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/FileMetadata"
+                  "$ref": "#/components/schemas/FileResponse"
                 }
               }
             },
@@ -40294,6 +41488,22 @@
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "404": {
             "content": {
               "application/json": {
@@ -40341,6 +41551,38 @@
               }
             },
             "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
           }
         },
         "summary": "Get file metadata",
@@ -40372,7 +41614,7 @@
             "name": "file_id",
             "required": true,
             "schema": {
-              "example": "file_011CNha8iCJcU1wXNR6q4V8w",
+              "example": "or_file_011CNha8iCJcU1wXNR6q4V8w",
               "type": "string"
             }
           },
@@ -40386,6 +41628,16 @@
               "example": "a103d8b6-42f0-4e50-9a3c-bf41e2c3c1a7",
               "format": "uuid",
               "type": "string"
+            }
+          },
+          {
+            "description": "Store or read this file on the named provider using your own API key for it. Omit to use OpenRouter storage.",
+            "example": "openai",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/FileProvider"
             }
           }
         ],
@@ -40434,6 +41686,22 @@
             },
             "description": "Unauthorized - Authentication required or invalid credentials"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 403,
+                    "message": "Only management keys can perform this operation"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenResponse"
+                }
+              }
+            },
+            "description": "Forbidden - Authentication successful but insufficient permissions"
+          },
           "404": {
             "content": {
               "application/json": {
@@ -40481,6 +41749,38 @@
               }
             },
             "description": "Internal Server Error - Unexpected server error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 502,
+                    "message": "Provider returned error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadGatewayResponse"
+                }
+              }
+            },
+            "description": "Bad Gateway - Provider/upstream API failure"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 503,
+                    "message": "Service temporarily unavailable"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable - Service temporarily unavailable"
           }
         },
         "summary": "Download file content",
@@ -41783,7 +43083,7 @@
                 }
               }
             },
-            "description": "Not Found - Resource does not exist"
+            "description": "Guardrail not found, or the workspace default guardrail has not been configured yet."
           },
           "500": {
             "content": {
@@ -41820,7 +43120,7 @@
         }
       ],
       "patch": {
-        "description": "Update an existing guardrail. Collection fields use replace semantics: send the full desired set on every update. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Update an existing guardrail, or materialize an unconfigured workspace default guardrail. Collection fields use replace semantics: send the full desired set on every update. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "updateGuardrail",
         "parameters": [
           {
@@ -41902,7 +43202,7 @@
                 }
               }
             },
-            "description": "Bad Request - Invalid request parameters or malformed input"
+            "description": "Invalid request, or an attempt to change a workspace default guardrail's name (which is derived from its workspace and not editable)."
           },
           "401": {
             "content": {
@@ -50336,12 +51636,705 @@
         },
         "summary": "Create a response",
         "tags": [
-          "responses",
+          "Responses",
           "beta.responses"
         ],
         "x-speakeasy-name-override": "send",
         "x-speakeasy-stream-request-field": "stream"
       }
+    },
+    "/scim/group-mappings": {
+      "get": {
+        "description": "List SCIM group-to-workspace mappings for the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listScimGroupMappings",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListScimGroupMappingsResponse"
+                }
+              }
+            },
+            "description": "List of SCIM group mappings"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List SCIM group mappings",
+        "tags": [
+          "SCIM"
+        ],
+        "x-speakeasy-name-override": "listMappings",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
+      "post": {
+        "description": "Create a SCIM group-to-workspace role mapping. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "createScimGroupMapping",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScimGroupMappingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateScimGroupMappingResponse"
+                }
+              }
+            },
+            "description": "SCIM group mapping created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 409,
+                    "message": "Resource conflict. Please try again later."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictResponse"
+                }
+              }
+            },
+            "description": "Conflict - Resource conflict or concurrent modification"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Create a SCIM group mapping",
+        "tags": [
+          "SCIM"
+        ],
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/scim/group-mappings/{id}": {
+      "delete": {
+        "description": "Delete a SCIM group-to-workspace mapping. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "deleteScimGroupMapping",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Required. Whether to keep workspace members after deleting the mapping. `false` **removes** the members this mapping granted access to; `true` deletes the mapping while leaving membership intact as manually-managed. There is deliberately no default \u2014 omitting it returns `400` so the destructive path cannot be reached by accident. Mirrors the dashboard, whose `DeleteMappingSchema.keepMembers` is likewise required.",
+            "in": "query",
+            "name": "keep_members",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "true",
+                    "false"
+                  ],
+                  "type": "string",
+                  "x-speakeasy-unknown-values": "allow"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Required. Whether to keep workspace members after deleting the mapping. `false` **removes** the members this mapping granted access to; `true` deletes the mapping while leaving membership intact as manually-managed. There is deliberately no default \u2014 omitting it returns `400` so the destructive path cannot be reached by accident. Mirrors the dashboard, whose `DeleteMappingSchema.keepMembers` is likewise required.",
+              "example": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteScimGroupMappingResponse"
+                }
+              }
+            },
+            "description": "SCIM group mapping deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Delete a SCIM group mapping",
+        "tags": [
+          "SCIM"
+        ],
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "description": "Get a SCIM group-to-workspace mapping. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "getScimGroupMapping",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetScimGroupMappingResponse"
+                }
+              }
+            },
+            "description": "SCIM group mapping"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Get a SCIM group mapping",
+        "tags": [
+          "SCIM"
+        ],
+        "x-speakeasy-name-override": "read"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ],
+      "patch": {
+        "description": "Update a SCIM group mapping role. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "updateScimGroupMapping",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScimGroupMappingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateScimGroupMappingResponse"
+                }
+              }
+            },
+            "description": "SCIM group mapping updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 400,
+                    "message": "Invalid request parameters"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Invalid request parameters or malformed input"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "Update a SCIM group mapping",
+        "tags": [
+          "SCIM"
+        ],
+        "x-speakeasy-name-override": "update"
+      }
+    },
+    "/scim/groups": {
+      "get": {
+        "description": "List SCIM groups for the organization. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "operationId": "listScimGroups",
+        "parameters": [
+          {
+            "description": "Number of records to skip for pagination",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip for pagination",
+              "example": 0,
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "Maximum number of records to return (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of records to return (max 100)",
+              "example": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListScimGroupsResponse"
+                }
+              }
+            },
+            "description": "List of SCIM groups"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 401,
+                    "message": "Missing Authentication header"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Authentication required or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 404,
+                    "message": "Resource not found"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found - Resource does not exist"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": 500,
+                    "message": "Internal Server Error"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error - Unexpected server error"
+          }
+        },
+        "summary": "List SCIM groups",
+        "tags": [
+          "SCIM"
+        ],
+        "x-speakeasy-name-override": "listGroups",
+        "x-speakeasy-pagination": {
+          "inputs": [
+            {
+              "in": "parameters",
+              "name": "offset",
+              "type": "offset"
+            },
+            {
+              "in": "parameters",
+              "name": "limit",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.data"
+          },
+          "type": "offsetLimit"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AppIdentifier"
+        },
+        {
+          "$ref": "#/components/parameters/AppDisplayName"
+        },
+        {
+          "$ref": "#/components/parameters/AppCategories"
+        }
+      ]
     },
     "/videos": {
       "parameters": [
@@ -50892,6 +52885,7 @@
                       "default_text_model": "openai/gpt-4o",
                       "description": "Production environment workspace",
                       "id": "550e8400-e29b-41d4-a716-446655440000",
+                      "include_byok_in_budgets": false,
                       "io_logging_api_key_ids": null,
                       "io_logging_sampling_rate": 1,
                       "is_data_discount_logging_enabled": true,
@@ -51014,6 +53008,7 @@
                     "default_text_model": "openai/gpt-4o",
                     "description": "Production environment workspace",
                     "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "include_byok_in_budgets": false,
                     "io_logging_api_key_ids": null,
                     "io_logging_sampling_rate": 1,
                     "is_data_discount_logging_enabled": true,
@@ -51253,6 +53248,7 @@
                     "default_text_model": "openai/gpt-4o",
                     "description": "Production environment workspace",
                     "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "include_byok_in_budgets": false,
                     "io_logging_api_key_ids": null,
                     "io_logging_sampling_rate": 1,
                     "is_data_discount_logging_enabled": true,
@@ -51381,6 +53377,7 @@
                     "default_text_model": "openai/gpt-4o",
                     "description": "Production environment workspace",
                     "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "include_byok_in_budgets": false,
                     "io_logging_api_key_ids": null,
                     "io_logging_sampling_rate": 1,
                     "is_data_discount_logging_enabled": true,
@@ -51704,7 +53701,7 @@
         }
       ],
       "put": {
-        "description": "Create or update the budget for a given interval. Budget limits must strictly decrease as the interval narrows (lifetime > monthly > weekly > daily). [Management key](/docs/guides/overview/auth/management-api-keys) required.",
+        "description": "Create or update the budget for a given interval. Budget limits must strictly decrease as the interval narrows (lifetime > monthly > weekly > daily). The optional `include_byok_in_budgets` flag is a workspace-wide setting: when provided it applies to every budget interval for the workspace, not just the interval in this request. Note that a change made here is applied to budget enforcement immediately, but an already-open workspace settings page in the web dashboard may keep showing the previous value until it is reloaded. [Management key](/docs/guides/overview/auth/management-api-keys) required.",
         "operationId": "upsertWorkspaceBudget",
         "parameters": [
           {
@@ -52416,6 +54413,14 @@
       "name": "Rerank"
     },
     {
+      "description": "OpenAI-compatible Responses API endpoints",
+      "name": "Responses"
+    },
+    {
+      "description": "SCIM endpoints",
+      "name": "SCIM"
+    },
+    {
       "description": "Speech-to-text endpoints",
       "name": "STT",
       "x-displayName": "Transcriptions"
@@ -52436,10 +54441,6 @@
     {
       "description": "beta.Analytics endpoints",
       "name": "beta.Analytics"
-    },
-    {
-      "description": "responses endpoints",
-      "name": "responses"
     },
     {
       "description": "Deprecated alias of responses. Use responses instead; scheduled for removal (sunset date TBD).",

--- a/specs/openrouter/openapi-baseline.operations.json
+++ b/specs/openrouter/openapi-baseline.operations.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-07-28T01:40:56+00:00",
+  "captured_at": "2026-08-03T08:48:33+00:00",
   "info": {
     "contact": {
       "email": "support@openrouter.ai",
@@ -14,7 +14,7 @@
     "title": "OpenRouter API",
     "version": "1.0.0"
   },
-  "operation_count": 89,
+  "operation_count": 95,
   "operations": [
     {
       "deprecated": false,
@@ -29,7 +29,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "145ca3aeda928ae4",
+      "fingerprint": "6c8d1d471e3dfa9f",
       "id": "DELETE /files/{file_id}",
       "method": "DELETE",
       "operation_id": "deleteFile",
@@ -69,6 +69,17 @@
       "path": "/observability/destinations/{id}",
       "tags": [
         "Observability"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "9a1a8c53ab50a698",
+      "id": "DELETE /scim/group-mappings/{id}",
+      "method": "DELETE",
+      "operation_id": "deleteScimGroupMapping",
+      "path": "/scim/group-mappings/{id}",
+      "tags": [
+        "SCIM"
       ]
     },
     {
@@ -117,7 +128,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6ccd145752d4520c",
+      "fingerprint": "68780109b64fca77",
       "id": "GET /benchmarks",
       "method": "GET",
       "operation_id": "getBenchmarks",
@@ -128,7 +139,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f9ffe89bf3759343",
+      "fingerprint": "d7f1970d9fd0a44f",
       "id": "GET /byok",
       "method": "GET",
       "operation_id": "listBYOKKeys",
@@ -139,7 +150,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0c72446afeeb6d46",
+      "fingerprint": "bf86c4ce0329565e",
       "id": "GET /byok/{id}",
       "method": "GET",
       "operation_id": "getBYOKKey",
@@ -194,7 +205,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "14478b1cc8de7965",
+      "fingerprint": "8be9f718ce33e81c",
       "id": "GET /embeddings/models",
       "method": "GET",
       "operation_id": "listEmbeddingsModels",
@@ -205,7 +216,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "7183c24c3524d1d0",
+      "fingerprint": "a2ae33bc1f92deb8",
       "id": "GET /endpoints/zdr",
       "method": "GET",
       "operation_id": "listEndpointsZdr",
@@ -216,7 +227,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "8f0d2cd29aa6c327",
+      "fingerprint": "313da32f9ee6ae01",
       "id": "GET /files",
       "method": "GET",
       "operation_id": "listFiles",
@@ -227,7 +238,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f39182f2d14ea314",
+      "fingerprint": "2d38e3f0677b17b6",
       "id": "GET /files/{file_id}",
       "method": "GET",
       "operation_id": "getFileMetadata",
@@ -238,7 +249,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cb8227219e5d8f23",
+      "fingerprint": "1e6c40baf7664561",
       "id": "GET /files/{file_id}/content",
       "method": "GET",
       "operation_id": "downloadFileContent",
@@ -249,7 +260,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "185f4431c8460e10",
+      "fingerprint": "379378aed4df90c4",
       "id": "GET /generation",
       "method": "GET",
       "operation_id": "getGeneration",
@@ -271,7 +282,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "0bf80e949ce80c57",
+      "fingerprint": "5bfdbef39fd4beb9",
       "id": "GET /guardrails",
       "method": "GET",
       "operation_id": "listGuardrails",
@@ -304,7 +315,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c0b10709c316fe7f",
+      "fingerprint": "9c661d0c6383c8c0",
       "id": "GET /guardrails/{id}",
       "method": "GET",
       "operation_id": "getGuardrail",
@@ -392,7 +403,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1443103dd307b550",
+      "fingerprint": "de8ac5738a46a47c",
       "id": "GET /model/{author}/{slug}",
       "method": "GET",
       "operation_id": "getModel",
@@ -403,7 +414,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "50b6ac4b9f523291",
+      "fingerprint": "87925f4eed9cbf51",
       "id": "GET /models",
       "method": "GET",
       "operation_id": "getModels",
@@ -425,7 +436,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "99d90081047dae88",
+      "fingerprint": "c99c3473508e66eb",
       "id": "GET /models/user",
       "method": "GET",
       "operation_id": "listModelsUser",
@@ -436,7 +447,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f4c01c2b71667e8d",
+      "fingerprint": "74885f24f41dac14",
       "id": "GET /models/{author}/{slug}/endpoints",
       "method": "GET",
       "operation_id": "listEndpoints",
@@ -535,7 +546,40 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b0271167246df379",
+      "fingerprint": "8ffa88ecb20e9013",
+      "id": "GET /scim/group-mappings",
+      "method": "GET",
+      "operation_id": "listScimGroupMappings",
+      "path": "/scim/group-mappings",
+      "tags": [
+        "SCIM"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "ad9585c702a510ea",
+      "id": "GET /scim/group-mappings/{id}",
+      "method": "GET",
+      "operation_id": "getScimGroupMapping",
+      "path": "/scim/group-mappings/{id}",
+      "tags": [
+        "SCIM"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "b849532aa7c047f9",
+      "id": "GET /scim/groups",
+      "method": "GET",
+      "operation_id": "listScimGroups",
+      "path": "/scim/groups",
+      "tags": [
+        "SCIM"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "18fbe6733f237dec",
       "id": "GET /videos/models",
       "method": "GET",
       "operation_id": "listVideosModels",
@@ -568,7 +612,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2ce1418cb2a5b1a4",
+      "fingerprint": "692fa1df2934dfab",
       "id": "GET /workspaces",
       "method": "GET",
       "operation_id": "listWorkspaces",
@@ -579,7 +623,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1daf328bed1552fc",
+      "fingerprint": "3746904ee98b0f48",
       "id": "GET /workspaces/{id}",
       "method": "GET",
       "operation_id": "getWorkspace",
@@ -590,7 +634,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "579f46650ccfe84c",
+      "fingerprint": "4ad2a1f59c8b2376",
       "id": "GET /workspaces/{id}/budgets",
       "method": "GET",
       "operation_id": "listWorkspaceBudgets",
@@ -612,7 +656,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "d1f3be28321c474c",
+      "fingerprint": "5a9f37ae61f88144",
       "id": "PATCH /byok/{id}",
       "method": "PATCH",
       "operation_id": "updateBYOKKey",
@@ -623,7 +667,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "1a8b03bcdd3d470e",
+      "fingerprint": "ab7f9c154c2ce23d",
       "id": "PATCH /guardrails/{id}",
       "method": "PATCH",
       "operation_id": "updateGuardrail",
@@ -656,7 +700,18 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "789f097907b8479b",
+      "fingerprint": "3c7aca0b0e7d49cd",
+      "id": "PATCH /scim/group-mappings/{id}",
+      "method": "PATCH",
+      "operation_id": "updateScimGroupMapping",
+      "path": "/scim/group-mappings/{id}",
+      "tags": [
+        "SCIM"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "4e55d3ea758b12da",
       "id": "PATCH /workspaces/{id}",
       "method": "PATCH",
       "operation_id": "updateWorkspace",
@@ -678,7 +733,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "4474f16b77c44bfb",
+      "fingerprint": "dbb2ba5e7e8bbfc9",
       "id": "POST /audio/speech",
       "method": "POST",
       "operation_id": "createAudioSpeech",
@@ -689,7 +744,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "37bc291d4719c045",
+      "fingerprint": "d80f756ac31de0e8",
       "id": "POST /audio/transcriptions",
       "method": "POST",
       "operation_id": "createAudioTranscriptions",
@@ -722,7 +777,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "e7c7ff195a04d7a9",
+      "fingerprint": "d12647d2de5bf349",
       "id": "POST /byok",
       "method": "POST",
       "operation_id": "createBYOKKey",
@@ -733,7 +788,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "574ff5ba68164e62",
+      "fingerprint": "6e742c5d1bf0f314",
       "id": "POST /chat/completions",
       "method": "POST",
       "operation_id": "sendChatCompletionRequest",
@@ -755,7 +810,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "2d1b0304b523a473",
+      "fingerprint": "0623a46d3ed59ab0",
       "id": "POST /embeddings",
       "method": "POST",
       "operation_id": "createEmbeddings",
@@ -766,7 +821,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "cec95bfa29c5fa3a",
+      "fingerprint": "7f6d42a9f7ec4ca2",
       "id": "POST /files",
       "method": "POST",
       "operation_id": "uploadFile",
@@ -788,7 +843,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "f3795b1b801f3bcf",
+      "fingerprint": "01f012a21360e37b",
       "id": "POST /guardrails",
       "method": "POST",
       "operation_id": "createGuardrail",
@@ -843,7 +898,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "312e001d1b64cfc4",
+      "fingerprint": "52efb88ad0ccb401",
       "id": "POST /images",
       "method": "POST",
       "operation_id": "createImages",
@@ -865,7 +920,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "bd2a664b308335d4",
+      "fingerprint": "f7a7512bf65a35ad",
       "id": "POST /messages",
       "method": "POST",
       "operation_id": "createMessages",
@@ -887,7 +942,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "5f0e41417312d4e8",
+      "fingerprint": "ea47d16fc52c2045",
       "id": "POST /presets/{slug}/chat/completions",
       "method": "POST",
       "operation_id": "createPresetsChatCompletions",
@@ -898,7 +953,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "eaf8bdacd098ea32",
+      "fingerprint": "5506e45527506fb2",
       "id": "POST /presets/{slug}/messages",
       "method": "POST",
       "operation_id": "createPresetsMessages",
@@ -909,7 +964,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "c053f41120e25f22",
+      "fingerprint": "b402ecf58004f4bf",
       "id": "POST /presets/{slug}/responses",
       "method": "POST",
       "operation_id": "createPresetsResponses",
@@ -920,7 +975,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "dd7fdd75710d43d1",
+      "fingerprint": "dd368eafc36934a3",
       "id": "POST /rerank",
       "method": "POST",
       "operation_id": "createRerank",
@@ -931,19 +986,30 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "6649cc0e5f208525",
+      "fingerprint": "eb4c4e8be5e4f6f8",
       "id": "POST /responses",
       "method": "POST",
       "operation_id": "createResponses",
       "path": "/responses",
       "tags": [
-        "responses",
+        "Responses",
         "beta.responses"
       ]
     },
     {
       "deprecated": false,
-      "fingerprint": "cd6f7076c7ce8cc5",
+      "fingerprint": "14977f046c1f312f",
+      "id": "POST /scim/group-mappings",
+      "method": "POST",
+      "operation_id": "createScimGroupMapping",
+      "path": "/scim/group-mappings",
+      "tags": [
+        "SCIM"
+      ]
+    },
+    {
+      "deprecated": false,
+      "fingerprint": "4665120d90ed9dcc",
       "id": "POST /videos",
       "method": "POST",
       "operation_id": "createVideos",
@@ -954,7 +1020,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "09fa7c795c50f15a",
+      "fingerprint": "4895d197ec875a7d",
       "id": "POST /workspaces",
       "method": "POST",
       "operation_id": "createWorkspace",
@@ -987,7 +1053,7 @@
     },
     {
       "deprecated": false,
-      "fingerprint": "b30971a50e5b4e36",
+      "fingerprint": "85f22e1415d3252a",
       "id": "PUT /workspaces/{id}/budgets/{interval}",
       "method": "PUT",
       "operation_id": "upsertWorkspaceBudget",

--- a/src/api/audio.rs
+++ b/src/api/audio.rs
@@ -48,7 +48,7 @@ pub struct SpeechRequest {
     #[builder(setter(into))]
     pub model: String,
     #[builder(setter(into), default)]
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub voice: String,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/api/audio.rs
+++ b/src/api/audio.rs
@@ -47,7 +47,8 @@ pub struct SpeechRequest {
     pub input: String,
     #[builder(setter(into))]
     pub model: String,
-    #[builder(setter(into))]
+    #[builder(setter(into), default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub voice: String,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/api/discovery.rs
+++ b/src/api/discovery.rs
@@ -551,6 +551,16 @@ impl UnifiedBenchmarksParams {
             max_results: None,
         }
     }
+
+    pub fn openrouter() -> Self {
+        Self {
+            source: Some("openrouter".to_string()),
+            task_type: None,
+            arena: None,
+            category: None,
+            max_results: None,
+        }
+    }
 }
 
 /// One Artificial Analysis row returned by `GET /benchmarks`.
@@ -586,12 +596,30 @@ pub struct UnifiedBenchmarksDAItem {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// One OpenRouter evaluation row returned by `GET /benchmarks`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct UnifiedBenchmarksORItem {
+    pub source: String,
+    pub model_permaslug: String,
+    pub display_name: String,
+    pub benchmark_type: String,
+    pub accuracy: f64,
+    pub accuracy_stddev: Option<f64>,
+    pub avg_cost_per_task: Option<f64>,
+    pub total_tasks: u64,
+    pub last_run_timestamp: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
 /// One benchmark row returned by `GET /benchmarks`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum UnifiedBenchmarkItem {
     DesignArena(UnifiedBenchmarksDAItem),
+    OpenRouter(UnifiedBenchmarksORItem),
     ArtificialAnalysis(UnifiedBenchmarksAAItem),
     Other(HashMap<String, serde_json::Value>),
 }

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -26,6 +26,62 @@ struct ListFilesQuery {
     workspace_id: Option<String>,
 }
 
+/// Query parameters shared by provider-backed file operations.
+#[derive(Serialize, Debug, Clone, Default, Builder)]
+#[builder(build_fn(error = "OpenRouterError"), default)]
+#[non_exhaustive]
+pub struct FileQuery {
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+}
+
+impl FileQuery {
+    pub fn builder() -> FileQueryBuilder {
+        FileQueryBuilder::default()
+    }
+}
+
+/// Query parameters for provider-aware file listing.
+#[derive(Serialize, Debug, Clone, Default, Builder)]
+#[builder(build_fn(error = "OpenRouterError"), default)]
+#[non_exhaustive]
+pub struct ListFilesParams {
+    #[builder(setter(strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_id: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<String>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
+}
+
+impl ListFilesParams {
+    pub fn builder() -> ListFilesParamsBuilder {
+        ListFilesParamsBuilder::default()
+    }
+}
+
 /// Metadata describing a stored file.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
@@ -62,6 +118,70 @@ pub struct FileDeleteResponse {
     pub id: String,
     #[serde(rename = "type")]
     pub object_type: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// File metadata in the shape negotiated with a backing provider.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ProviderFileMetadata {
+    #[serde(rename = "_shape")]
+    pub shape: String,
+    pub id: String,
+    pub filename: String,
+    #[serde(default, rename = "type")]
+    pub object_type: Option<String>,
+    #[serde(default)]
+    pub object: Option<String>,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+    #[serde(default)]
+    pub size_bytes: Option<u64>,
+    #[serde(default)]
+    pub bytes: Option<u64>,
+    pub created_at: serde_json::Value,
+    #[serde(default)]
+    pub downloadable: Option<bool>,
+    #[serde(default)]
+    pub purpose: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// A provider-shaped page of files.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ProviderFileListResponse {
+    #[serde(rename = "_shape")]
+    pub shape: String,
+    pub data: Vec<ProviderFileMetadata>,
+    pub has_more: bool,
+    pub first_id: Option<String>,
+    pub last_id: Option<String>,
+    #[serde(default)]
+    pub cursor: Option<String>,
+    #[serde(default)]
+    pub object: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Provider-shaped confirmation that a file was deleted.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ProviderFileDeleteResponse {
+    #[serde(rename = "_shape")]
+    pub shape: String,
+    pub id: String,
+    #[serde(default, rename = "type")]
+    pub object_type: Option<String>,
+    #[serde(default)]
+    pub object: Option<String>,
+    #[serde(default)]
+    pub deleted: Option<bool>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
 }
@@ -146,6 +266,37 @@ pub(crate) async fn list_files_with_client(
     }
 }
 
+/// List files using a provider-native response shape (`GET /files`).
+pub async fn list_provider_files(
+    base_url: &str,
+    api_key: &str,
+    params: &ListFilesParams,
+) -> Result<ProviderFileListResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_provider_files_with_client(&http_client, base_url, api_key, params).await
+}
+
+pub(crate) async fn list_provider_files_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    params: &ListFilesParams,
+) -> Result<ProviderFileListResponse, OpenRouterError> {
+    let url = format!("{base_url}/files");
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .query(params)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "provider file list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
 /// Upload a file into the default or selected workspace (`POST /files`).
 pub async fn upload_file(
     base_url: &str,
@@ -188,6 +339,48 @@ pub(crate) async fn upload_file_with_client(
     }
 }
 
+/// Upload a file using a provider-native response shape (`POST /files`).
+pub async fn upload_provider_file(
+    base_url: &str,
+    api_key: &str,
+    request: &UploadFileRequest,
+    query: &FileQuery,
+) -> Result<ProviderFileMetadata, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    upload_provider_file_with_client(&http_client, base_url, api_key, request, query).await
+}
+
+pub(crate) async fn upload_provider_file_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    request: &UploadFileRequest,
+    query: &FileQuery,
+) -> Result<ProviderFileMetadata, OpenRouterError> {
+    let url = format!("{base_url}/files");
+    let mut part =
+        multipart::Part::bytes(request.content.clone()).file_name(request.filename.clone());
+    if let Some(mime_type) = &request.mime_type {
+        part = part
+            .mime_str(mime_type)
+            .map_err(|error| OpenRouterError::ConfigError(error.to_string()))?;
+    }
+    let form = multipart::Form::new().part("file", part);
+    let response =
+        transport_request::with_bearer_auth(transport_request::post(http_client, &url), api_key)
+            .query(query)
+            .multipart(form)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "provider file upload").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
 /// Get metadata for one file (`GET /files/{file_id}`).
 pub async fn get_file_metadata(
     base_url: &str,
@@ -214,6 +407,39 @@ pub(crate) async fn get_file_metadata_with_client(
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "file metadata").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Get metadata using a provider-native response shape (`GET /files/{file_id}`).
+pub async fn get_provider_file_metadata(
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    query: &FileQuery,
+) -> Result<ProviderFileMetadata, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_provider_file_metadata_with_client(&http_client, base_url, api_key, file_id, query).await
+}
+
+pub(crate) async fn get_provider_file_metadata_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    query: &FileQuery,
+) -> Result<ProviderFileMetadata, OpenRouterError> {
+    let url = format!("{base_url}/files/{}", encode(file_id));
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .query(query)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "provider file metadata").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()
@@ -252,6 +478,40 @@ pub(crate) async fn download_file_content_with_client(
     }
 }
 
+/// Download raw content from a selected provider (`GET /files/{file_id}/content`).
+pub async fn download_provider_file_content(
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    query: &FileQuery,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    download_provider_file_content_with_client(&http_client, base_url, api_key, file_id, query)
+        .await
+}
+
+pub(crate) async fn download_provider_file_content_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    query: &FileQuery,
+) -> Result<Vec<u8>, OpenRouterError> {
+    let url = format!("{base_url}/files/{}/content", encode(file_id));
+    let response =
+        transport_request::with_bearer_auth(transport_request::get(http_client, &url), api_key)
+            .query(query)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        Ok(response.bytes().await?.to_vec())
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
 /// Delete one file (`DELETE /files/{file_id}`).
 pub async fn delete_file(
     base_url: &str,
@@ -278,6 +538,39 @@ pub(crate) async fn delete_file_with_client(
 
     if response.status().is_success() {
         transport_response::parse_json_response(response, "file deletion").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Delete a file using a provider-native response shape (`DELETE /files/{file_id}`).
+pub async fn delete_provider_file(
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    query: &FileQuery,
+) -> Result<ProviderFileDeleteResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_provider_file_with_client(&http_client, base_url, api_key, file_id, query).await
+}
+
+pub(crate) async fn delete_provider_file_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    file_id: &str,
+    query: &FileQuery,
+) -> Result<ProviderFileDeleteResponse, OpenRouterError> {
+    let url = format!("{base_url}/files/{}", encode(file_id));
+    let response =
+        transport_request::with_bearer_auth(transport_request::delete(http_client, &url), api_key)
+            .query(query)
+            .send()
+            .await?;
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "provider file deletion").await
     } else {
         transport_response::handle_error(response).await?;
         unreachable!()

--- a/src/api/guardrails.rs
+++ b/src/api/guardrails.rs
@@ -108,6 +108,12 @@ pub struct Guardrail {
     #[serde(default)]
     pub include_byok_in_budgets: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_free_model_publication: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_free_model_training: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_paid_model_training: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reset_interval: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_providers: Option<Vec<String>>,
@@ -160,6 +166,15 @@ pub struct CreateGuardrailRequest {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     include_byok_in_budgets: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_free_model_publication: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_free_model_training: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_paid_model_training: Option<bool>,
     #[builder(setter(into, strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     reset_interval: Option<String>,
@@ -224,6 +239,12 @@ pub struct UpdateGuardrailRequest {
     limit_usd: Option<f64>,
     #[builder(setter(strip_option), default)]
     include_byok_in_budgets: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enable_free_model_publication: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enable_free_model_training: Option<bool>,
+    #[builder(setter(strip_option), default)]
+    enable_paid_model_training: Option<bool>,
     #[builder(setter(into, strip_option), default)]
     reset_interval: Option<String>,
     #[builder(setter(custom), default)]
@@ -277,6 +298,15 @@ impl Serialize for UpdateGuardrailRequest {
         }
         if let Some(value) = &self.include_byok_in_budgets {
             map.serialize_entry("include_byok_in_budgets", value)?;
+        }
+        if let Some(value) = &self.enable_free_model_publication {
+            map.serialize_entry("enable_free_model_publication", value)?;
+        }
+        if let Some(value) = &self.enable_free_model_training {
+            map.serialize_entry("enable_free_model_training", value)?;
+        }
+        if let Some(value) = &self.enable_paid_model_training {
+            map.serialize_entry("enable_paid_model_training", value)?;
         }
         if let Some(value) = &self.reset_interval {
             map.serialize_entry("reset_interval", value)?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@
 //! - `client.images()` -> [`images`]
 //! - `client.videos()` -> [`videos`]
 //! - `client.models()` -> [`models`], [`embeddings`], [`discovery`]
-//! - `client.management()` -> [`api_keys`], [`auth`], [`byok`], [`credits`], [`generation`], [`guardrails`], [`observability`], [`organization`], [`presets`], [`workspaces`]
+//! - `client.management()` -> [`api_keys`], [`auth`], [`byok`], [`credits`], [`generation`], [`guardrails`], [`observability`], [`organization`], [`presets`], [`scim`], [`workspaces`]
 //! - `client.legacy()` -> [`legacy`] (feature `legacy-completions`)
 //!
 //! Endpoint families currently implemented here:
@@ -35,6 +35,7 @@
 //! - preset creation from inference request bodies
 //! - guardrails and guardrail assignments
 //! - organization member listing
+//! - SCIM group discovery and group-role mappings
 //! - workspace CRUD and membership management
 //! - structured API error payloads
 //!
@@ -140,6 +141,7 @@ pub mod organization;
 pub mod presets;
 pub mod rerank;
 pub mod responses;
+pub mod scim;
 #[deprecated(note = "use api::audio for the canonical /audio/speech surface")]
 pub mod tts;
 pub mod videos;

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -46,8 +46,18 @@ pub struct Model {
     pub benchmarks: Option<ModelBenchmarks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ModelReasoning>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias_target: Option<ModelAliasTarget>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+}
+
+/// Concrete model targeted by a model alias.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ModelAliasTarget {
+    pub slug: String,
+    pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/api/scim.rs
+++ b/src/api/scim.rs
@@ -1,0 +1,330 @@
+use derive_builder::Builder;
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use urlencoding::encode;
+
+use crate::{
+    error::OpenRouterError,
+    transport::{request as transport_request, response as transport_response},
+    types::{ApiResponse, PaginationOptions},
+};
+
+#[derive(Serialize)]
+struct PaginationQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    offset: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct KeepMembersQuery {
+    keep_members: bool,
+}
+
+#[derive(Deserialize)]
+struct DeleteScimGroupMappingResponse {
+    deleted: bool,
+}
+
+/// One SCIM group synchronized into the organization.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ScimGroup {
+    pub id: String,
+    pub organization_id: String,
+    pub external_id: Option<String>,
+    pub display_name: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Paginated SCIM group response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ListScimGroupsResponse {
+    pub data: Vec<ScimGroup>,
+    pub total_count: u64,
+}
+
+/// One SCIM group-to-workspace role mapping.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ScimGroupMapping {
+    pub id: String,
+    pub organization_id: String,
+    pub scim_group_id: String,
+    pub workspace_id: String,
+    pub role: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Paginated SCIM group mapping response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
+pub struct ListScimGroupMappingsResponse {
+    pub data: Vec<ScimGroupMapping>,
+    pub total_count: u64,
+}
+
+/// Request to map a SCIM group to one workspace role.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct CreateScimGroupMappingRequest {
+    #[builder(setter(into))]
+    pub scim_group_id: String,
+    #[builder(setter(into))]
+    pub workspace_id: String,
+    #[builder(setter(into))]
+    pub role: String,
+}
+
+impl CreateScimGroupMappingRequest {
+    pub fn builder() -> CreateScimGroupMappingRequestBuilder {
+        CreateScimGroupMappingRequestBuilder::default()
+    }
+}
+
+/// Request to update a SCIM group mapping role.
+#[derive(Serialize, Deserialize, Debug, Clone, Builder)]
+#[builder(build_fn(error = "OpenRouterError"))]
+#[non_exhaustive]
+pub struct UpdateScimGroupMappingRequest {
+    #[builder(setter(into))]
+    pub role: String,
+}
+
+impl UpdateScimGroupMappingRequest {
+    pub fn builder() -> UpdateScimGroupMappingRequestBuilder {
+        UpdateScimGroupMappingRequestBuilder::default()
+    }
+}
+
+/// List SCIM groups (`GET /scim/groups`).
+pub async fn list_scim_groups(
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListScimGroupsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_scim_groups_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_scim_groups_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListScimGroupsResponse, OpenRouterError> {
+    let query = PaginationQuery {
+        offset: pagination.and_then(|value| value.offset),
+        limit: pagination.and_then(|value| value.limit),
+    };
+    let request = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &format!("{base_url}/scim/groups")),
+        management_key,
+    );
+    let response = if query.offset.is_none() && query.limit.is_none() {
+        request.send().await?
+    } else {
+        request.query(&query).send().await?
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "SCIM group list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// List SCIM group mappings (`GET /scim/group-mappings`).
+pub async fn list_scim_group_mappings(
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListScimGroupMappingsResponse, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    list_scim_group_mappings_with_client(&http_client, base_url, management_key, pagination).await
+}
+
+pub(crate) async fn list_scim_group_mappings_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    pagination: Option<PaginationOptions>,
+) -> Result<ListScimGroupMappingsResponse, OpenRouterError> {
+    let query = PaginationQuery {
+        offset: pagination.and_then(|value| value.offset),
+        limit: pagination.and_then(|value| value.limit),
+    };
+    let request = transport_request::with_bearer_auth(
+        transport_request::get(http_client, &format!("{base_url}/scim/group-mappings")),
+        management_key,
+    );
+    let response = if query.offset.is_none() && query.limit.is_none() {
+        request.send().await?
+    } else {
+        request.query(&query).send().await?
+    };
+
+    if response.status().is_success() {
+        transport_response::parse_json_response(response, "SCIM group mapping list").await
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Create a SCIM group mapping (`POST /scim/group-mappings`).
+pub async fn create_scim_group_mapping(
+    base_url: &str,
+    management_key: &str,
+    request: &CreateScimGroupMappingRequest,
+) -> Result<ScimGroupMapping, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    create_scim_group_mapping_with_client(&http_client, base_url, management_key, request).await
+}
+
+pub(crate) async fn create_scim_group_mapping_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    request: &CreateScimGroupMappingRequest,
+) -> Result<ScimGroupMapping, OpenRouterError> {
+    let response = transport_request::with_bearer_auth(
+        transport_request::post(http_client, &format!("{base_url}/scim/group-mappings")),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let response: ApiResponse<ScimGroupMapping> =
+            transport_response::parse_json_response(response, "SCIM group mapping creation")
+                .await?;
+        Ok(response.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Get one SCIM group mapping (`GET /scim/group-mappings/{id}`).
+pub async fn get_scim_group_mapping(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<ScimGroupMapping, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    get_scim_group_mapping_with_client(&http_client, base_url, management_key, id).await
+}
+
+pub(crate) async fn get_scim_group_mapping_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+) -> Result<ScimGroupMapping, OpenRouterError> {
+    let response = transport_request::with_bearer_auth(
+        transport_request::get(
+            http_client,
+            &format!("{base_url}/scim/group-mappings/{}", encode(id)),
+        ),
+        management_key,
+    )
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let response: ApiResponse<ScimGroupMapping> =
+            transport_response::parse_json_response(response, "SCIM group mapping").await?;
+        Ok(response.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Update one SCIM group mapping (`PATCH /scim/group-mappings/{id}`).
+pub async fn update_scim_group_mapping(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateScimGroupMappingRequest,
+) -> Result<ScimGroupMapping, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    update_scim_group_mapping_with_client(&http_client, base_url, management_key, id, request).await
+}
+
+pub(crate) async fn update_scim_group_mapping_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    request: &UpdateScimGroupMappingRequest,
+) -> Result<ScimGroupMapping, OpenRouterError> {
+    let response = transport_request::with_bearer_auth(
+        transport_request::patch(
+            http_client,
+            &format!("{base_url}/scim/group-mappings/{}", encode(id)),
+        ),
+        management_key,
+    )
+    .json(request)
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let response: ApiResponse<ScimGroupMapping> =
+            transport_response::parse_json_response(response, "SCIM group mapping update").await?;
+        Ok(response.data)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}
+
+/// Delete one SCIM group mapping (`DELETE /scim/group-mappings/{id}`).
+pub async fn delete_scim_group_mapping(
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    keep_members: bool,
+) -> Result<bool, OpenRouterError> {
+    let http_client = crate::transport::new_client()?;
+    delete_scim_group_mapping_with_client(&http_client, base_url, management_key, id, keep_members)
+        .await
+}
+
+pub(crate) async fn delete_scim_group_mapping_with_client(
+    http_client: &HttpClient,
+    base_url: &str,
+    management_key: &str,
+    id: &str,
+    keep_members: bool,
+) -> Result<bool, OpenRouterError> {
+    let response = transport_request::with_bearer_auth(
+        transport_request::delete(
+            http_client,
+            &format!("{base_url}/scim/group-mappings/{}", encode(id)),
+        ),
+        management_key,
+    )
+    .query(&KeepMembersQuery { keep_members })
+    .send()
+    .await?;
+
+    if response.status().is_success() {
+        let response: DeleteScimGroupMappingResponse =
+            transport_response::parse_json_response(response, "SCIM group mapping deletion")
+                .await?;
+        Ok(response.deleted)
+    } else {
+        transport_response::handle_error(response).await?;
+        unreachable!()
+    }
+}

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -36,6 +36,8 @@ pub struct Workspace {
     pub default_image_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_provider_sort: Option<String>,
+    #[serde(default)]
+    pub include_byok_in_budgets: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_logging_api_key_ids: Option<Vec<u64>>,
     pub io_logging_sampling_rate: f64,
@@ -286,6 +288,7 @@ impl UpsertWorkspaceBudgetRequest {
 #[non_exhaustive]
 pub struct UpsertWorkspaceBudgetResponse {
     pub data: WorkspaceBudget,
+    #[serde(default)]
     pub include_byok_in_budgets: bool,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
     api::{
         analytics, api_keys, audio, auth, byok, chat, credits, discovery, embeddings, files,
         generation, guardrails, images, messages, models, observability, organization, presets,
-        rerank, responses, videos, workspaces,
+        rerank, responses, scim, videos, workspaces,
     },
     error::OpenRouterError,
     strip_option_vec_setter,
@@ -2844,6 +2844,13 @@ pub struct FilesClient<'a> {
 }
 
 impl<'a> FilesClient<'a> {
+    fn api_key(&self) -> Result<&str, OpenRouterError> {
+        self.client
+            .api_key
+            .as_deref()
+            .ok_or(OpenRouterError::KeyNotConfigured)
+    }
+
     /// List files (`GET /files`).
     pub async fn list(
         &self,
@@ -2890,6 +2897,84 @@ impl<'a> FilesClient<'a> {
         workspace_id: Option<&str>,
     ) -> Result<files::FileDeleteResponse, OpenRouterError> {
         self.client.delete_file(file_id, workspace_id).await
+    }
+
+    /// List files in the response shape negotiated with a backing provider.
+    pub async fn list_for_provider(
+        &self,
+        params: &files::ListFilesParams,
+    ) -> Result<files::ProviderFileListResponse, OpenRouterError> {
+        files::list_provider_files_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.api_key()?,
+            params,
+        )
+        .await
+    }
+
+    /// Upload a file to a selected backing provider.
+    pub async fn upload_for_provider(
+        &self,
+        request: &files::UploadFileRequest,
+        query: &files::FileQuery,
+    ) -> Result<files::ProviderFileMetadata, OpenRouterError> {
+        files::upload_provider_file_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.api_key()?,
+            request,
+            query,
+        )
+        .await
+    }
+
+    /// Get file metadata in a provider-native response shape.
+    pub async fn get_metadata_for_provider(
+        &self,
+        file_id: &str,
+        query: &files::FileQuery,
+    ) -> Result<files::ProviderFileMetadata, OpenRouterError> {
+        files::get_provider_file_metadata_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.api_key()?,
+            file_id,
+            query,
+        )
+        .await
+    }
+
+    /// Download file content from a selected backing provider.
+    pub async fn download_content_for_provider(
+        &self,
+        file_id: &str,
+        query: &files::FileQuery,
+    ) -> Result<Vec<u8>, OpenRouterError> {
+        files::download_provider_file_content_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.api_key()?,
+            file_id,
+            query,
+        )
+        .await
+    }
+
+    /// Delete a file from a selected backing provider.
+    pub async fn delete_for_provider(
+        &self,
+        file_id: &str,
+        query: &files::FileQuery,
+    ) -> Result<files::ProviderFileDeleteResponse, OpenRouterError> {
+        files::delete_provider_file_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.api_key()?,
+            file_id,
+            query,
+        )
+        .await
     }
 }
 
@@ -3055,6 +3140,101 @@ pub struct ManagementClient<'a> {
 }
 
 impl<'a> ManagementClient<'a> {
+    fn management_key(&self) -> Result<&str, OpenRouterError> {
+        self.client
+            .management_key
+            .as_deref()
+            .ok_or(OpenRouterError::KeyNotConfigured)
+    }
+
+    /// List SCIM groups (`GET /scim/groups`).
+    pub async fn list_scim_groups(
+        &self,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<scim::ListScimGroupsResponse, OpenRouterError> {
+        scim::list_scim_groups_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.management_key()?,
+            pagination,
+        )
+        .await
+    }
+
+    /// List SCIM group mappings (`GET /scim/group-mappings`).
+    pub async fn list_scim_group_mappings(
+        &self,
+        pagination: Option<PaginationOptions>,
+    ) -> Result<scim::ListScimGroupMappingsResponse, OpenRouterError> {
+        scim::list_scim_group_mappings_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.management_key()?,
+            pagination,
+        )
+        .await
+    }
+
+    /// Create a SCIM group mapping (`POST /scim/group-mappings`).
+    pub async fn create_scim_group_mapping(
+        &self,
+        request: &scim::CreateScimGroupMappingRequest,
+    ) -> Result<scim::ScimGroupMapping, OpenRouterError> {
+        scim::create_scim_group_mapping_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.management_key()?,
+            request,
+        )
+        .await
+    }
+
+    /// Get a SCIM group mapping (`GET /scim/group-mappings/{id}`).
+    pub async fn get_scim_group_mapping(
+        &self,
+        id: &str,
+    ) -> Result<scim::ScimGroupMapping, OpenRouterError> {
+        scim::get_scim_group_mapping_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.management_key()?,
+            id,
+        )
+        .await
+    }
+
+    /// Update a SCIM group mapping (`PATCH /scim/group-mappings/{id}`).
+    pub async fn update_scim_group_mapping(
+        &self,
+        id: &str,
+        request: &scim::UpdateScimGroupMappingRequest,
+    ) -> Result<scim::ScimGroupMapping, OpenRouterError> {
+        scim::update_scim_group_mapping_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.management_key()?,
+            id,
+            request,
+        )
+        .await
+    }
+
+    /// Delete a SCIM group mapping (`DELETE /scim/group-mappings/{id}`).
+    pub async fn delete_scim_group_mapping(
+        &self,
+        id: &str,
+        keep_members: bool,
+    ) -> Result<bool, OpenRouterError> {
+        scim::delete_scim_group_mapping_with_client(
+            self.client.http_client(),
+            &self.client.base_url,
+            self.management_key()?,
+            id,
+            keep_members,
+        )
+        .await
+    }
+
     /// Create a managed API key (`POST /keys`).
     pub async fn create_api_key(
         &self,

--- a/tests/unit/audio.rs
+++ b/tests/unit/audio.rs
@@ -55,6 +55,13 @@ fn test_speech_request_allows_omitting_voice() {
 
     let value = serde_json::to_value(request).expect("speech request should serialize");
     assert!(value.get("voice").is_none());
+
+    let request: SpeechRequest = serde_json::from_value(serde_json::json!({
+        "model": "openai/gpt-audio",
+        "input": "Hello world"
+    }))
+    .expect("voice is optional when deserializing");
+    assert!(request.voice.is_empty());
 }
 
 #[test]

--- a/tests/unit/audio.rs
+++ b/tests/unit/audio.rs
@@ -46,6 +46,18 @@ fn test_speech_request_serialization() {
 }
 
 #[test]
+fn test_speech_request_allows_omitting_voice() {
+    let request = SpeechRequest::builder()
+        .model("openai/gpt-audio")
+        .input("Hello world")
+        .build()
+        .expect("voice is optional in the upstream contract");
+
+    let value = serde_json::to_value(request).expect("speech request should serialize");
+    assert!(value.get("voice").is_none());
+}
+
+#[test]
 fn test_transcription_request_serialization() {
     let mut provider_options = HashMap::new();
     provider_options.insert(

--- a/tests/unit/client_domains.rs
+++ b/tests/unit/client_domains.rs
@@ -10,7 +10,7 @@ use openrouter_rs::{
     OpenRouterClient,
     api::{
         analytics, audio, auth, byok, chat, credits, discovery, embeddings, files, guardrails,
-        images, messages, observability, rerank, responses, videos, workspaces,
+        images, messages, observability, rerank, responses, scim, videos, workspaces,
     },
     error::OpenRouterError,
     types::{ModelCategory, PaginationOptions, Role, SupportedParameters},
@@ -391,6 +391,14 @@ async fn test_files_domain_requires_api_key() {
         .content(b"hello".to_vec())
         .build()
         .expect("upload request should build");
+    let query = files::FileQuery::builder()
+        .provider("openai")
+        .build()
+        .expect("file query should build");
+    let list_params = files::ListFilesParams::builder()
+        .provider("openai")
+        .build()
+        .expect("list params should build");
 
     assert!(matches!(
         client.files().list(None, None, None).await,
@@ -410,6 +418,32 @@ async fn test_files_domain_requires_api_key() {
     ));
     assert!(matches!(
         client.files().delete("file_123", None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().list_for_provider(&list_params).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().upload_for_provider(&upload, &query).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .files()
+            .get_metadata_for_provider("file_123", &query)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .files()
+            .download_content_for_provider("file_123", &query)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.files().delete_for_provider("file_123", &query).await,
         Err(OpenRouterError::KeyNotConfigured)
     ));
 }
@@ -534,6 +568,57 @@ async fn test_management_domain_requires_management_key() {
         .create_api_key("new-key", Some(10.0))
         .await;
     assert!(matches!(result, Err(OpenRouterError::KeyNotConfigured)));
+}
+
+#[tokio::test]
+async fn test_management_domain_scim_requires_management_key() {
+    let client = OpenRouterClient::builder()
+        .build()
+        .expect("client should build");
+    let create = scim::CreateScimGroupMappingRequest::builder()
+        .scim_group_id("group-1")
+        .workspace_id("workspace-1")
+        .role("member")
+        .build()
+        .expect("create mapping request should build");
+    let update = scim::UpdateScimGroupMappingRequest::builder()
+        .role("admin")
+        .build()
+        .expect("update mapping request should build");
+
+    assert!(matches!(
+        client.management().list_scim_groups(None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().list_scim_group_mappings(None).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client.management().create_scim_group_mapping(&create).await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .get_scim_group_mapping("mapping-1")
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .update_scim_group_mapping("mapping-1", &update)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
+    assert!(matches!(
+        client
+            .management()
+            .delete_scim_group_mapping("mapping-1", false)
+            .await,
+        Err(OpenRouterError::KeyNotConfigured)
+    ));
 }
 
 #[test]

--- a/tests/unit/discovery.rs
+++ b/tests/unit/discovery.rs
@@ -825,6 +825,32 @@ async fn test_get_benchmarks_all_sources_omits_source_query() {
 }
 
 #[tokio::test]
+async fn test_get_benchmarks_deserializes_openrouter_rows() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"source":"openrouter","model_permaslug":"openai/gpt-4o","display_name":"GPT-4o","benchmark_type":"gpqa_diamond","accuracy":0.72,"accuracy_stddev":0.03,"avg_cost_per_task":0.002,"total_tasks":300,"last_run_timestamp":"2026-06-03T12:00:00Z"}],"meta":{"as_of":"2026-06-03T12:00:00Z","version":"v1","source":"openrouter","source_url":null,"citation":null,"model_count":1,"task_type":null}}"#,
+    );
+
+    let response =
+        discovery::get_benchmarks(&base_url, "api-key", &UnifiedBenchmarksParams::openrouter())
+            .await
+            .expect("OpenRouter benchmarks should deserialize");
+
+    assert!(matches!(
+        &response.data[0],
+        UnifiedBenchmarkItem::OpenRouter(item)
+            if item.benchmark_type == "gpqa_diamond" && item.total_tasks == 300
+    ));
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/benchmarks?source=openrouter HTTP/1.1"
+    );
+    server.join().expect("server should finish");
+}
+
+#[tokio::test]
 async fn test_get_activity_without_date_uses_base_path() {
     let (base_url, rx, server) = spawn_json_server(r#"{"data":[]}"#);
 

--- a/tests/unit/files.rs
+++ b/tests/unit/files.rs
@@ -6,7 +6,9 @@ use std::{
     time::Duration,
 };
 
-use openrouter_rs::api::files::{self, FileDeleteResponse, FileListResponse, FileMetadata};
+use openrouter_rs::api::files::{
+    self, FileDeleteResponse, FileListResponse, FileMetadata, FileQuery, ListFilesParams,
+};
 
 struct CapturedRequest {
     request_line: String,
@@ -140,6 +142,64 @@ fn test_file_payloads_deserialize() {
         serde_json::from_str(r#"{"id":"file_123","type":"file_deleted"}"#)
             .expect("file delete response should deserialize");
     assert_eq!(deleted.id, "file_123");
+}
+
+#[tokio::test]
+async fn test_list_provider_files_sends_provider_pagination_query() {
+    let (base_url, rx, server) = spawn_server(
+        br#"{"_shape":"openai","object":"list","data":[{"_shape":"openai","id":"file_123","object":"file","bytes":12,"created_at":1735689600,"filename":"data.jsonl","purpose":"batch","status":"processed"}],"has_more":false,"first_id":"file_123","last_id":"file_123"}"#,
+        "application/json",
+    );
+    let params = ListFilesParams::builder()
+        .provider("openai")
+        .limit(25)
+        .after("file_100")
+        .order("desc")
+        .build()
+        .expect("provider list params should build");
+
+    let files = files::list_provider_files(&base_url, "api-key", &params)
+        .await
+        .expect("provider file list should succeed");
+    assert_eq!(files.shape, "openai");
+    assert_eq!(files.data[0].bytes, Some(12));
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/files?limit=25&provider=openai&after=file_100&order=desc HTTP/1.1"
+    );
+    server.join().expect("server thread should finish");
+}
+
+#[tokio::test]
+async fn test_get_provider_file_sends_provider_and_workspace_query() {
+    let (base_url, rx, server) = spawn_server(
+        br#"{"_shape":"anthropic","id":"file/123","type":"file","filename":"notes.txt","mime_type":"text/plain","size_bytes":5,"created_at":"2026-08-03T00:00:00Z","downloadable":false}"#,
+        "application/json",
+    );
+    let query = FileQuery::builder()
+        .workspace_id("ws_123")
+        .provider("anthropic")
+        .build()
+        .expect("file query should build");
+
+    let file = files::get_provider_file_metadata(&base_url, "api-key", "file/123", &query)
+        .await
+        .expect("provider file metadata should succeed");
+    assert_eq!(file.shape, "anthropic");
+    assert_eq!(file.size_bytes, Some(5));
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("should capture request");
+    assert_eq!(
+        captured.request_line,
+        "GET /api/v1/files/file%2F123?workspace_id=ws_123&provider=anthropic HTTP/1.1"
+    );
+    server.join().expect("server thread should finish");
 }
 
 #[tokio::test]

--- a/tests/unit/guardrails.rs
+++ b/tests/unit/guardrails.rs
@@ -114,6 +114,9 @@ fn test_create_guardrail_request_serialization() {
         .description("Production guardrail")
         .limit_usd(100.0)
         .include_byok_in_budgets(true)
+        .enable_free_model_publication(false)
+        .enable_free_model_training(true)
+        .enable_paid_model_training(true)
         .reset_interval("monthly")
         .allowed_providers(vec!["openai".to_string(), "anthropic".to_string()])
         .allowed_models(vec![
@@ -130,6 +133,9 @@ fn test_create_guardrail_request_serialization() {
     assert_eq!(value["description"], "Production guardrail");
     assert_eq!(value["limit_usd"], 100.0);
     assert_eq!(value["include_byok_in_budgets"], true);
+    assert_eq!(value["enable_free_model_publication"], false);
+    assert_eq!(value["enable_free_model_training"], true);
+    assert_eq!(value["enable_paid_model_training"], true);
     assert_eq!(value["reset_interval"], "monthly");
     assert_eq!(value["allowed_providers"][0], "openai");
     assert_eq!(value["allowed_models"][1], "anthropic/claude-sonnet-4");
@@ -187,6 +193,9 @@ fn test_update_guardrail_request_serialization() {
     let request = UpdateGuardrailRequest::builder()
         .name("Updated")
         .include_byok_in_budgets(false)
+        .enable_free_model_publication(true)
+        .enable_free_model_training(false)
+        .enable_paid_model_training(false)
         .enforce_zdr(false)
         .build()
         .expect("update guardrail request should build");
@@ -194,6 +203,9 @@ fn test_update_guardrail_request_serialization() {
     let value = serde_json::to_value(&request).expect("request should serialize");
     assert_eq!(value["name"], "Updated");
     assert_eq!(value["include_byok_in_budgets"], false);
+    assert_eq!(value["enable_free_model_publication"], true);
+    assert_eq!(value["enable_free_model_training"], false);
+    assert_eq!(value["enable_paid_model_training"], false);
     assert_eq!(value["enforce_zdr"], false);
     assert!(value.get("description").is_none());
     assert!(value.get("allowed_models").is_none());
@@ -320,6 +332,9 @@ fn test_guardrail_response_deserialization() {
             "description": "Guardrail for production traffic",
             "limit_usd": 100,
             "include_byok_in_budgets": true,
+            "enable_free_model_publication": false,
+            "enable_free_model_training": true,
+            "enable_paid_model_training": true,
             "reset_interval": "monthly",
             "allowed_providers": ["openai"],
             "allowed_models": ["openai/gpt-4.1"],
@@ -355,6 +370,9 @@ fn test_guardrail_response_deserialization() {
     assert_eq!(parsed.data.enforce_zdr_google, Some(true));
     assert_eq!(parsed.data.enforce_zdr_other, Some(false));
     assert!(parsed.data.include_byok_in_budgets);
+    assert_eq!(parsed.data.enable_free_model_publication, Some(false));
+    assert_eq!(parsed.data.enable_free_model_training, Some(true));
+    assert_eq!(parsed.data.enable_paid_model_training, Some(true));
     assert_eq!(
         parsed.data.content_filter_builtins.unwrap_or_default()[0].slug,
         ContentFilterBuiltinSlug::RegexPromptInjection

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -35,6 +35,7 @@ pub mod provider;
 pub mod rerank;
 pub mod response_format;
 pub mod responses;
+pub mod scim;
 pub mod stream;
 pub mod tool_builder;
 pub mod unified_stream;

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -216,6 +216,10 @@ fn test_model_response_deserializes_links_and_benchmarks() {
             "links": {
                 "details": "/api/v1/models/openai/gpt-4/endpoints"
             },
+            "alias_target": {
+                "slug": "openai/gpt-4.1",
+                "name": "GPT-4.1"
+            },
             "benchmarks": {
                 "artificial_analysis": {
                     "intelligence_index": 71.4,
@@ -244,6 +248,14 @@ fn test_model_response_deserializes_links_and_benchmarks() {
         serde_json::from_str(raw).expect("single model response should deserialize");
     assert_eq!(parsed.data.canonical_slug.as_deref(), Some("openai/gpt-4"));
     assert!(parsed.data.context_length.is_none());
+    assert_eq!(
+        parsed
+            .data
+            .alias_target
+            .as_ref()
+            .map(|target| target.slug.as_str()),
+        Some("openai/gpt-4.1")
+    );
     assert_eq!(
         parsed
             .data

--- a/tests/unit/scim.rs
+++ b/tests/unit/scim.rs
@@ -1,0 +1,188 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use openrouter_rs::{api::scim, types::PaginationOptions};
+
+fn spawn_json_server(
+    response_body: &str,
+) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener.local_addr().expect("listener should have address");
+    let body = response_body.to_string();
+    let (tx, rx) = mpsc::channel();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("server should accept request");
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("server should read request");
+            request.extend_from_slice(&chunk[..read]);
+            if let Some(position) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break position + 4;
+            }
+            assert_ne!(read, 0, "request should contain headers");
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                line.to_ascii_lowercase()
+                    .strip_prefix("content-length:")?
+                    .trim()
+                    .parse::<usize>()
+                    .ok()
+            })
+            .unwrap_or(0);
+        while request.len() - header_end < content_length {
+            let read = stream.read(&mut chunk).expect("server should read body");
+            request.extend_from_slice(&chunk[..read]);
+        }
+        tx.send(String::from_utf8_lossy(&request).into_owned())
+            .expect("request should be captured");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("server should write response");
+    });
+    (format!("http://{addr}/api/v1"), rx, server)
+}
+
+#[tokio::test]
+async fn test_list_scim_groups_path_and_response() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"group-1","organization_id":"org-1","external_id":null,"display_name":"Engineering","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}],"total_count":1}"#,
+    );
+
+    let response = scim::list_scim_groups(
+        &base_url,
+        "mgmt-key",
+        Some(PaginationOptions::with_offset_and_limit(5, 25)),
+    )
+    .await
+    .expect("SCIM groups should list");
+
+    assert_eq!(response.total_count, 1);
+    assert_eq!(response.data[0].display_name, "Engineering");
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert!(request.starts_with("GET /api/v1/scim/groups?offset=5&limit=25 HTTP/1.1"));
+    assert!(request.to_ascii_lowercase().contains("bearer mgmt-key"));
+    server.join().expect("server should finish");
+}
+
+#[tokio::test]
+async fn test_list_scim_group_mappings_path_and_response() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":[{"id":"mapping-1","organization_id":"org-1","scim_group_id":"group-1","workspace_id":"workspace-1","role":"member","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}],"total_count":1}"#,
+    );
+
+    let response = scim::list_scim_group_mappings(&base_url, "mgmt-key", None)
+        .await
+        .expect("SCIM mappings should list");
+
+    assert_eq!(response.total_count, 1);
+    assert_eq!(response.data[0].role, "member");
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert!(request.starts_with("GET /api/v1/scim/group-mappings HTTP/1.1"));
+    server.join().expect("server should finish");
+}
+
+#[tokio::test]
+async fn test_create_scim_group_mapping_path_body_and_response() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"mapping-1","organization_id":"org-1","scim_group_id":"group-1","workspace_id":"workspace-1","role":"admin","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}"#,
+    );
+    let body = scim::CreateScimGroupMappingRequest::builder()
+        .scim_group_id("group-1")
+        .workspace_id("workspace-1")
+        .role("admin")
+        .build()
+        .expect("mapping request should build");
+
+    let mapping = scim::create_scim_group_mapping(&base_url, "mgmt-key", &body)
+        .await
+        .expect("SCIM mapping should be created");
+
+    assert_eq!(mapping.role, "admin");
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert!(request.starts_with("POST /api/v1/scim/group-mappings HTTP/1.1"));
+    assert!(request.contains(r#""scim_group_id":"group-1""#));
+    assert!(request.contains(r#""workspace_id":"workspace-1""#));
+    assert!(request.contains(r#""role":"admin""#));
+    server.join().expect("server should finish");
+}
+
+#[tokio::test]
+async fn test_get_scim_group_mapping_encodes_id() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"mapping-1","organization_id":"org-1","scim_group_id":"group-1","workspace_id":"workspace-1","role":"member","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}"#,
+    );
+
+    let mapping = scim::get_scim_group_mapping(&base_url, "mgmt-key", "mapping 1")
+        .await
+        .expect("SCIM mapping should be returned");
+
+    assert_eq!(mapping.id, "mapping-1");
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert!(request.starts_with("GET /api/v1/scim/group-mappings/mapping%201 HTTP/1.1"));
+    server.join().expect("server should finish");
+}
+
+#[tokio::test]
+async fn test_update_scim_group_mapping_path_body_and_response() {
+    let (base_url, rx, server) = spawn_json_server(
+        r#"{"data":{"id":"mapping-1","organization_id":"org-1","scim_group_id":"group-1","workspace_id":"workspace-1","role":"admin","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z"}}"#,
+    );
+    let body = scim::UpdateScimGroupMappingRequest::builder()
+        .role("admin")
+        .build()
+        .expect("update request should build");
+
+    let mapping = scim::update_scim_group_mapping(&base_url, "mgmt-key", "mapping-1", &body)
+        .await
+        .expect("SCIM mapping should update");
+
+    assert_eq!(mapping.role, "admin");
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert!(request.starts_with("PATCH /api/v1/scim/group-mappings/mapping-1 HTTP/1.1"));
+    assert!(request.contains(r#""role":"admin""#));
+    server.join().expect("server should finish");
+}
+
+#[tokio::test]
+async fn test_delete_scim_group_mapping_requires_keep_members_query() {
+    let (base_url, rx, server) = spawn_json_server(r#"{"deleted":true}"#);
+
+    let deleted = scim::delete_scim_group_mapping(&base_url, "mgmt-key", "mapping-1", false)
+        .await
+        .expect("SCIM mapping should delete");
+
+    assert!(deleted);
+    let request = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("request should be captured");
+    assert!(
+        request.starts_with(
+            "DELETE /api/v1/scim/group-mappings/mapping-1?keep_members=false HTTP/1.1"
+        )
+    );
+    server.join().expect("server should finish");
+}

--- a/tests/unit/workspaces.rs
+++ b/tests/unit/workspaces.rs
@@ -230,6 +230,7 @@ fn test_workspace_response_deserialization() {
             "default_text_model": "openai/gpt-4o",
             "default_image_model": "openai/dall-e-3",
             "default_provider_sort": "price",
+            "include_byok_in_budgets": true,
             "io_logging_api_key_ids": [101, 202],
             "io_logging_sampling_rate": 0.5,
             "is_observability_io_logging_enabled": false,
@@ -252,6 +253,7 @@ fn test_workspace_response_deserialization() {
     assert_eq!(parsed.data.created_by.as_deref(), Some("user_123"));
     assert_eq!(parsed.data.io_logging_api_key_ids, Some(vec![101, 202]));
     assert_eq!(parsed.data.io_logging_sampling_rate, 0.5);
+    assert!(parsed.data.include_byok_in_budgets);
 }
 
 #[test]
@@ -566,7 +568,7 @@ async fn test_list_workspace_members_encodes_id_pagination_and_auth_header() {
 #[tokio::test]
 async fn test_upsert_workspace_budget_encodes_path_and_body() {
     let (base_url, rx, server) = spawn_json_server(
-        r#"{"data":{"id":"770e8400-e29b-41d4-a716-446655440000","workspace_id":"550e8400-e29b-41d4-a716-446655440000","limit_usd":100,"reset_interval":"monthly","created_at":"2025-08-24T10:30:00Z","updated_at":"2025-08-24T15:45:00Z"},"include_byok_in_budgets":true}"#,
+        r#"{"data":{"id":"770e8400-e29b-41d4-a716-446655440000","workspace_id":"550e8400-e29b-41d4-a716-446655440000","limit_usd":100,"reset_interval":"monthly","created_at":"2025-08-24T10:30:00Z","updated_at":"2025-08-24T15:45:00Z"}}"#,
     );
     let request = UpsertWorkspaceBudgetRequest::builder()
         .limit_usd(100.0)
@@ -584,7 +586,7 @@ async fn test_upsert_workspace_budget_encodes_path_and_body() {
     .await
     .expect("upsert workspace budget should succeed");
     assert_eq!(response.data.limit_usd, 100.0);
-    assert!(response.include_byok_in_budgets);
+    assert!(!response.include_byok_in_budgets);
 
     let captured = rx
         .recv_timeout(Duration::from_secs(2))


### PR DESCRIPTION
Closes #242

## Summary
- add typed management support for six SCIM group and group-mapping endpoints
- add provider-aware Files queries and OpenAI/Anthropic response shapes without breaking the existing default Files surface
- accept stable schema changes for benchmarks, audio speech, models, guardrails, and workspaces
- refresh the tracked OpenAPI baseline to 95 / 95 endpoints

## Validation
- `just openapi-drift-check` (added=0, removed=0, changed=0)
- `just quality-ci`