### PR TITLE
chore: prepare 0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-09-08
+
 ### Added
 - Added container file list/metadata/download/promotion through `files()`, public OAuth signing keys and workload token exchange through `management()`, and SCIM sync job creation/status through `management()`.
 - Added regional guardrails and observability destinations, the `secrets` filter, BYOK API-key allowlists with explicit clearing, external API-key identities, user-model pagination/modality filters, pricing weekdays, endpoint tool-choice/workload performance metadata, server-tool cost, image user identifiers, video processing, chat configuration updates, and Anthropic message/thinking/container-result controls.
@@ -18,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Accepted issue #248 against the 2026-09-08 upstream snapshot (`105 / 105` operations); `POST /organization` from the issue report was withdrawn upstream before review.
-- Corrected the workspace deletion confirmation query to `confirm_default_workspace_deletion`; the positional Rust method signature is unchanged.
+- Workspace deletion confirmation now uses the upstream query name `confirm_default_workspace_deletion`.
 - **Breaking:** `ByokKey::workspace_id` is now `Option<String>` because upstream returns `null` for account-level credentials.
 - **Breaking:** `delete_workspace(...)` now takes a `confirm_default_workspace_deletion: Option<bool>` argument; pass `None` to keep the previous behavior.
 - Accepted the 2026-08-17 OpenAPI drift review, restoring the official endpoint snapshot to `97 / 97`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "openrouter-rs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openrouter-rs"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["luckywood <morrisliu1994@outlook.com>"]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,23 +2,23 @@
 
 This document keeps historical migration guides intact because the repo still smoke-tests older domain/naming transitions.
 
-## Unreleased: 0.14.x -> next
+## Latest: 0.14.x -> 0.15.0
 
 Two management-surface changes match the upstream OpenRouter schema.
 
-### Quick Checklist For The Next Release
+### Quick Checklist For 0.15.0
 
 - Treat `ByokKey::workspace_id` as optional: account-level BYOK credentials now deserialize with `None`.
-- Pass a third argument to `delete_workspace(...)`: `Some(true)` confirms deleting the workspace's default settings, `None` preserves the previous behavior.
+- Pass the optional confirmation argument to `delete_workspace(...)`: `Some(true)` confirms deleting the default workspace, `None` omits the confirmation query.
 
-### Breaking-Change Mapping For The Next Release
+### Breaking-Change Mapping For 0.15.0
 
-| Area | Old Usage (`0.14.x`) | New Usage |
+| Area | Old Usage (`0.14.x`) | New Usage (`0.15.0`) |
 | --- | --- | --- |
 | BYOK credential workspace | `key.workspace_id` is `String` | `key.workspace_id` is `Option<String>` |
 | Workspace deletion | `client.management().delete_workspace("ws_123").await?` | `client.management().delete_workspace("ws_123", None).await?` |
 
-## Latest: 0.12.x -> 0.13.0
+## Previous breaking release: 0.12.x -> 0.13.0
 
 Two public return/type shapes changed to match the upstream OpenRouter schema.
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ## 📈 Release History
 
+### Unreleased
+
 ### Version 0.15.0 *(Latest)*
 
 - Added container files, workload OAuth token exchange/signing keys, SCIM sync jobs, regional management controls, and expanded message/model fields. Accepted the 2026-09-08 OpenAPI review with `105 / 105` tracked operations.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The September OpenAPI update adds container file listing, metadata, downloads an
 
 ```toml
 [dependencies]
-openrouter-rs = "0.14.0"
+openrouter-rs = "0.15.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -49,7 +49,7 @@ Legacy text completions are opt-in:
 
 ```toml
 [dependencies]
-openrouter-rs = { version = "0.14.0", features = ["legacy-completions"] }
+openrouter-rs = { version = "0.15.0", features = ["legacy-completions"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -358,7 +358,7 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 
 ## 📈 Release History
 
-### Unreleased
+### Version 0.15.0 *(Latest)*
 
 - Added container files, workload OAuth token exchange/signing keys, SCIM sync jobs, regional management controls, and expanded message/model fields. Accepted the 2026-09-08 OpenAPI review with `105 / 105` tracked operations.
 
@@ -366,7 +366,7 @@ Start with [`docs/README.md`](docs/README.md) for grouped navigation across root
 - **Breaking:** `ByokKey::workspace_id` is now optional, and `delete_workspace(...)` takes an optional `confirm_default_workspace_deletion` argument.
 - Accepted the 2026-08-17 OpenAPI drift review and restored tracked endpoint coverage to `97 / 97`.
 
-### Version 0.14.0 *(Latest)*
+### Version 0.14.0
 
 - Tool-aware chat streaming now preserves provider-supplied tool-call indices without inventing missing values, and `FinishReason::Other` keeps unknown provider finish reasons forward-compatible.
 - Added SCIM group and group-role mapping management plus provider-aware Files API support.

--- a/crates/openrouter-cli/Cargo.toml
+++ b/crates/openrouter-cli/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.37", features = ["derive"] }
-openrouter-rs = { version = "0.14.0", path = "../.." }
+openrouter-rs = { version = "0.15.0", path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/scripts/check_migration_docs.sh
+++ b/scripts/check_migration_docs.sh
@@ -51,7 +51,10 @@ require_pattern "management().create_api_key_from_auth_code(...)" "$README_PATH"
 # If MIGRATION.md exists (OR-25 and later), validate current and historical key structure.
 if [[ -f "$MIGRATION_PATH" ]]; then
   require_pattern "# Migration Guide" "$MIGRATION_PATH"
-  require_pattern "## Latest: 0.12.x -> 0.13.0" "$MIGRATION_PATH"
+  require_pattern "## Latest: 0.14.x -> 0.15.0" "$MIGRATION_PATH"
+  require_pattern "## Previous breaking release: 0.12.x -> 0.13.0" "$MIGRATION_PATH"
+  require_pattern 'key.workspace_id` is `Option<String>' "$MIGRATION_PATH"
+  require_pattern 'delete_workspace("ws_123", None)' "$MIGRATION_PATH"
   require_pattern "response.include_byok_in_budgets" "$MIGRATION_PATH"
   require_pattern "ContentPart::Text { text, cache_control, .. }" "$MIGRATION_PATH"
   require_pattern "## Previous breaking release: 0.9.x -> 0.10.0" "$MIGRATION_PATH"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! openrouter-rs = "0.14.0"
+//! openrouter-rs = "0.15.0"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
Prepare SDK v0.15.0 with the accumulated OpenAPI compatibility updates, including container files, workload OAuth, SCIM sync jobs, regional controls, and 105/105 tracked endpoint coverage.

Synchronizes the SDK manifest/lockfile, installation snippets, changelog, and README release history. Finalizes the 0.14.x → 0.15.0 migration guide for optional BYOK workspace IDs and the workspace deletion confirmation argument, and updates its validation checks. The CLI workspace dependency follows SDK 0.15.0; the CLI version remains 0.2.0 and no CLI release is planned.

Validation:
- `just quality`
- release version synchronization script for 0.15.0
- `just quality-ci`
- `cargo package --locked --allow-dirty`

After this PR is merged, tag the merged main commit as `v0.15.0` and let the existing GitHub Actions Release workflow publish the SDK. No local cargo publish.
