### PR TITLE
chore: refresh integration model pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@ OPENROUTER_MANAGEMENT_KEY=sk-your-openrouter-management-key
 # Optional integration-test overrides
 # OPENROUTER_INTEGRATION_TIER=stable
 # OPENROUTER_TEST_CHAT_MODEL=x-ai/grok-4.3
-# OPENROUTER_TEST_REASONING_MODEL=deepseek/deepseek-r1
-# OPENROUTER_TEST_STABLE_MODELS=x-ai/grok-4.3,openai/gpt-4o-mini,deepseek/deepseek-r1
+# OPENROUTER_TEST_REASONING_MODEL=deepseek/deepseek-v4-flash
+# OPENROUTER_TEST_STABLE_MODELS=x-ai/grok-4.3,openai/gpt-4o-mini,deepseek/deepseek-v4-flash
 # OPENROUTER_TEST_HOT_RESPONSES_MODELS=openai/gpt-5.4-pro,x-ai/grok-4.20-beta
 # OPENROUTER_TEST_HOT_RESPONSES_MODELS_LIMIT=10
 # OPENROUTER_RUN_MANAGEMENT_TESTS=1

--- a/scripts/sync_hot_models.sh
+++ b/scripts/sync_hot_models.sh
@@ -323,13 +323,13 @@ if [ -z "$stable_chat" ]; then
   stable_chat="x-ai/grok-4.3"
 fi
 if [ -z "$stable_reasoning" ]; then
-  stable_reasoning="deepseek/deepseek-r1"
+  stable_reasoning="deepseek/deepseek-v4-flash"
 fi
 if [ "${#stable_regression[@]}" -eq 0 ]; then
   stable_regression=(
     "x-ai/grok-4.3"
     "openai/gpt-4o-mini"
-    "deepseek/deepseek-r1"
+    "deepseek/deepseek-v4-flash"
   )
 fi
 

--- a/tests/integration/model_pool.json
+++ b/tests/integration/model_pool.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-05-20T08:21:53Z",
+  "generated_at": "2026-08-10T02:43:02Z",
   "source": {
     "type": "models-endpoint-fallback",
     "endpoint": "https://openrouter.ai/api/v1/models",
@@ -8,26 +8,26 @@
   },
   "stable": {
     "chat": "x-ai/grok-4.3",
-    "reasoning": "deepseek/deepseek-r1",
+    "reasoning": "deepseek/deepseek-v4-flash",
     "regression": [
       "x-ai/grok-4.3",
       "openai/gpt-4o-mini",
-      "deepseek/deepseek-r1"
+      "deepseek/deepseek-v4-flash"
     ]
   },
   "responses": {
     "hot": {
       "models": [
-        "google/gemini-3.5-flash",
-        "anthropic/claude-opus-4.7-fast",
-        "perceptron/perceptron-mk1",
-        "inclusionai/ring-2.6-1t",
-        "google/gemini-3.1-flash-lite",
-        "baidu/cobuddy:free",
-        "openai/gpt-chat-latest",
-        "x-ai/grok-4.3",
-        "ibm-granite/granite-4.1-8b",
-        "mistralai/mistral-medium-3-5"
+        "inclusionai/ling-3.0-tiny:free",
+        "meta/muse-spark-1.2",
+        "qwen/qwen3.8-max",
+        "~deepseek/deepseek-v4-flash-latest",
+        "deepseek/deepseek-v4-flash-0731",
+        "thinkingmachines/inkling-small",
+        "qwen/qwen3.7-flash",
+        "anthropic/claude-opus-5-fast",
+        "anthropic/claude-opus-5",
+        "anthropic/claude-opus-5:batch"
       ]
     }
   }

--- a/tests/integration/model_pool.rs
+++ b/tests/integration/model_pool.rs
@@ -4,11 +4,11 @@ use std::{collections::HashSet, env, fs, path::PathBuf};
 const DEFAULT_MODEL_POOL_FILE: &str = "tests/integration/model_pool.json";
 const LEGACY_MODEL_POOL_FILE: &str = "tests/integration/hot_models.json";
 const DEFAULT_CHAT_MODEL: &str = "x-ai/grok-4.3";
-const DEFAULT_REASONING_MODEL: &str = "deepseek/deepseek-r1";
+const DEFAULT_REASONING_MODEL: &str = "deepseek/deepseek-v4-flash";
 const DEFAULT_STABLE_REGRESSION_MODELS: [&str; 3] = [
     "x-ai/grok-4.3",
     "openai/gpt-4o-mini",
-    "deepseek/deepseek-r1",
+    "deepseek/deepseek-v4-flash",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- refresh the tracked hot Responses model pool from the current OpenRouter catalog
- replace the retired DeepSeek R1 stable reasoning default with deepseek/deepseek-v4-flash
- keep script fallbacks and documented environment overrides synchronized

## Validation

- just quality
- just quality-ci

## CI investigation context

The recent scheduled CodeQL failure was a GitHub Actions Service Unavailable error while resolving action downloads. The earlier live integration failure is separate: the model-endpoint probe asserts on the first successful response with an empty endpoints array instead of continuing to another model. That test-hardening change is intentionally not mixed into this model-pool refresh.