### PR TITLE
chore: prepare 0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-03
+
 ### Added
 - Added management-key support for SCIM group discovery and group-role mappings through `client.management()`.
 - Added provider-aware Files queries and response types for OpenAI and Anthropic-backed file storage.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The current repo snapshot implements `95 / 95` official OpenAPI method/path entr
 
 ```toml
 [dependencies]
-openrouter-rs = "0.13.0"
+openrouter-rs = "0.14.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -47,7 +47,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.13.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.14.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -355,11 +355,15 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ### Unreleased
 
+- No unreleased changes yet.
+
+### Version 0.14.0 *(Latest)*
+
 - Tool-aware chat streaming now preserves provider-supplied tool-call indices without inventing missing values, and `FinishReason::Other` keeps unknown provider finish reasons forward-compatible.
 - Added SCIM group and group-role mapping management plus provider-aware Files API support.
 - Accepted the 2026-08-03 OpenAPI drift review and restored tracked endpoint coverage to `95 / 95`.
 
-### Version 0.13.0 *(Latest)*
+### Version 0.13.0
 
 - Added explicit prompt-cache controls, static predicted output, image provider routing, conditional pricing overrides, cache-creation usage details, and guardrail `flag` actions.
 - Added assistant-message model annotations, BYOK-aware guardrail/workspace budgets, workspace default guardrail IDs, transcription speaker labels, and Anthropic compaction/dynamic-tool blocks.

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.13.0", path = "../.." }
+openrouter-rs = { version = "0.14.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.13.0"
+//! openrouter-rs = "0.14.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- bump openrouter-rs and the CLI path dependency to 0.14.0
- finalize the 2026-08-03 changelog and README release history
- synchronize SDK installation and doctest versions

## Validation
- `just quality`
- `bash .agents/skills/openrouter-rs-release/scripts/verify_release_sync.sh 0.14.0`
- `just quality-ci`
- `cargo package --locked --allow-dirty`